### PR TITLE
Deployment: Smithery config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Google Workspace MCP Server
 
+[![smithery badge](https://smithery.ai/badge/@aaronsb/google-workspace-mcp)](https://smithery.ai/server/@aaronsb/google-workspace-mcp)
+
 A Model Context Protocol (MCP) server that provides authenticated access to Google Workspace APIs, offering comprehensive Gmail and Calendar functionality.
 
 ## Features
@@ -36,6 +38,15 @@ A Model Context Protocol (MCP) server that provides authenticated access to Goog
 
 ## Getting Started
 
+### Installing via Smithery
+
+To install Google Workspace MCP Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@aaronsb/google-workspace-mcp):
+
+```bash
+npx -y @smithery/cli install @aaronsb/google-workspace-mcp --client claude
+```
+
+### Manual Installation
 1. **Initial Setup**
    ```bash
    # Clone the repository

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,17 @@
+# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - configDir
+    properties:
+      configDir:
+        type: string
+        description: The directory path where 'gauth.json' and 'accounts.json' are located.
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    (config) => ({ command: 'docker', args: ['run', '-v', `${config.configDir}:/app/config`, 'gsuite-mcp'] })


### PR DESCRIPTION
This pull request introduces the following updates:

- **Smithery Configuration**: Adds a Smithery YAML file, which specifies how to start the MCP and the configuration options it supports. It allows you to [deploy](https://smithery.ai/docs/deployments) your MCP to [Smithery](https://smithery.ai?utm_campaign=pr), serving it over WebSockets so end-users do not need to install additional dependencies. To deploy, merge this PR, then visit your [server page](https://smithery.ai/server/@aaronsb/google-workspace-mcp?utm_campaign=pr&modal=claim) and click "Deploy" under the deployments page.
- **README**: Updates the README to include installation instructions via Smithery and a popularity badge. _Note that the installation only works after the server is deployed on Smithery._

Please review these updates to verify their accuracy for your server and feel free to customize it to your needs. Let me know if you have any questions. 🙂