### PR TITLE
feat: Queue detail modes and per-operation refs

### DIFF
--- a/src/__tests__/server/queue.test.ts
+++ b/src/__tests__/server/queue.test.ts
@@ -154,4 +154,77 @@ describe('handleQueue', () => {
     expect(result.text).toContain('## Queue Results');
     expect(result.text).toContain('1/1 succeeded');
   });
+
+  it('exposes per-operation refs in results array', async () => {
+    const result = await handleQueue({
+      operations: [
+        { tool: 'tool_a', args: { input: 'hello' } },
+        { tool: 'tool_b', args: { ref: 'world' } },
+      ],
+    }, handlers);
+
+    const opResults = result.refs.results as Array<Record<string, unknown>>;
+    expect(opResults).toHaveLength(2);
+    expect(opResults[0]).toMatchObject({ tool: 'tool_a', status: 'success', id: 'result-a' });
+    expect(opResults[1]).toMatchObject({ tool: 'tool_b', status: 'success', id: 'result-b' });
+  });
+
+  it('includes error status in per-operation results', async () => {
+    const result = await handleQueue({
+      operations: [
+        { tool: 'tool_fail', args: {}, onError: 'continue' },
+        { tool: 'tool_a', args: {} },
+      ],
+    }, handlers);
+
+    const opResults = result.refs.results as Array<Record<string, unknown>>;
+    expect(opResults[0]).toMatchObject({ tool: 'tool_fail', status: 'error' });
+    expect(opResults[1]).toMatchObject({ tool: 'tool_a', status: 'success' });
+  });
+
+  describe('detail: full', () => {
+    it('includes complete operation output below summary lines', async () => {
+      const result = await handleQueue({
+        operations: [
+          { tool: 'tool_a', args: { input: 'hello' } },
+          { tool: 'tool_b', args: { ref: 'world' } },
+        ],
+        detail: 'full',
+      }, handlers);
+
+      expect(result.text).toContain('## Queue Results');
+      // Full output should appear
+      expect(result.text).toContain('Result A: hello');
+      expect(result.text).toContain('Result B: ref=world');
+    });
+
+    it('does not include output for failed operations', async () => {
+      const result = await handleQueue({
+        operations: [
+          { tool: 'tool_a', args: {} },
+          { tool: 'tool_fail', args: {}, onError: 'continue' },
+        ],
+        detail: 'full',
+      }, handlers);
+
+      expect(result.text).toContain('Result A: default');
+      expect(result.text).toContain('✗ tool_fail');
+      // Error message appears in summary line, not as full output
+    });
+  });
+
+  describe('detail: summary (default)', () => {
+    it('only shows one-liner per operation, not full output blocks', async () => {
+      const result = await handleQueue({
+        operations: [
+          { tool: 'tool_a', args: { input: 'hello' } },
+        ],
+      }, handlers);
+
+      // Summary line contains the first content line
+      expect(result.text).toContain('✓ tool_a — Result A: hello');
+      // No blank-line-separated full output block
+      expect(result.text).not.toMatch(/\n\nResult A: hello\n/);
+    });
+  });
 });

--- a/src/server/queue.ts
+++ b/src/server/queue.ts
@@ -41,6 +41,8 @@ export async function handleQueue(
     throw new Error('operations array is required and must not be empty');
   }
 
+  const detail = (params.detail as string) ?? 'summary';
+
   const results: OperationResult[] = [];
   let bailedAt = -1;
   let lastSuccessText = '';
@@ -88,7 +90,7 @@ export async function handleQueue(
   const failed = results.filter(r => r.status === 'error').length;
   const skipped = results.filter(r => r.status === 'skipped').length;
 
-  // Build summary markdown
+  // Build markdown output
   const lines: string[] = [
     `## Queue Results (${succeeded}/${results.length} succeeded)`,
     '',
@@ -96,25 +98,32 @@ export async function handleQueue(
 
   for (const r of results) {
     const icon = r.status === 'success' ? '✓' : r.status === 'error' ? '✗' : '○';
-    const summary = r.status === 'error' ? r.error
-                  : r.text ? firstLine(r.text)
-                  : r.status;
-    lines.push(`${icon} ${r.tool} — ${summary}`);
+    const headline = r.status === 'error' ? r.error
+                   : r.text ? firstLine(r.text)
+                   : r.status;
+    lines.push(`${icon} ${r.tool} — ${headline}`);
+
+    // Full mode: include complete operation output below the summary line
+    if (detail === 'full' && r.status === 'success' && r.text) {
+      lines.push('', r.text, '');
+    }
   }
 
   // Append consolidated next-steps from last successful operation
   const nextStepsSuffix = extractNextSteps(lastSuccessText);
   const text = lines.join('\n') + nextStepsSuffix;
 
-  // Queue-level refs are aggregate counters only.
-  // Per-operation refs are available during execution for $N.field resolution
-  // but not exposed in the final response. Exposing them (e.g. as results[N].refs)
-  // is scoped for the queue-enhancement workstream.
   const refs: Record<string, unknown> = {
     total: results.length,
     succeeded,
     failed,
     skipped,
+    // Per-operation refs keyed by index for downstream access
+    results: results.map(r => ({
+      tool: r.tool,
+      status: r.status,
+      ...(r.refs ?? {}),
+    })),
   };
 
   return { text, refs };

--- a/src/server/tools.ts
+++ b/src/server/tools.ts
@@ -146,6 +146,11 @@ export const toolSchemas: ToolSchema[] = [
           maxItems: 10,
           description: 'Operations to execute sequentially',
         },
+        detail: {
+          type: 'string',
+          enum: ['summary', 'full'],
+          description: 'summary: one-line status per operation (default) | full: include complete output from each operation',
+        },
       },
       required: ['operations'],
       additionalProperties: false,


### PR DESCRIPTION
## Summary

- **`detail` parameter** on `queue_operations`: `summary` (default) shows one-liner per operation; `full` includes complete handler output below each summary line
- **Per-operation refs** exposed in `refs.results[]` — each entry has `tool`, `status`, plus the handler's refs (e.g. `messageId`, `fileId`, `count`)

Completes workstream 2 from `.claude/plan-response-quality.md`.

## Example

**Summary mode (default):**
```markdown
## Queue Results (2/2 succeeded)

✓ manage_email search — msg-1 | alice@test.com | Hello | Mar 14
✓ manage_email read — **From:** alice@test.com
```

**Full mode:**
```markdown
## Queue Results (2/2 succeeded)

✓ manage_email search — msg-1 | alice@test.com | Hello | Mar 14

## Messages (1)

msg-1 | alice@test.com | Hello | Mar 14

✓ manage_email read — **From:** alice@test.com

## Hello
...full email detail...
```

## Test plan

- [x] `make test` — 181 unit tests pass
- [x] `make test-all` — 191 total (unit + integration)
- [x] Summary mode (default) unchanged from previous behavior
- [x] Full mode includes complete output blocks
- [x] Per-operation refs exposed with tool, status, and handler refs