### PR TITLE
Structuring service level layout: Moving the DriveService implementat…

### DIFF
--- a/src/modules/drive/index.ts
+++ b/src/modules/drive/index.ts
@@ -1,20 +1,21 @@
+import { driveService } from '../../services/drive/index.js';
 import { DriveService } from './service.js';
-import { registerDriveScopes } from './scopes.js';
 import { DriveOperationResult } from './types.js';
 
 // Export types and service
 export * from './types.js';
 export * from './scopes.js';
+export { DriveService };
 
-// Singleton instance
-let driveService: DriveService | undefined;
+// Get singleton instance
+let serviceInstance: DriveService | undefined;
 
 export async function getDriveService(): Promise<DriveService> {
-  if (!driveService) {
-    driveService = new DriveService();
-    await driveService.ensureInitialized();
+  if (!serviceInstance) {
+    serviceInstance = driveService;
+    await serviceInstance.ensureInitialized();
   }
-  return driveService;
+  return serviceInstance;
 }
 
 // Initialize module

--- a/src/modules/drive/service.ts
+++ b/src/modules/drive/service.ts
@@ -1,13 +1,13 @@
-import { drive_v3, google } from 'googleapis';
-import { GaxiosResponse } from 'gaxios';
+import { google } from 'googleapis';
 import { BaseGoogleService } from '../../services/base/BaseGoogleService.js';
 import { DriveOperationResult, FileDownloadOptions, FileListOptions, FileSearchOptions, FileUploadOptions, PermissionOptions } from './types.js';
 import { Readable } from 'stream';
 import { DRIVE_SCOPES } from './scopes.js';
 import { workspaceManager } from '../../utils/workspace.js';
 import fs from 'fs/promises';
+import { GaxiosResponse } from 'gaxios';
 
-export class DriveService extends BaseGoogleService<drive_v3.Drive> {
+export class DriveService extends BaseGoogleService<ReturnType<typeof google.drive>> {
   private initialized = false;
 
   constructor() {

--- a/src/services/drive/index.ts
+++ b/src/services/drive/index.ts
@@ -1,0 +1,7 @@
+import { DriveService } from '../../modules/drive/service.js';
+
+// Create singleton instance
+const driveService = new DriveService();
+
+// Export singleton instance
+export { driveService };


### PR DESCRIPTION
Moving the DriveService implementation to modules/drive/service.ts where it belongs
Simplifying services/drive/index.ts to only create and export the singleton instance
Updating modules/drive/index.ts to properly manage the singleton instance

Updating modules/drive/index.ts to properly manage the singleton instanc
 The architecture now follows the established patterns:

Core service implementation in modules/[service]/service.ts
Singleton instance management in services/[service]/index.ts
Module initialization and exports in modules/[service]/index.ts
