### PR TITLE
Consolidate label tools into unified interface

### DIFF
--- a/src/modules/gmail/index.ts
+++ b/src/modules/gmail/index.ts
@@ -32,8 +32,8 @@ export function getGmailService(): GmailService {
   return gmailService;
 }
 
+export { GmailService } from './service.js';
 export {
-  GmailService,
   GetEmailsParams,
   SendEmailParams,
   EmailResponse,
@@ -41,5 +41,12 @@ export {
   GetGmailSettingsParams,
   GetGmailSettingsResponse,
   GmailError,
-  GmailModuleConfig
-};
+  GmailModuleConfig,
+  // Label management types
+  ManageLabelParams,
+  ManageLabelAssignmentParams,
+  ManageLabelFilterParams,
+  LabelAction,
+  LabelAssignmentAction,
+  LabelFilterAction
+} from './types.js';

--- a/src/modules/gmail/services/base.ts
+++ b/src/modules/gmail/services/base.ts
@@ -16,19 +16,15 @@ import {
   GetDraftsResponse,
   SendDraftParams,
   Label,
-  GetLabelsParams,
   GetLabelsResponse,
-  CreateLabelParams,
-  UpdateLabelParams,
-  DeleteLabelParams,
-  ModifyMessageLabelsParams,
-  CreateLabelFilterParams,
-  UpdateLabelFilterParams,
-  DeleteLabelFilterParams,
-  GetLabelFiltersParams,
-  GetLabelFiltersResponse,
   LabelFilter
 } from '../types.js';
+
+import {
+  ManageLabelParams,
+  ManageLabelAssignmentParams,
+  ManageLabelFilterParams
+} from './label.js';
 import { EmailService } from './email.js';
 import { SearchService } from './search.js';
 import { DraftService } from './draft.js';
@@ -144,58 +140,22 @@ export class GmailService extends BaseGoogleService<ReturnType<typeof google.gma
     return this.settingsService.getWorkspaceGmailSettings(params);
   }
 
-  async getLabels(params: GetLabelsParams): Promise<GetLabelsResponse> {
+  // Consolidated Label Management Methods
+  async manageLabel(params: ManageLabelParams): Promise<Label | GetLabelsResponse | void> {
     this.ensureServices();
     await this.getGmailClient(params.email);
-    return this.labelService.getLabels(params);
+    return this.labelService.manageLabel(params);
   }
 
-  async createLabel(params: CreateLabelParams): Promise<Label> {
+  async manageLabelAssignment(params: ManageLabelAssignmentParams): Promise<void> {
     this.ensureServices();
     await this.getGmailClient(params.email);
-    return this.labelService.createLabel(params);
+    return this.labelService.manageLabelAssignment(params);
   }
 
-  async updateLabel(params: UpdateLabelParams): Promise<Label> {
+  async manageLabelFilter(params: ManageLabelFilterParams): Promise<LabelFilter | GetLabelsResponse | void> {
     this.ensureServices();
     await this.getGmailClient(params.email);
-    return this.labelService.updateLabel(params);
-  }
-
-  async deleteLabel(params: DeleteLabelParams): Promise<void> {
-    this.ensureServices();
-    await this.getGmailClient(params.email);
-    return this.labelService.deleteLabel(params);
-  }
-
-  async modifyMessageLabels(params: ModifyMessageLabelsParams): Promise<void> {
-    this.ensureServices();
-    await this.getGmailClient(params.email);
-    return this.labelService.modifyMessageLabels(params);
-  }
-
-  // Label Filter Methods
-  async createLabelFilter(params: CreateLabelFilterParams): Promise<LabelFilter> {
-    this.ensureServices();
-    await this.getGmailClient(params.email);
-    return this.filterService.createFilter(params);
-  }
-
-  async getLabelFilters(params: GetLabelFiltersParams): Promise<GetLabelFiltersResponse> {
-    this.ensureServices();
-    await this.getGmailClient(params.email);
-    return this.filterService.getFilters(params);
-  }
-
-  async updateLabelFilter(params: UpdateLabelFilterParams): Promise<LabelFilter> {
-    this.ensureServices();
-    await this.getGmailClient(params.email);
-    return this.filterService.updateFilter(params);
-  }
-
-  async deleteLabelFilter(params: DeleteLabelFilterParams): Promise<void> {
-    this.ensureServices();
-    await this.getGmailClient(params.email);
-    return this.filterService.deleteFilter(params);
+    return this.labelService.manageLabelFilter(params);
   }
 }

--- a/src/modules/gmail/services/label.ts
+++ b/src/modules/gmail/services/label.ts
@@ -7,13 +7,56 @@ import {
   GetLabelsParams,
   GetLabelsResponse,
   ModifyMessageLabelsParams,
-  GmailError
+  GmailError,
+  CreateLabelFilterParams,
+  GetLabelFiltersParams,
+  UpdateLabelFilterParams,
+  DeleteLabelFilterParams,
+  LabelFilterCriteria,
+  LabelFilterActions
 } from '../types.js';
 import {
   isValidGmailLabelColor,
   getNearestGmailLabelColor,
   LABEL_ERROR_MESSAGES
 } from '../constants.js';
+
+export type LabelAction = 'create' | 'read' | 'update' | 'delete';
+export type LabelAssignmentAction = 'add' | 'remove';
+export type LabelFilterAction = 'create' | 'read' | 'update' | 'delete';
+
+export interface ManageLabelParams {
+  action: LabelAction;
+  email: string;
+  labelId?: string;
+  data?: {
+    name?: string;
+    messageListVisibility?: 'show' | 'hide';
+    labelListVisibility?: 'labelShow' | 'labelHide' | 'labelShowIfUnread';
+    color?: {
+      textColor: string;
+      backgroundColor: string;
+    };
+  };
+}
+
+export interface ManageLabelAssignmentParams {
+  action: LabelAssignmentAction;
+  email: string;
+  messageId: string;
+  labelIds: string[];
+}
+
+export interface ManageLabelFilterParams {
+  action: LabelFilterAction;
+  email: string;
+  filterId?: string;
+  labelId?: string;
+  data?: {
+    criteria: LabelFilterCriteria;
+    actions: LabelFilterActions;
+  };
+}
 
 export class LabelService {
   private client: gmail_v1.Gmail | null = null;
@@ -32,56 +75,161 @@ export class LabelService {
     }
   }
 
-  /**
-   * Get all labels in the user's mailbox
-   */
-  async getLabels(params: GetLabelsParams): Promise<GetLabelsResponse> {
+  async manageLabel(params: ManageLabelParams): Promise<Label | GetLabelsResponse | void> {
     this.ensureClient();
-    try {
-      const response = await this.client?.users.labels.list({
-        userId: params.email
-      });
 
-      if (!response?.data.labels) {
-        return { labels: [] };
-      }
+    switch (params.action) {
+      case 'create':
+        if (!params.data?.name) {
+          throw new GmailError(
+            'Label name is required for creation',
+            'VALIDATION_ERROR',
+            'Please provide a name for the label'
+          );
+        }
+        return this.createLabel({
+          email: params.email,
+          name: params.data.name,
+          messageListVisibility: params.data.messageListVisibility,
+          labelListVisibility: params.data.labelListVisibility,
+          color: params.data.color
+        });
 
-      return {
-        labels: response.data.labels.map(label => {
-          const mappedLabel: Label = {
-            id: label.id || '',
-            name: label.name || '',
-            type: (label.type || 'user') as 'system' | 'user',
-            messageListVisibility: (label.messageListVisibility || 'show') as 'hide' | 'show',
-            labelListVisibility: (label.labelListVisibility || 'labelShow') as 'labelHide' | 'labelShow' | 'labelShowIfUnread'
-          };
-
-          if (label.color?.textColor && label.color?.backgroundColor) {
-            mappedLabel.color = {
-              textColor: label.color.textColor,
-              backgroundColor: label.color.backgroundColor
-            };
+      case 'read':
+        if (params.labelId) {
+          // Get specific label
+          const response = await this.client?.users.labels.get({
+            userId: params.email,
+            id: params.labelId
+          });
+          if (!response?.data) {
+            throw new GmailError(
+              'Label not found',
+              'NOT_FOUND_ERROR',
+              `Label ${params.labelId} does not exist`
+            );
           }
+          return this.mapGmailLabel(response.data);
+        } else {
+          // Get all labels
+          return this.getLabels({ email: params.email });
+        }
 
-          return mappedLabel;
-        })
-      };
-    } catch (error: unknown) {
-      throw new GmailError(
-        'Failed to fetch labels',
-        'FETCH_ERROR',
-        error instanceof Error ? error.message : 'Unknown error'
-      );
+      case 'update':
+        if (!params.labelId) {
+          throw new GmailError(
+            'Label ID is required for update',
+            'VALIDATION_ERROR',
+            'Please provide a label ID'
+          );
+        }
+        return this.updateLabel({
+          email: params.email,
+          labelId: params.labelId,
+          ...params.data
+        });
+
+      case 'delete':
+        if (!params.labelId) {
+          throw new GmailError(
+            'Label ID is required for deletion',
+            'VALIDATION_ERROR',
+            'Please provide a label ID'
+          );
+        }
+        return this.deleteLabel({
+          email: params.email,
+          labelId: params.labelId
+        });
+
+      default:
+        throw new GmailError(
+          'Invalid label action',
+          'VALIDATION_ERROR',
+          `Action ${params.action} is not supported`
+        );
     }
   }
 
-  /**
-   * Create a new label
-   */
-  async createLabel(params: CreateLabelParams): Promise<Label> {
+  async manageLabelAssignment(params: ManageLabelAssignmentParams): Promise<void> {
     this.ensureClient();
+
+    const modifyParams: ModifyMessageLabelsParams = {
+      email: params.email,
+      messageId: params.messageId,
+      addLabelIds: params.action === 'add' ? params.labelIds : [],
+      removeLabelIds: params.action === 'remove' ? params.labelIds : []
+    };
+
+    return this.modifyMessageLabels(modifyParams);
+  }
+
+  async manageLabelFilter(params: ManageLabelFilterParams): Promise<any> {
+    this.ensureClient();
+
+    switch (params.action) {
+      case 'create':
+        if (!params.labelId || !params.data?.criteria || !params.data?.actions) {
+          throw new GmailError(
+            'Missing required filter data',
+            'VALIDATION_ERROR',
+            'Please provide labelId, criteria, and actions'
+          );
+        }
+        return this.createLabelFilter({
+          email: params.email,
+          labelId: params.labelId,
+          criteria: params.data.criteria,
+          actions: params.data.actions
+        });
+
+      case 'read':
+        return this.getLabelFilters({
+          email: params.email,
+          labelId: params.labelId
+        });
+
+      case 'update':
+        if (!params.filterId || !params.labelId || !params.data?.criteria || !params.data?.actions) {
+          throw new GmailError(
+            'Missing required filter update data',
+            'VALIDATION_ERROR',
+            'Please provide filterId, labelId, criteria, and actions'
+          );
+        }
+        return this.updateLabelFilter({
+          email: params.email,
+          filterId: params.filterId,
+          labelId: params.labelId,
+          criteria: params.data.criteria,
+          actions: params.data.actions
+        });
+
+      case 'delete':
+        if (!params.filterId) {
+          throw new GmailError(
+            'Filter ID is required for deletion',
+            'VALIDATION_ERROR',
+            'Please provide a filter ID'
+          );
+        }
+        return this.deleteLabelFilter({
+          email: params.email,
+          filterId: params.filterId
+        });
+
+      default:
+        throw new GmailError(
+          'Invalid filter action',
+          'VALIDATION_ERROR',
+          `Action ${params.action} is not supported`
+        );
+    }
+  }
+
+  // Helper methods that implement the actual operations
+  private async createLabel(params: CreateLabelParams): Promise<Label> {
     try {
-      // Validate colors if provided
       if (params.color) {
         const { textColor, backgroundColor } = params.color;
         if (!isValidGmailLabelColor(textColor, backgroundColor)) {
@@ -115,23 +263,7 @@ export class LabelService {
         );
       }
 
-      const label = response.data;
-      const mappedLabel: Label = {
-        id: label.id || '',
-        name: label.name || '',
-        type: (label.type || 'user') as 'system' | 'user',
-        messageListVisibility: (label.messageListVisibility || 'show') as 'hide' | 'show',
-        labelListVisibility: (label.labelListVisibility || 'labelShow') as 'labelHide' | 'labelShow' | 'labelShowIfUnread'
-      };
-
-      if (label.color?.textColor && label.color?.backgroundColor) {
-        mappedLabel.color = {
-          textColor: label.color.textColor,
-          backgroundColor: label.color.backgroundColor
-        };
-      }
-
-      return mappedLabel;
+      return this.mapGmailLabel(response.data);
     } catch (error: unknown) {
       throw new GmailError(
         'Failed to create label',
@@ -141,13 +273,30 @@ export class LabelService {
     }
   }
 
-  /**
-   * Update an existing label
-   */
-  async updateLabel(params: UpdateLabelParams): Promise<Label> {
-    this.ensureClient();
+  private async getLabels(params: GetLabelsParams): Promise<GetLabelsResponse> {
     try {
-      // Validate colors if provided
+      const response = await this.client?.users.labels.list({
+        userId: params.email
+      });
+
+      if (!response?.data.labels) {
+        return { labels: [] };
+      }
+
+      return {
+        labels: response.data.labels.map(this.mapGmailLabel)
+      };
+    } catch (error: unknown) {
+      throw new GmailError(
+        'Failed to fetch labels',
+        'FETCH_ERROR',
+        error instanceof Error ? error.message : 'Unknown error'
+      );
+    }
+  }
+
+  private async updateLabel(params: UpdateLabelParams): Promise<Label> {
+    try {
       if (params.color) {
         const { textColor, backgroundColor } = params.color;
         if (!isValidGmailLabelColor(textColor, backgroundColor)) {
@@ -182,23 +331,7 @@ export class LabelService {
         );
       }
 
-      const label = response.data;
-      const mappedLabel: Label = {
-        id: label.id || '',
-        name: label.name || '',
-        type: (label.type || 'user') as 'system' | 'user',
-        messageListVisibility: (label.messageListVisibility || 'show') as 'hide' | 'show',
-        labelListVisibility: (label.labelListVisibility || 'labelShow') as 'labelHide' | 'labelShow' | 'labelShowIfUnread'
-      };
-
-      if (label.color?.textColor && label.color?.backgroundColor) {
-        mappedLabel.color = {
-          textColor: label.color.textColor,
-          backgroundColor: label.color.backgroundColor
-        };
-      }
-
-      return mappedLabel;
+      return this.mapGmailLabel(response.data);
     } catch (error: unknown) {
       throw new GmailError(
         'Failed to update label',
@@ -208,11 +341,7 @@ export class LabelService {
     }
   }
 
-  /**
-   * Delete a label
-   */
-  async deleteLabel(params: DeleteLabelParams): Promise<void> {
-    this.ensureClient();
+  private async deleteLabel(params: DeleteLabelParams): Promise<void> {
     try {
       await this.client?.users.labels.delete({
         userId: params.email,
@@ -227,11 +356,7 @@ export class LabelService {
     }
   }
 
-  /**
-   * Modify labels on a message
-   */
-  async modifyMessageLabels(params: ModifyMessageLabelsParams): Promise<void> {
-    this.ensureClient();
+  private async modifyMessageLabels(params: ModifyMessageLabelsParams): Promise<void> {
     try {
       await this.client?.users.messages.modify({
         userId: params.email,
@@ -248,5 +373,183 @@ export class LabelService {
         error instanceof Error ? error.message : 'Unknown error'
       );
     }
+  }
+
+  private async createLabelFilter(params: CreateLabelFilterParams): Promise<gmail_v1.Schema$Filter> {
+    try {
+      // Convert our criteria format to Gmail API format
+      const criteria: gmail_v1.Schema$FilterCriteria = {
+        from: params.criteria.from?.join(' OR ') || null,
+        to: params.criteria.to?.join(' OR ') || null,
+        subject: params.criteria.subject || null,
+        query: params.criteria.hasWords?.join(' OR ') || null,
+        negatedQuery: params.criteria.doesNotHaveWords?.join(' OR ') || null,
+        hasAttachment: params.criteria.hasAttachment || null,
+        size: params.criteria.size?.size || null,
+        sizeComparison: params.criteria.size?.operator || null
+      };
+
+      // Initialize arrays for label IDs
+      const addLabelIds: string[] = [params.labelId];
+      const removeLabelIds: string[] = [];
+
+      // Add additional label IDs based on actions
+      if (params.actions.markImportant) {
+        addLabelIds.push('IMPORTANT');
+      }
+      if (params.actions.markRead) {
+        removeLabelIds.push('UNREAD');
+      }
+      if (params.actions.archive) {
+        removeLabelIds.push('INBOX');
+      }
+
+      // Create the filter action
+      const action: gmail_v1.Schema$FilterAction = {
+        addLabelIds,
+        removeLabelIds,
+        forward: null
+      };
+
+      const response = await this.client?.users.settings.filters.create({
+        userId: params.email,
+        requestBody: {
+          criteria,
+          action
+        }
+      });
+      if (!response?.data) {
+        throw new GmailError(
+          'No response data from create filter request',
+          'CREATE_ERROR',
+          'Server returned empty response'
+        );
+      }
+      return response.data;
+    } catch (error: unknown) {
+      throw new GmailError(
+        'Failed to create label filter',
+        'CREATE_ERROR',
+        error instanceof Error ? error.message : 'Unknown error'
+      );
+    }
+  }
+
+  private async getLabelFilters(params: GetLabelFiltersParams): Promise<gmail_v1.Schema$ListFiltersResponse> {
+    try {
+      const response = await this.client?.users.settings.filters.list({
+        userId: params.email
+      });
+      if (!response?.data) {
+        return { filter: [] };
+      }
+      return response.data;
+    } catch (error: unknown) {
+      throw new GmailError(
+        'Failed to get label filters',
+        'FETCH_ERROR',
+        error instanceof Error ? error.message : 'Unknown error'
+      );
+    }
+  }
+
+  private async updateLabelFilter(params: UpdateLabelFilterParams): Promise<gmail_v1.Schema$Filter> {
+    try {
+      // Gmail API doesn't support direct filter updates, so we need to delete and recreate
+      await this.deleteLabelFilter({
+        email: params.email,
+        filterId: params.filterId
+      });
+
+      // Convert our criteria format to Gmail API format
+      const criteria: gmail_v1.Schema$FilterCriteria = {
+        from: params.criteria.from?.join(' OR ') || null,
+        to: params.criteria.to?.join(' OR ') || null,
+        subject: params.criteria.subject || null,
+        query: params.criteria.hasWords?.join(' OR ') || null,
+        negatedQuery: params.criteria.doesNotHaveWords?.join(' OR ') || null,
+        hasAttachment: params.criteria.hasAttachment || null,
+        size: params.criteria.size?.size || null,
+        sizeComparison: params.criteria.size?.operator || null
+      };
+
+      // Initialize arrays for label IDs
+      const addLabelIds: string[] = [params.labelId];
+      const removeLabelIds: string[] = [];
+
+      // Add additional label IDs based on actions
+      if (params.actions.markImportant) {
+        addLabelIds.push('IMPORTANT');
+      }
+      if (params.actions.markRead) {
+        removeLabelIds.push('UNREAD');
+      }
+      if (params.actions.archive) {
+        removeLabelIds.push('INBOX');
+      }
+
+      // Create the filter action
+      const action: gmail_v1.Schema$FilterAction = {
+        addLabelIds,
+        removeLabelIds,
+        forward: null
+      };
+
+      const response = await this.client?.users.settings.filters.create({
+        userId: params.email,
+        requestBody: {
+          criteria,
+          action
+        }
+      });
+      if (!response?.data) {
+        throw new GmailError(
+          'No response data from update filter request',
+          'UPDATE_ERROR',
+          'Server returned empty response'
+        );
+      }
+      return response.data;
+    } catch (error: unknown) {
+      throw new GmailError(
+        'Failed to update label filter',
+        'UPDATE_ERROR',
+        error instanceof Error ? error.message : 'Unknown error'
+      );
+    }
+  }
+
+  private async deleteLabelFilter(params: DeleteLabelFilterParams): Promise<void> {
+    try {
+      await this.client?.users.settings.filters.delete({
+        userId: params.email,
+        id: params.filterId
+      });
+    } catch (error: unknown) {
+      throw new GmailError(
+        'Failed to delete label filter',
+        'DELETE_ERROR',
+        error instanceof Error ? error.message : 'Unknown error'
+      );
+    }
+  }
+
+  private mapGmailLabel(label: gmail_v1.Schema$Label): Label {
+    const mappedLabel: Label = {
+      id: label.id || '',
+      name: label.name || '',
+      type: (label.type || 'user') as 'system' | 'user',
+      messageListVisibility: (label.messageListVisibility || 'show') as 'hide' | 'show',
+      labelListVisibility: (label.labelListVisibility || 'labelShow') as 'labelHide' | 'labelShow' | 'labelShowIfUnread'
+    };
+
+    if (label.color?.textColor && label.color?.backgroundColor) {
+      mappedLabel.color = {
+        textColor: label.color.textColor,
+        backgroundColor: label.color.backgroundColor
+      };
+    }
+
+    return mappedLabel;
   }
 }

--- a/src/modules/gmail/types.ts
+++ b/src/modules/gmail/types.ts
@@ -271,8 +271,9 @@ export interface CreateLabelFilterParams {
 export interface UpdateLabelFilterParams {
   email: string;
   filterId: string;
-  criteria?: LabelFilterCriteria;
-  actions?: LabelFilterActions;
+  labelId: string;
+  criteria: LabelFilterCriteria;
+  actions: LabelFilterActions;
 }
 
 /**
@@ -297,6 +298,16 @@ export interface GetLabelFiltersParams {
 export interface GetLabelFiltersResponse {
   filters: LabelFilter[];
 }
+
+// Re-export label management types
+export {
+  LabelAction,
+  LabelAssignmentAction,
+  LabelFilterAction,
+  ManageLabelParams,
+  ManageLabelAssignmentParams,
+  ManageLabelFilterParams
+} from './services/label.js';
 
 export class GmailError extends Error {
   constructor(

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -716,57 +716,34 @@ export const calendarTools: ToolMetadata[] = [
 // Label Management Tools
 export const labelTools: ToolMetadata[] = [
   {
-    name: 'get_workspace_labels',
+    name: 'manage_workspace_label',
     category: 'Gmail/Labels',
-    description: `List all labels in a Gmail account.
+    description: `Manage Gmail labels with CRUD operations.
     
-    IMPORTANT: Before listing labels:
+    IMPORTANT: Before any operation:
     1. Verify account access with list_workspace_accounts
     2. Confirm account if multiple exist
     
-    Response includes:
-    - System labels (INBOX, SENT, etc.)
-    - Custom labels
-    - Nested label hierarchies
-    - Label visibility settings
-    - Label colors if set`,
-    aliases: ['list_labels', 'show_labels', 'get_labels'],
-    inputSchema: {
-      type: 'object',
-      properties: {
-        email: {
-          type: 'string',
-          description: 'Email address of the Gmail account'
-        }
-      },
-      required: ['email']
-    }
-  },
-  {
-    name: 'create_workspace_label',
-    category: 'Gmail/Labels',
-    description: `Create a new label in a Gmail account.
-    
-    IMPORTANT: Before creating labels:
-    1. Verify account access with list_workspace_accounts
-    2. Confirm account if multiple exist
-    3. Check if similar label exists
-    
-    Limitations:
-    - Cannot create/modify system labels (INBOX, SENT, SPAM)
-    - Label names must be unique
+    Operations:
+    - create: Create a new label
+    - read: Get a specific label or list all labels
+    - update: Modify an existing label
+    - delete: Remove a label
     
     Features:
     - Nested labels: Use "/" (e.g., "Work/Projects")
     - Custom colors: Hex codes (e.g., "#000000")
     - Visibility options: Show/hide in lists
     
+    Limitations:
+    - Cannot create/modify system labels (INBOX, SENT, SPAM)
+    - Label names must be unique
+    
     Example Flow:
     1. Check account access
-    2. Verify label doesn't exist
-    3. Create with desired settings
-    4. Confirm creation success`,
-    aliases: ['create_label', 'new_label', 'add_label', 'create_gmail_label'],
+    2. Perform desired operation
+    3. Confirm success`,
+    aliases: ['manage_label', 'label_operation', 'handle_label'],
     inputSchema: {
       type: 'object',
       properties: {
@@ -774,133 +751,68 @@ export const labelTools: ToolMetadata[] = [
           type: 'string',
           description: 'Email address of the Gmail account'
         },
-        name: {
+        action: {
           type: 'string',
-          description: 'Name of the label'
+          enum: ['create', 'read', 'update', 'delete'],
+          description: 'Operation to perform'
         },
-        messageListVisibility: {
+        labelId: {
           type: 'string',
-          enum: ['show', 'hide'],
-          description: 'Label visibility in message list'
+          description: 'Label ID (required for read/update/delete)'
         },
-        labelListVisibility: {
-          type: 'string',
-          enum: ['labelShow', 'labelHide', 'labelShowIfUnread'],
-          description: 'Label visibility in label list'
-        },
-        color: {
+        data: {
           type: 'object',
           properties: {
-            textColor: {
+            name: {
               type: 'string',
-              description: 'Text color in hex format (e.g., "#000000" for black)'
+              description: 'Label name (required for create)'
             },
-            backgroundColor: {
+            messageListVisibility: {
               type: 'string',
-              description: 'Background color in hex format (e.g., "#FFFFFF" for white)'
+              enum: ['show', 'hide'],
+              description: 'Label visibility in message list'
+            },
+            labelListVisibility: {
+              type: 'string',
+              enum: ['labelShow', 'labelHide', 'labelShowIfUnread'],
+              description: 'Label visibility in label list'
+            },
+            color: {
+              type: 'object',
+              properties: {
+                textColor: {
+                  type: 'string',
+                  description: 'Text color in hex format'
+                },
+                backgroundColor: {
+                  type: 'string',
+                  description: 'Background color in hex format'
+                }
+              }
             }
           }
         }
       },
-      required: ['email', 'name']
+      required: ['email', 'action']
     }
   },
   {
-    name: 'update_workspace_label',
+    name: 'manage_workspace_label_assignment',
     category: 'Gmail/Labels',
-    description: `Update an existing label in a Gmail account.
+    description: `Manage label assignments for Gmail messages.
     
-    IMPORTANT: Before updating:
-    1. Verify account access with list_workspace_accounts
-    2. Confirm account if multiple exist
-    3. Verify label exists and is modifiable
-    
-    Common Updates:
-    - Rename label
-    - Change colors
-    - Adjust visibility
-    - Modify hierarchy
-    
-    Limitations:
-    - Cannot modify system labels
-    - Cannot create duplicates
-    - Must maintain unique names`,
-    aliases: ['update_label', 'edit_label', 'modify_label'],
-    inputSchema: {
-      type: 'object',
-      properties: {
-        email: {
-          type: 'string',
-          description: 'Email address of the Gmail account'
-        },
-        labelId: {
-          type: 'string',
-          description: 'ID of the label to update'
-        },
-        name: {
-          type: 'string',
-          description: 'New name for the label'
-        },
-        messageListVisibility: {
-          type: 'string',
-          enum: ['show', 'hide'],
-          description: 'Label visibility in message list'
-        },
-        labelListVisibility: {
-          type: 'string',
-          enum: ['labelShow', 'labelHide', 'labelShowIfUnread'],
-          description: 'Label visibility in label list'
-        },
-        color: {
-          type: 'object',
-          properties: {
-            textColor: {
-              type: 'string',
-              description: 'Text color in hex format'
-            },
-            backgroundColor: {
-              type: 'string',
-              description: 'Background color in hex format'
-            }
-          }
-        }
-      },
-      required: ['email', 'labelId']
-    }
-  },
-  {
-    name: 'delete_workspace_label',
-    category: 'Gmail/Labels',
-    description: 'Delete a label from a Gmail account',
-    aliases: ['delete_label', 'remove_label'],
-    inputSchema: {
-      type: 'object',
-      properties: {
-        email: {
-          type: 'string',
-          description: 'Email address of the Gmail account'
-        },
-        labelId: {
-          type: 'string',
-          description: 'ID of the label to delete'
-        }
-      },
-      required: ['email', 'labelId']
-    }
-  },
-  {
-    name: 'modify_workspace_message_labels',
-    category: 'Gmail/Labels',
-    description: `Add or remove labels from a Gmail message.
-    
-    IMPORTANT: Before modifying:
+    IMPORTANT: Before assigning:
     1. Verify account access with list_workspace_accounts
     2. Confirm account if multiple exist
     3. Verify message exists
     4. Check label validity
     
-    Common Patterns:
-    - Add single label
+    Operations:
+    - add: Apply labels to a message
+    - remove: Remove labels from a message
+    
+    Common Use Cases:
+    - Apply single label
     - Remove single label
     - Batch modify multiple labels
     - Update system labels (e.g., mark as read)
@@ -910,7 +822,7 @@ export const labelTools: ToolMetadata[] = [
     2. Verify message and labels exist
     3. Apply requested changes
     4. Confirm modifications`,
-    aliases: ['modify_message_labels', 'update_message_labels', 'change_message_labels'],
+    aliases: ['assign_label', 'modify_message_labels', 'change_message_labels'],
     inputSchema: {
       type: 'object',
       properties: {
@@ -918,38 +830,40 @@ export const labelTools: ToolMetadata[] = [
           type: 'string',
           description: 'Email address of the Gmail account'
         },
+        action: {
+          type: 'string',
+          enum: ['add', 'remove'],
+          description: 'Whether to add or remove labels'
+        },
         messageId: {
           type: 'string',
           description: 'ID of the message to modify'
         },
-        addLabelIds: {
+        labelIds: {
           type: 'array',
-          items: {
-            type: 'string'
-          },
-          description: 'Array of label IDs to add to the message'
-        },
-        removeLabelIds: {
-          type: 'array',
-          items: {
-            type: 'string'
-          },
-          description: 'Array of label IDs to remove from the message'
+          items: { type: 'string' },
+          description: 'Array of label IDs to add or remove'
         }
       },
-      required: ['email', 'messageId']
+      required: ['email', 'action', 'messageId', 'labelIds']
     }
   },
   {
-    name: 'create_workspace_label_filter',
+    name: 'manage_workspace_label_filter',
     category: 'Gmail/Labels',
-    description: `Create a new filter for a Gmail label.
+    description: `Manage Gmail label filters with CRUD operations.
     
-    IMPORTANT: Before creating filters:
+    IMPORTANT: Before any operation:
     1. Verify account access with list_workspace_accounts
     2. Confirm account if multiple exist
-    3. Verify label exists
+    3. Verify label exists for create/update
     4. Validate filter criteria
+    
+    Operations:
+    - create: Create a new filter
+    - read: Get filters (all or by label)
+    - update: Modify existing filter
+    - delete: Remove filter
     
     Filter Capabilities:
     - Match sender(s) and recipient(s)
@@ -962,46 +876,24 @@ export const labelTools: ToolMetadata[] = [
     - Mark as important
     - Mark as read
     - Archive message
-
-    Criteria Format Requirements:
-    1. For simple filters:
+    
+    Criteria Format:
+    1. Simple filters:
        - from: Array of email addresses
        - to: Array of email addresses
        - subject: String for exact match
        - hasAttachment: Boolean
-
-    2. For complex Gmail queries:
-       - hasWords: Array with single string containing full Gmail query
-       - Example: ["from:(*@domain.com OR other@domain.com) subject:(word1 OR word2)"]
     
-    Common Query Patterns:
-    - Meeting emails: ["from:(*@zoom.us OR zoom.us OR calendar-notification@google.com) subject:(meeting OR sync OR invite)"]
-    - HR/Admin: ["from:(*@workday.com OR *@adp.com) subject:(time off OR PTO OR benefits)"]
-    - Team updates: ["from:(*@company.com) -from:(notifications@company.com)"]
-    - Newsletters: ["subject:(newsletter OR digest) from:(*@company.com)"]
-    
-    Common Errors:
-    - "Proto field is not repeating" → Convert string to array
-    - "params.criteria.X?.join is not a function" → Make sure field is array
-    - "Invalid JSON payload" → Check field format matches Gmail API
-    
-    Testing Strategy:
-    1. Test search query first:
-       - Use search_workspace_emails with content field
-       - Verify matches expected messages
-    2. Create filter with validated query:
-       - Convert search query to hasWords array
-       - Set appropriate actions
-    3. Verify filter operation:
-       - Check filter was created
-       - Confirm it catches new matching emails
+    2. Complex queries:
+       - hasWords: Array of query strings
+       - doesNotHaveWords: Array of exclusion strings
     
     Example Flow:
     1. Check account access
-    2. Test search query
-    3. Create filter with validated criteria
-    4. Confirm filter creation and operation`,
-    aliases: ['create_filter', 'add_filter', 'new_label_filter'],
+    2. Validate criteria
+    3. Perform operation
+    4. Verify result`,
+    aliases: ['manage_filter', 'handle_filter', 'filter_operation'],
     inputSchema: {
       type: 'object',
       properties: {
@@ -1009,276 +901,95 @@ export const labelTools: ToolMetadata[] = [
           type: 'string',
           description: 'Email address of the Gmail account'
         },
-        labelId: {
+        action: {
           type: 'string',
-          description: 'ID of the label to apply'
-        },
-        criteria: {
-          type: 'object',
-          properties: {
-            from: {
-              type: 'array',
-              items: { type: 'string' },
-              description: 'Match sender email addresses'
-            },
-            to: {
-              type: 'array',
-              items: { type: 'string' },
-              description: 'Match recipient email addresses'
-            },
-            subject: {
-              type: 'string',
-              description: 'Match text in subject'
-            },
-            hasWords: {
-              type: 'array',
-              items: { type: 'string' },
-              description: 'Complex Gmail query strings (e.g., ["from:(*@domain.com) subject:(word1 OR word2)"])'
-            },
-            doesNotHaveWords: {
-              type: 'array',
-              items: { type: 'string' },
-              description: 'Exclude messages with these words'
-            },
-            hasAttachment: {
-              type: 'boolean',
-              description: 'Match messages with attachments'
-            },
-            size: {
-              type: 'object',
-              properties: {
-                operator: {
-                  type: 'string',
-                  enum: ['larger', 'smaller'],
-                  description: 'Size comparison operator'
-                },
-                size: {
-                  type: 'number',
-                  description: 'Size in bytes'
-                }
-              }
-            }
-          }
-        },
-        actions: {
-          type: 'object',
-          properties: {
-            addLabel: {
-              type: 'boolean',
-              description: 'Apply the label'
-            },
-            markImportant: {
-              type: 'boolean',
-              description: 'Mark as important'
-            },
-            markRead: {
-              type: 'boolean',
-              description: 'Mark as read'
-            },
-            archive: {
-              type: 'boolean',
-              description: 'Archive the message'
-            }
-          },
-          required: ['addLabel']
-        }
-      },
-      required: ['email', 'labelId', 'criteria', 'actions']
-    }
-  },
-  {
-    name: 'get_workspace_label_filters',
-    category: 'Gmail/Labels',
-    description: `Get filters for a Gmail label.
-    
-    IMPORTANT: Before listing filters:
-    1. Verify account access with list_workspace_accounts
-    2. Confirm account if multiple exist
-    
-    Response includes:
-    - Filter IDs
-    - Filter criteria
-    - Associated actions
-    - Label associations`,
-    aliases: ['list_filters', 'show_filters', 'get_filters'],
-    inputSchema: {
-      type: 'object',
-      properties: {
-        email: {
-          type: 'string',
-          description: 'Email address of the Gmail account'
-        },
-        labelId: {
-          type: 'string',
-          description: 'Optional: get filters for specific label'
-        }
-      },
-      required: ['email']
-    }
-  },
-  {
-    name: 'update_workspace_label_filter',
-    category: 'Gmail/Labels',
-    description: `Update an existing Gmail label filter.
-    
-    IMPORTANT: Before updating:
-    1. Verify account access with list_workspace_accounts
-    2. Confirm account if multiple exist
-    3. Verify filter exists
-    
-    Common Updates:
-    - Modify criteria
-    - Change actions
-    - Adjust matching rules
-    
-    Criteria Format Requirements:
-    1. For simple filters:
-       - from: Array of email addresses
-       - to: Array of email addresses
-       - subject: String for exact match
-       - hasAttachment: Boolean
-
-    2. For complex Gmail queries:
-       - hasWords: Array with single string containing full Gmail query
-       - Example: ["from:(*@domain.com OR other@domain.com) subject:(word1 OR word2)"]
-    
-    Common Query Patterns:
-    - Meeting emails: ["from:(*@zoom.us OR zoom.us OR calendar-notification@google.com) subject:(meeting OR sync OR invite)"]
-    - HR/Admin: ["from:(*@workday.com OR *@adp.com) subject:(time off OR PTO OR benefits)"]
-    - Team updates: ["from:(*@company.com) -from:(notifications@company.com)"]
-    - Newsletters: ["subject:(newsletter OR digest) from:(*@company.com)"]
-    
-    Common Errors:
-    - "Proto field is not repeating" → Convert string to array
-    - "params.criteria.X?.join is not a function" → Make sure field is array
-    - "Invalid JSON payload" → Check field format matches Gmail API
-    
-    Testing Strategy:
-    1. Test search query first:
-       - Use search_workspace_emails with content field
-       - Verify matches expected messages
-    2. Update filter with validated query:
-       - Convert search query to hasWords array
-       - Set appropriate actions
-    3. Verify filter operation:
-       - Check filter was updated
-       - Confirm it catches new matching emails
-    
-    Example Flow:
-    1. Check account access
-    2. Test search query
-    3. Update filter with validated criteria
-    4. Confirm filter changes and operation`,
-    aliases: ['update_filter', 'edit_filter', 'modify_filter'],
-    inputSchema: {
-      type: 'object',
-      properties: {
-        email: {
-          type: 'string',
-          description: 'Email address of the Gmail account'
+          enum: ['create', 'read', 'update', 'delete'],
+          description: 'Operation to perform'
         },
         filterId: {
           type: 'string',
-          description: 'ID of filter to update'
+          description: 'Filter ID (required for update/delete)'
         },
-        criteria: {
+        labelId: {
+          type: 'string',
+          description: 'Label ID (required for create/update)'
+        },
+        data: {
           type: 'object',
           properties: {
-            from: {
-              type: 'array',
-              items: { type: 'string' },
-              description: 'Match sender email addresses'
-            },
-            to: {
-              type: 'array',
-              items: { type: 'string' },
-              description: 'Match recipient email addresses'
-            },
-            subject: {
-              type: 'string',
-              description: 'Match text in subject'
-            },
-            hasWords: {
-              type: 'array',
-              items: { type: 'string' },
-              description: 'Complex Gmail query strings (e.g., ["from:(*@domain.com) subject:(word1 OR word2)"])'
-            },
-            doesNotHaveWords: {
-              type: 'array',
-              items: { type: 'string' },
-              description: 'Exclude messages with these words'
-            },
-            hasAttachment: {
-              type: 'boolean',
-              description: 'Match messages with attachments'
-            },
-            size: {
+            criteria: {
               type: 'object',
               properties: {
-                operator: {
+                from: {
+                  type: 'array',
+                  items: { type: 'string' },
+                  description: 'Match sender email addresses'
+                },
+                to: {
+                  type: 'array',
+                  items: { type: 'string' },
+                  description: 'Match recipient email addresses'
+                },
+                subject: {
                   type: 'string',
-                  enum: ['larger', 'smaller'],
-                  description: 'Size comparison operator'
+                  description: 'Match text in subject'
+                },
+                hasWords: {
+                  type: 'array',
+                  items: { type: 'string' },
+                  description: 'Match words in message body'
+                },
+                doesNotHaveWords: {
+                  type: 'array',
+                  items: { type: 'string' },
+                  description: 'Exclude messages with these words'
+                },
+                hasAttachment: {
+                  type: 'boolean',
+                  description: 'Match messages with attachments'
                 },
                 size: {
-                  type: 'number',
-                  description: 'Size in bytes'
+                  type: 'object',
+                  properties: {
+                    operator: {
+                      type: 'string',
+                      enum: ['larger', 'smaller'],
+                      description: 'Size comparison operator'
+                    },
+                    size: {
+                      type: 'number',
+                      description: 'Size in bytes'
+                    }
+                  }
                 }
               }
-            }
-          }
-        },
-        actions: {
-          type: 'object',
-          properties: {
-            addLabel: {
-              type: 'boolean',
-              description: 'Apply the label'
             },
-            markImportant: {
-              type: 'boolean',
-              description: 'Mark as important'
-            },
-            markRead: {
-              type: 'boolean',
-              description: 'Mark as read'
-            },
-            archive: {
-              type: 'boolean',
-              description: 'Archive the message'
+            actions: {
+              type: 'object',
+              properties: {
+                addLabel: {
+                  type: 'boolean',
+                  description: 'Apply the label'
+                },
+                markImportant: {
+                  type: 'boolean',
+                  description: 'Mark as important'
+                },
+                markRead: {
+                  type: 'boolean',
+                  description: 'Mark as read'
+                },
+                archive: {
+                  type: 'boolean',
+                  description: 'Archive the message'
+                }
+              },
+              required: ['addLabel']
             }
           }
         }
       },
-      required: ['email', 'filterId']
-    }
-  },
-  {
-    name: 'delete_workspace_label_filter',
-    category: 'Gmail/Labels',
-    description: `Delete a Gmail label filter.
-    
-    IMPORTANT: Before deleting:
-    1. Verify account access with list_workspace_accounts
-    2. Confirm account if multiple exist
-    3. Verify filter exists
-    4. Confirm deletion intent
-    
-    Note: This action cannot be undone.`,
-    aliases: ['delete_filter', 'remove_filter'],
-    inputSchema: {
-      type: 'object',
-      properties: {
-        email: {
-          type: 'string',
-          description: 'Email address of the Gmail account'
-        },
-        filterId: {
-          type: 'string',
-          description: 'ID of filter to delete'
-        }
-      },
-      required: ['email', 'filterId']
+      required: ['email', 'action']
     }
   }
 ];

--- a/src/tools/server.ts
+++ b/src/tools/server.ts
@@ -28,15 +28,9 @@ import {
   handleCreateWorkspaceDraft,
   handleGetWorkspaceDrafts,
   handleSendWorkspaceDraft,
-  handleGetWorkspaceLabels,
-  handleCreateWorkspaceLabel,
-  handleUpdateWorkspaceLabel,
-  handleDeleteWorkspaceLabel,
-  handleModifyWorkspaceMessageLabels,
-  handleCreateWorkspaceLabelFilter,
-  handleGetWorkspaceLabelFilters,
-  handleUpdateWorkspaceLabelFilter,
-  handleDeleteWorkspaceLabelFilter
+  handleManageWorkspaceLabel,
+  handleManageWorkspaceLabelAssignment,
+  handleManageWorkspaceLabelFilter
 } from './gmail-handlers.js';
 
 import {
@@ -66,15 +60,10 @@ import {
   SendEmailArgs,
   CreateDraftArgs,
   SendDraftArgs,
-  CreateLabelArgs,
-  UpdateLabelArgs,
-  DeleteLabelArgs,
-  ModifyLabelsArgs,
   AuthenticateAccountArgs,
-  CreateLabelFilterArgs,
-  GetLabelFiltersArgs,
-  UpdateLabelFilterArgs,
-  DeleteLabelFilterArgs
+  ManageLabelParams,
+  ManageLabelAssignmentParams,
+  ManageLabelFilterParams
 } from './types.js';
 
 import {
@@ -84,14 +73,9 @@ import {
   assertSendEmailArgs,
   assertCreateDraftArgs,
   assertSendDraftArgs,
-  assertCreateLabelArgs,
-  assertUpdateLabelArgs,
-  assertDeleteLabelArgs,
-  assertModifyLabelsArgs,
-  assertCreateLabelFilterArgs,
-  assertGetLabelFiltersArgs,
-  assertUpdateLabelFilterArgs,
-  assertDeleteLabelFilterArgs
+  assertManageLabelParams,
+  assertManageLabelAssignmentParams,
+  assertManageLabelFilterParams
 } from './type-guards.js';
 
 export class GSuiteServer {
@@ -219,35 +203,15 @@ export class GSuiteServer {
             return await handleDeleteWorkspaceCalendarEvent(args);
 
           // Label Management
-          case 'get_workspace_labels':
-            assertBaseToolArguments(args);
-            return await handleGetWorkspaceLabels(args);
-          case 'create_workspace_label':
-            assertCreateLabelArgs(args);
-            return await handleCreateWorkspaceLabel(args as CreateLabelArgs);
-          case 'update_workspace_label':
-            assertUpdateLabelArgs(args);
-            return await handleUpdateWorkspaceLabel(args as UpdateLabelArgs);
-          case 'delete_workspace_label':
-            assertDeleteLabelArgs(args);
-            return await handleDeleteWorkspaceLabel(args as DeleteLabelArgs);
-          case 'modify_workspace_message_labels':
-            assertModifyLabelsArgs(args);
-            return await handleModifyWorkspaceMessageLabels(args as ModifyLabelsArgs);
-            
-          // Label Filter Operations
-          case 'create_workspace_label_filter':
-            assertCreateLabelFilterArgs(args);
-            return await handleCreateWorkspaceLabelFilter(args as CreateLabelFilterArgs);
-          case 'get_workspace_label_filters':
-            assertGetLabelFiltersArgs(args);
-            return await handleGetWorkspaceLabelFilters(args as GetLabelFiltersArgs);
-          case 'update_workspace_label_filter':
-            assertUpdateLabelFilterArgs(args);
-            return await handleUpdateWorkspaceLabelFilter(args as UpdateLabelFilterArgs);
-          case 'delete_workspace_label_filter':
-            assertDeleteLabelFilterArgs(args);
-            return await handleDeleteWorkspaceLabelFilter(args as DeleteLabelFilterArgs);
+          case 'manage_workspace_label':
+            assertManageLabelParams(args);
+            return await handleManageWorkspaceLabel(args);
+          case 'manage_workspace_label_assignment':
+            assertManageLabelAssignmentParams(args);
+            return await handleManageWorkspaceLabelAssignment(args);
+          case 'manage_workspace_label_filter':
+            assertManageLabelFilterParams(args);
+            return await handleManageWorkspaceLabelFilter(args);
 
           default:
             throw new Error(`Unknown tool: ${request.params.name}`);

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -256,3 +256,10 @@ export interface UpdateLabelFilterArgs extends BaseToolArguments {
 export interface DeleteLabelFilterArgs extends BaseToolArguments {
   filterId: string;
 }
+
+// Re-export consolidated label management types
+export {
+  ManageLabelParams,
+  ManageLabelAssignmentParams,
+  ManageLabelFilterParams
+} from '../modules/gmail/types.js';


### PR DESCRIPTION
Consolidates label tools into a unified interface with three main operations:

- manageLabel (CRUD operations)
- manageLabelAssignment (add/remove labels to messages)
- manageLabelFilter (manage label filters)

Changes:
- Old methods are now private implementation details
- Updated tests to use new interface
- Maintained full test coverage
- Improved code organization and maintainability