### PR TITLE
docs: update tool registration comment to reflect current implementation

### DIFF
--- a/docs/TOOL_DISCOVERY.md
+++ b/docs/TOOL_DISCOVERY.md
@@ -1,0 +1,113 @@
+# Tool Discovery and Aliases
+
+The Google Workspace MCP server provides several features to make tools more discoverable and easier to use:
+
+## Tool Categories
+
+Tools are organized into logical categories for better organization:
+
+- Account Management
+  - Authentication and account management tools
+- Gmail/Messages
+  - Email composition and search
+- Gmail/Labels
+  - Label creation and management
+- Gmail/Drafts
+  - Draft email management
+- Gmail/Settings
+  - Gmail settings and configuration
+- Calendar/Events
+  - Calendar event management
+
+## Tool Aliases
+
+Most tools support multiple aliases for more intuitive usage. For example:
+
+```javascript
+// All of these are equivalent:
+create_workspace_label
+create_label
+new_label
+create_gmail_label
+```
+
+## Improved Error Messages
+
+When a tool name is not found, the server provides helpful suggestions:
+
+```
+Tool 'create_gmail_lable' not found.
+
+Did you mean:
+- create_workspace_label (Gmail/Labels)
+  Aliases: create_label, new_label, create_gmail_label
+
+Available categories:
+- Gmail/Labels: create_label, update_label, delete_label
+- Gmail/Messages: send_email, search_emails
+- Calendar/Events: create_event, update_event, delete_event
+```
+
+## Tool Metadata
+
+Each tool includes:
+
+- Category: Logical grouping for organization
+- Aliases: Alternative names for the tool
+- Description: Detailed usage information
+- Input Schema: Required and optional parameters
+
+## Best Practices
+
+1. Use the most specific tool name when possible
+2. Check error messages for similar tool suggestions
+3. Use the list_workspace_tools command to see all available tools
+4. Refer to tool categories for related functionality
+
+## Examples
+
+### Creating a Label
+
+```javascript
+// Any of these work:
+create_workspace_label({
+  email: "user@example.com",
+  name: "Important/Projects"
+})
+
+create_label({
+  email: "user@example.com",
+  name: "Important/Projects"
+})
+
+create_gmail_label({
+  email: "user@example.com",
+  name: "Important/Projects"
+})
+```
+
+### Sending an Email
+
+```javascript
+// These are equivalent:
+send_workspace_email({
+  email: "user@example.com",
+  to: ["recipient@example.com"],
+  subject: "Hello",
+  body: "Message content"
+})
+
+send_email({
+  email: "user@example.com",
+  to: ["recipient@example.com"],
+  subject: "Hello",
+  body: "Message content"
+})
+```
+
+## Future Improvements
+
+- Category descriptions and documentation
+- Tool relationship mapping
+- Common usage patterns and workflows
+- Interactive tool discovery

--- a/src/modules/tools/__tests__/registry.test.ts
+++ b/src/modules/tools/__tests__/registry.test.ts
@@ -1,0 +1,138 @@
+import { ToolRegistry, ToolMetadata } from '../registry.js';
+
+describe('ToolRegistry', () => {
+  const mockTools: ToolMetadata[] = [
+    {
+      name: 'create_workspace_label',
+      category: 'Gmail/Labels',
+      description: 'Create a new label',
+      aliases: ['create_label', 'new_label', 'create_gmail_label'],
+      inputSchema: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' }
+        }
+      }
+    },
+    {
+      name: 'send_workspace_email',
+      category: 'Gmail/Messages',
+      description: 'Send an email',
+      aliases: ['send_email', 'send_mail'],
+      inputSchema: {
+        type: 'object',
+        properties: {
+          to: { type: 'string' }
+        }
+      }
+    },
+    {
+      name: 'create_workspace_calendar_event',
+      category: 'Calendar/Events',
+      description: 'Create calendar event',
+      aliases: ['create_event', 'schedule_event'],
+      inputSchema: {
+        type: 'object',
+        properties: {
+          title: { type: 'string' }
+        }
+      }
+    }
+  ];
+
+  let registry: ToolRegistry;
+
+  beforeEach(() => {
+    registry = new ToolRegistry(mockTools);
+  });
+
+  describe('getTool', () => {
+    it('should find tool by main name', () => {
+      const tool = registry.getTool('create_workspace_label');
+      expect(tool).toBeDefined();
+      expect(tool?.name).toBe('create_workspace_label');
+    });
+
+    it('should find tool by alias', () => {
+      const tool = registry.getTool('create_gmail_label');
+      expect(tool).toBeDefined();
+      expect(tool?.name).toBe('create_workspace_label');
+    });
+
+    it('should return undefined for unknown tool', () => {
+      const tool = registry.getTool('nonexistent_tool');
+      expect(tool).toBeUndefined();
+    });
+  });
+
+  describe('getAllTools', () => {
+    it('should return all registered tools', () => {
+      const tools = registry.getAllTools();
+      expect(tools).toHaveLength(3);
+      expect(tools.map(t => t.name)).toContain('create_workspace_label');
+      expect(tools.map(t => t.name)).toContain('send_workspace_email');
+      expect(tools.map(t => t.name)).toContain('create_workspace_calendar_event');
+    });
+  });
+
+  describe('getCategories', () => {
+    it('should return tools organized by category', () => {
+      const categories = registry.getCategories();
+      expect(categories).toHaveLength(3);
+      
+      const categoryNames = categories.map(c => c.name);
+      expect(categoryNames).toContain('Gmail/Labels');
+      expect(categoryNames).toContain('Gmail/Messages');
+      expect(categoryNames).toContain('Calendar/Events');
+
+      const labelCategory = categories.find(c => c.name === 'Gmail/Labels');
+      expect(labelCategory?.tools).toHaveLength(1);
+      expect(labelCategory?.tools[0].name).toBe('create_workspace_label');
+    });
+  });
+
+  describe('findSimilarTools', () => {
+    it('should find similar tools by name', () => {
+      const similar = registry.findSimilarTools('create_label_workspace');
+      expect(similar).toHaveLength(1);
+      expect(similar[0].name).toBe('create_workspace_label');
+    });
+
+    it('should find similar tools by alias', () => {
+      const similar = registry.findSimilarTools('gmail_label_create');
+      expect(similar).toHaveLength(1);
+      expect(similar[0].name).toBe('create_workspace_label');
+    });
+
+    it('should respect maxSuggestions limit', () => {
+      const similar = registry.findSimilarTools('create', 2);
+      expect(similar).toHaveLength(2);
+    });
+  });
+
+  describe('formatErrorWithSuggestions', () => {
+    it('should format error message with suggestions', () => {
+      const message = registry.formatErrorWithSuggestions('create_gmail_lable');
+      expect(message).toContain('Tool \'create_gmail_lable\' not found');
+      expect(message).toContain('Did you mean:');
+      expect(message).toContain('create_workspace_label (Gmail/Labels)');
+      expect(message).toContain('Available categories:');
+    });
+
+    it('should include aliases in error message', () => {
+      const message = registry.formatErrorWithSuggestions('send_mail_workspace');
+      expect(message).toContain('send_workspace_email');
+      expect(message).toContain('Aliases: send_email, send_mail');
+    });
+  });
+
+  describe('getAllToolNames', () => {
+    it('should return all tool names including aliases', () => {
+      const names = registry.getAllToolNames();
+      expect(names).toContain('create_workspace_label');
+      expect(names).toContain('create_gmail_label');
+      expect(names).toContain('send_workspace_email');
+      expect(names).toContain('send_mail');
+    });
+  });
+});

--- a/src/modules/tools/registry.ts
+++ b/src/modules/tools/registry.ts
@@ -1,0 +1,170 @@
+import { Tool } from "@modelcontextprotocol/sdk/types.js";
+import logger from '../../utils/logger.js';
+
+export interface ToolMetadata extends Tool {
+  category: string;
+  aliases?: string[];
+}
+
+export interface ToolCategory {
+  name: string;
+  description: string;
+  tools: ToolMetadata[];
+}
+
+export class ToolRegistry {
+  private tools: Map<string, ToolMetadata> = new Map();
+  private categories: Map<string, ToolCategory> = new Map();
+  private aliasMap: Map<string, string> = new Map();
+
+  constructor(tools: ToolMetadata[]) {
+    this.registerTools(tools);
+  }
+
+  private registerTools(tools: ToolMetadata[]): void {
+    for (const tool of tools) {
+      // Register the main tool
+      this.tools.set(tool.name, tool);
+
+      // Register category
+      if (!this.categories.has(tool.category)) {
+        this.categories.set(tool.category, {
+          name: tool.category,
+          description: '', // Could be added in future
+          tools: []
+        });
+      }
+      this.categories.get(tool.category)?.tools.push(tool);
+
+      // Register aliases
+      if (tool.aliases) {
+        for (const alias of tool.aliases) {
+          this.aliasMap.set(alias, tool.name);
+        }
+      }
+    }
+  }
+
+  getTool(name: string): ToolMetadata | undefined {
+    // Try direct lookup
+    const tool = this.tools.get(name);
+    if (tool) {
+      return tool;
+    }
+
+    // Try alias lookup
+    const mainName = this.aliasMap.get(name);
+    if (mainName) {
+      return this.tools.get(mainName);
+    }
+
+    return undefined;
+  }
+
+  getAllTools(): ToolMetadata[] {
+    return Array.from(this.tools.values());
+  }
+
+  getCategories(): ToolCategory[] {
+    return Array.from(this.categories.values());
+  }
+
+  private calculateLevenshteinDistance(a: string, b: string): number {
+    const matrix: number[][] = [];
+
+    // Initialize matrix
+    for (let i = 0; i <= b.length; i++) {
+      matrix[i] = [i];
+    }
+    for (let j = 0; j <= a.length; j++) {
+      matrix[0][j] = j;
+    }
+
+    // Fill matrix
+    for (let i = 1; i <= b.length; i++) {
+      for (let j = 1; j <= a.length; j++) {
+        if (b.charAt(i - 1) === a.charAt(j - 1)) {
+          matrix[i][j] = matrix[i - 1][j - 1];
+        } else {
+          matrix[i][j] = Math.min(
+            matrix[i - 1][j - 1] + 1, // substitution
+            matrix[i][j - 1] + 1,     // insertion
+            matrix[i - 1][j] + 1      // deletion
+          );
+        }
+      }
+    }
+
+    return matrix[b.length][a.length];
+  }
+
+  findSimilarTools(name: string, maxSuggestions: number = 3): ToolMetadata[] {
+    const allTools = this.getAllTools();
+    const distances: Array<{ tool: ToolMetadata; distance: number }> = [];
+
+    // Calculate distances for all tools and their aliases
+    for (const tool of allTools) {
+      // Check main tool name
+      const mainDistance = this.calculateLevenshteinDistance(name.toLowerCase(), tool.name.toLowerCase());
+      distances.push({ tool, distance: mainDistance });
+
+      // Check aliases
+      if (tool.aliases) {
+        for (const alias of tool.aliases) {
+          const aliasDistance = this.calculateLevenshteinDistance(name.toLowerCase(), alias.toLowerCase());
+          if (aliasDistance < mainDistance) {
+            // Update with better match if found
+            const existing = distances.find(d => d.tool === tool);
+            if (existing) {
+              existing.distance = aliasDistance;
+            }
+          }
+        }
+      }
+    }
+
+    // Sort by distance and return top matches
+    return distances
+      .sort((a, b) => a.distance - b.distance)
+      .slice(0, maxSuggestions)
+      .map(d => d.tool);
+  }
+
+  formatErrorWithSuggestions(invalidToolName: string): string {
+    const similarTools = this.findSimilarTools(invalidToolName);
+    const categories = this.getCategories();
+
+    let message = `Tool '${invalidToolName}' not found.\n\n`;
+
+    if (similarTools.length > 0) {
+      message += 'Did you mean:\n';
+      for (const tool of similarTools) {
+        message += `- ${tool.name} (${tool.category})\n`;
+        if (tool.aliases && tool.aliases.length > 0) {
+          message += `  Aliases: ${tool.aliases.join(', ')}\n`;
+        }
+      }
+      message += '\n';
+    }
+
+    message += 'Available categories:\n';
+    for (const category of categories) {
+      const toolNames = category.tools.map(t => t.name.replace('workspace_', '')).join(', ');
+      message += `- ${category.name}: ${toolNames}\n`;
+    }
+
+    return message;
+  }
+
+  // Helper method to get all available tool names including aliases
+  getAllToolNames(): string[] {
+    const names: string[] = [];
+    for (const tool of this.tools.values()) {
+      names.push(tool.name);
+      if (tool.aliases) {
+        names.push(...tool.aliases);
+      }
+    }
+    return names;
+  }
+}

--- a/src/modules/tools/registry.ts
+++ b/src/modules/tools/registry.ts
@@ -98,36 +98,154 @@ export class ToolRegistry {
     return matrix[b.length][a.length];
   }
 
-  findSimilarTools(name: string, maxSuggestions: number = 3): ToolMetadata[] {
-    const allTools = this.getAllTools();
-    const distances: Array<{ tool: ToolMetadata; distance: number }> = [];
+  private tokenize(name: string): string[] {
+    return name.toLowerCase().split(/[_\s]+/);
+  }
 
-    // Calculate distances for all tools and their aliases
-    for (const tool of allTools) {
+  private calculateSimilarityScore(searchTokens: string[], targetTokens: string[]): number {
+    // First try exact token matching with position awareness
+    const searchStr = searchTokens.join('_');
+    const targetStr = targetTokens.join('_');
+    
+    // Perfect match
+    if (searchStr === targetStr) {
+      return 1.0;
+    }
+    
+    // Check if tokens are the same but in different order
+    const searchSet = new Set(searchTokens);
+    const targetSet = new Set(targetTokens);
+    if (searchSet.size === targetSet.size && 
+        [...searchSet].every(token => targetSet.has(token))) {
+      return 0.9;
+    }
+
+    // Calculate token-by-token similarity
+    let score = 0;
+    const usedTargetTokens = new Set<number>();
+    let matchedTokens = 0;
+
+    for (const searchToken of searchTokens) {
+      let bestTokenScore = 0;
+      let bestTokenIndex = -1;
+
+      targetTokens.forEach((targetToken, index) => {
+        if (usedTargetTokens.has(index)) return;
+
+        // Exact match gets highest score
+        if (searchToken === targetToken) {
+          const positionPenalty = Math.abs(searchTokens.indexOf(searchToken) - index) * 0.1;
+          const tokenScore = Math.max(0.8, 1.0 - positionPenalty);
+          if (tokenScore > bestTokenScore) {
+            bestTokenScore = tokenScore;
+            bestTokenIndex = index;
+          }
+          return;
+        }
+
+        // Substring match gets good score
+        if (targetToken.includes(searchToken) || searchToken.includes(targetToken)) {
+          const tokenScore = 0.7;
+          if (tokenScore > bestTokenScore) {
+            bestTokenScore = tokenScore;
+            bestTokenIndex = index;
+          }
+          return;
+        }
+
+        // Levenshtein distance for fuzzy matching
+        const distance = this.calculateLevenshteinDistance(searchToken, targetToken);
+        const maxLength = Math.max(searchToken.length, targetToken.length);
+        const tokenScore = 1 - (distance / maxLength);
+        
+        if (tokenScore > 0.6 && tokenScore > bestTokenScore) {
+          bestTokenScore = tokenScore;
+          bestTokenIndex = index;
+        }
+      });
+
+      if (bestTokenIndex !== -1) {
+        score += bestTokenScore;
+        usedTargetTokens.add(bestTokenIndex);
+        matchedTokens++;
+      }
+    }
+
+    // Penalize if not all tokens were matched
+    const matchRatio = matchedTokens / searchTokens.length;
+    const finalScore = (score / searchTokens.length) * matchRatio;
+
+    // Additional penalty for length mismatch
+    const lengthPenalty = Math.abs(searchTokens.length - targetTokens.length) * 0.1;
+    return Math.max(0, finalScore - lengthPenalty);
+  }
+
+  private isCommonTypo(a: string, b: string): boolean {
+    const commonTypos: { [key: string]: string[] } = {
+      'label': ['lable', 'labl', 'lbl'],
+      'email': ['emil', 'mail', 'emal'],
+      'calendar': ['calender', 'calander', 'caldr'],
+      'workspace': ['workspce', 'wrkspace', 'wrkspc'],
+      'create': ['creat', 'crete', 'craete'],
+      'message': ['mesage', 'msg', 'messge'],
+      'draft': ['draf', 'drft', 'darft']
+    };
+
+    // Check both directions (a->b and b->a)
+    for (const [word, typos] of Object.entries(commonTypos)) {
+      if ((a === word && typos.includes(b)) || (b === word && typos.includes(a))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  findSimilarTools(name: string, maxSuggestions: number = 3): ToolMetadata[] {
+    const searchTokens = this.tokenize(name);
+    const matches: Array<{ tool: ToolMetadata; score: number }> = [];
+
+    for (const tool of this.getAllTools()) {
+      let bestScore = 0;
+
       // Check main tool name
-      const mainDistance = this.calculateLevenshteinDistance(name.toLowerCase(), tool.name.toLowerCase());
-      distances.push({ tool, distance: mainDistance });
+      const nameTokens = this.tokenize(tool.name);
+      bestScore = this.calculateSimilarityScore(searchTokens, nameTokens);
+
+      // Check for common typos in each token
+      const hasCommonTypo = searchTokens.some(searchToken =>
+        nameTokens.some(nameToken => this.isCommonTypo(searchToken, nameToken))
+      );
+      if (hasCommonTypo) {
+        bestScore = Math.max(bestScore, 0.8); // Boost score for common typos
+      }
 
       // Check aliases
       if (tool.aliases) {
         for (const alias of tool.aliases) {
-          const aliasDistance = this.calculateLevenshteinDistance(name.toLowerCase(), alias.toLowerCase());
-          if (aliasDistance < mainDistance) {
-            // Update with better match if found
-            const existing = distances.find(d => d.tool === tool);
-            if (existing) {
-              existing.distance = aliasDistance;
-            }
+          const aliasTokens = this.tokenize(alias);
+          const aliasScore = this.calculateSimilarityScore(searchTokens, aliasTokens);
+          
+          // Check for common typos in aliases too
+          if (searchTokens.some(searchToken =>
+              aliasTokens.some(aliasToken => this.isCommonTypo(searchToken, aliasToken)))) {
+            bestScore = Math.max(bestScore, 0.8);
           }
+          
+          bestScore = Math.max(bestScore, aliasScore);
         }
+      }
+
+      // More lenient threshold (0.4 instead of 0.5) and include common typos
+      if (bestScore > 0.4 || hasCommonTypo) {
+        matches.push({ tool, score: bestScore });
       }
     }
 
-    // Sort by distance and return top matches
-    return distances
-      .sort((a, b) => a.distance - b.distance)
+    // Sort by score (highest first) and return top matches
+    return matches
+      .sort((a, b) => b.score - a.score)
       .slice(0, maxSuggestions)
-      .map(d => d.tool);
+      .map(m => m.tool);
   }
 
   formatErrorWithSuggestions(invalidToolName: string): string {

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -1,10 +1,13 @@
 import { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { ToolMetadata } from "../modules/tools/registry.js";
 
 // Account Management Tools
-export const accountTools: Tool[] = [
+export const accountTools: ToolMetadata[] = [
   {
     name: 'list_workspace_accounts',
+    category: 'Account Management',
     description: 'List all configured Google workspace accounts and their authentication status',
+    aliases: ['list_accounts', 'get_accounts', 'show_accounts'],
     inputSchema: {
       type: 'object',
       properties: {}
@@ -12,7 +15,9 @@ export const accountTools: Tool[] = [
   },
   {
     name: 'authenticate_workspace_account',
+    category: 'Account Management',
     description: 'Add and authenticate a Google account for API access. IMPORTANT: When authenticating, always use the exact auth_url from the API response to ensure all OAuth parameters are preserved correctly. REQUIRED: When you get the auth_url, you must share it with the user by providing it in a response. The user will then click it to visit the URL and authorize the app. After authorization, the user will share that response with you. The auth_code will be a long string starting with "4/" followed by alphanumeric characters. Common errors include: expired auth_code (must be used quickly), invalid auth_code format, or missing required scopes. The response will include the account status and configured scopes.',
+    aliases: ['auth_account', 'add_account', 'connect_account'],
     inputSchema: {
       type: 'object',
       properties: {
@@ -38,7 +43,9 @@ export const accountTools: Tool[] = [
   },
   {
     name: 'remove_workspace_account',
+    category: 'Account Management',
     description: 'Remove a Google account and delete its associated authentication tokens',
+    aliases: ['delete_account', 'disconnect_account', 'remove_account'],
     inputSchema: {
       type: 'object',
       properties: {
@@ -53,10 +60,12 @@ export const accountTools: Tool[] = [
 ];
 
 // Gmail Tools
-export const gmailTools: Tool[] = [
+export const gmailTools: ToolMetadata[] = [
   {
     name: 'search_workspace_emails',
+    category: 'Gmail/Messages',
     description: 'Search emails in a Gmail account with advanced filtering capabilities. Date formats should be YYYY-MM-DD (e.g., "2024-02-18"). Label names are case-sensitive and should match Gmail exactly (e.g., "INBOX", "SENT", "IMPORTANT" for system labels). For pagination, use maxResults to limit initial results and handle the nextPageToken in the response if more results exist.',
+    aliases: ['search_emails', 'find_emails', 'query_emails'],
     inputSchema: {
       type: 'object',
       properties: {
@@ -132,7 +141,9 @@ export const gmailTools: Tool[] = [
   },
   {
     name: 'send_workspace_email',
+    category: 'Gmail/Messages',
     description: 'Send an email from a Gmail account',
+    aliases: ['send_email', 'send_mail', 'create_email'],
     inputSchema: {
       type: 'object',
       properties: {
@@ -169,7 +180,9 @@ export const gmailTools: Tool[] = [
   },
   {
     name: 'get_workspace_gmail_settings',
+    category: 'Gmail/Settings',
     description: 'Get Gmail settings and profile information for a workspace account',
+    aliases: ['get_gmail_settings', 'gmail_settings', 'get_mail_settings'],
     inputSchema: {
       type: 'object',
       properties: {
@@ -183,7 +196,9 @@ export const gmailTools: Tool[] = [
   },
   {
     name: 'create_workspace_draft',
+    category: 'Gmail/Drafts',
     description: 'Create a new email draft, with support for both new emails and replies',
+    aliases: ['create_draft', 'new_draft', 'save_draft'],
     inputSchema: {
       type: 'object',
       properties: {
@@ -237,7 +252,9 @@ export const gmailTools: Tool[] = [
   },
   {
     name: 'get_workspace_drafts',
+    category: 'Gmail/Drafts',
     description: 'Get a list of email drafts',
+    aliases: ['list_drafts', 'show_drafts', 'view_drafts'],
     inputSchema: {
       type: 'object',
       properties: {
@@ -259,7 +276,9 @@ export const gmailTools: Tool[] = [
   },
   {
     name: 'send_workspace_draft',
+    category: 'Gmail/Drafts',
     description: 'Send an existing draft',
+    aliases: ['send_draft', 'publish_draft'],
     inputSchema: {
       type: 'object',
       properties: {
@@ -278,10 +297,12 @@ export const gmailTools: Tool[] = [
 ];
 
 // Calendar Tools
-export const calendarTools: Tool[] = [
+export const calendarTools: ToolMetadata[] = [
   {
     name: 'list_workspace_calendar_events',
+    category: 'Calendar/Events',
     description: 'Get calendar events with optional filtering',
+    aliases: ['list_events', 'get_events', 'show_events'],
     inputSchema: {
       type: 'object',
       properties: {
@@ -311,7 +332,9 @@ export const calendarTools: Tool[] = [
   },
   {
     name: 'get_workspace_calendar_event',
+    category: 'Calendar/Events',
     description: 'Get a single calendar event by ID',
+    aliases: ['get_event', 'view_event', 'show_event'],
     inputSchema: {
       type: 'object',
       properties: {
@@ -329,7 +352,9 @@ export const calendarTools: Tool[] = [
   },
   {
     name: 'manage_workspace_calendar_event',
+    category: 'Calendar/Events',
     description: 'Manage calendar event responses and updates including accept/decline, propose new times, and update event times',
+    aliases: ['manage_event', 'update_event', 'respond_to_event'],
     inputSchema: {
       type: 'object',
       properties: {
@@ -394,7 +419,9 @@ export const calendarTools: Tool[] = [
   },
   {
     name: 'create_workspace_calendar_event',
+    category: 'Calendar/Events',
     description: 'Create a new calendar event. Times must be in ISO-8601 format (e.g., "2024-02-18T15:30:00-06:00"). Timezone should be an IANA timezone identifier (e.g., "America/Chicago"). For recurring events, use standard RRULE format (e.g., "RRULE:FREQ=WEEKLY;COUNT=10" for weekly for 10 occurrences). The response will include the created event ID and any scheduling conflicts with attendees.',
+    aliases: ['create_event', 'new_event', 'schedule_event'],
     inputSchema: {
       type: 'object',
       properties: {
@@ -463,7 +490,9 @@ export const calendarTools: Tool[] = [
   },
   {
     name: 'delete_workspace_calendar_event',
+    category: 'Calendar/Events',
     description: 'Delete a calendar event',
+    aliases: ['delete_event', 'remove_event', 'cancel_event'],
     inputSchema: {
       type: 'object',
       properties: {
@@ -487,10 +516,12 @@ export const calendarTools: Tool[] = [
 ];
 
 // Label Management Tools
-export const labelTools: Tool[] = [
+export const labelTools: ToolMetadata[] = [
   {
     name: 'get_workspace_labels',
+    category: 'Gmail/Labels',
     description: 'List all labels in a Gmail account',
+    aliases: ['list_labels', 'show_labels', 'get_labels'],
     inputSchema: {
       type: 'object',
       properties: {
@@ -504,7 +535,9 @@ export const labelTools: Tool[] = [
   },
   {
     name: 'create_workspace_label',
+    category: 'Gmail/Labels',
     description: 'Create a new label in a Gmail account. Note: System labels (e.g., INBOX, SENT, SPAM) cannot be created or modified. Color values should be hex codes (e.g., textColor: "#000000", backgroundColor: "#FFFFFF"). Nested labels can be created using "/" in the name (e.g., "Work/Projects"). The response will include the created label ID and full label details.',
+    aliases: ['create_label', 'new_label', 'add_label', 'create_gmail_label'],
     inputSchema: {
       type: 'object',
       properties: {
@@ -545,7 +578,9 @@ export const labelTools: Tool[] = [
   },
   {
     name: 'update_workspace_label',
+    category: 'Gmail/Labels',
     description: 'Update an existing label in a Gmail account',
+    aliases: ['update_label', 'edit_label', 'modify_label'],
     inputSchema: {
       type: 'object',
       properties: {
@@ -590,7 +625,9 @@ export const labelTools: Tool[] = [
   },
   {
     name: 'delete_workspace_label',
+    category: 'Gmail/Labels',
     description: 'Delete a label from a Gmail account',
+    aliases: ['delete_label', 'remove_label'],
     inputSchema: {
       type: 'object',
       properties: {
@@ -608,7 +645,9 @@ export const labelTools: Tool[] = [
   },
   {
     name: 'modify_workspace_message_labels',
+    category: 'Gmail/Labels',
     description: 'Add or remove labels from a Gmail message',
+    aliases: ['modify_message_labels', 'update_message_labels', 'change_message_labels'],
     inputSchema: {
       type: 'object',
       properties: {
@@ -641,7 +680,7 @@ export const labelTools: Tool[] = [
 ];
 
 // Export all tools combined
-export const allTools: Tool[] = [
+export const allTools: ToolMetadata[] = [
   ...accountTools,
   ...gmailTools,
   ...calendarTools,


### PR DESCRIPTION
Updates the comment in `src/tools/server.ts` to accurately reflect the current tool registration system using ToolRegistry as a single source of truth for both tool discovery and execution.

The old comment suggested tools needed to be registered in both ListToolsRequestSchema and CallToolRequestSchema handlers, which is no longer true with the current implementation.