### PR TITLE
fix: Hydrate email search results with From/Subject/Date

### DIFF
--- a/src/__tests__/server/handlers/__mocks__/executor.ts
+++ b/src/__tests__/server/handlers/__mocks__/executor.ts
@@ -34,6 +34,22 @@ export const gmailMessageListResponse = {
   ],
 };
 
+// Metadata responses for hydration (format: metadata)
+export function gmailMetadataResponse(id: string, from: string, subject: string, date: string) {
+  return {
+    id,
+    threadId: `thread-${id}`,
+    snippet: `Preview of ${subject}`,
+    payload: {
+      headers: [
+        { name: 'From', value: from },
+        { name: 'Subject', value: subject },
+        { name: 'Date', value: date },
+      ],
+    },
+  };
+}
+
 export const gmailMessageDetailResponse = {
   id: 'msg-1',
   threadId: 'thread-1',

--- a/src/__tests__/server/handlers/email.test.ts
+++ b/src/__tests__/server/handlers/email.test.ts
@@ -1,6 +1,7 @@
 import {
   mockExecute, mockGwsResponse,
   gmailTriageResponse, gmailMessageDetailResponse, gmailSendResponse, gmailMessageListResponse,
+  gmailMetadataResponse,
 } from './__mocks__/executor.js';
 import { handleEmail } from '../../../server/handlers/email.js';
 
@@ -29,23 +30,50 @@ describe('handleEmail', () => {
   });
 
   describe('search', () => {
-    it('passes query to gws', async () => {
-      mockExecute.mockResolvedValue(mockGwsResponse(gmailMessageListResponse));
-      await handleEmail({ operation: 'search', email: 'user@test.com', query: 'from:alice' });
+    it('passes query to gws and hydrates results with metadata', async () => {
+      // First call: messages.list returns IDs only
+      // Subsequent calls: messages.get with format=metadata for each ID
+      mockExecute
+        .mockResolvedValueOnce(mockGwsResponse(gmailMessageListResponse))
+        .mockResolvedValueOnce(mockGwsResponse(gmailMetadataResponse('msg-1', 'alice@test.com', 'Hello', 'Mon, 10 Mar 2026')))
+        .mockResolvedValueOnce(mockGwsResponse(gmailMetadataResponse('msg-2', 'bob@test.com', 'Meeting', 'Mon, 10 Mar 2026')));
 
-      const args = mockExecute.mock.calls[0][0];
-      const params = JSON.parse(args[args.indexOf('--params') + 1]);
-      expect(params.q).toBe('from:alice');
-      expect(params.userId).toBe('me');
+      const result = await handleEmail({ operation: 'search', email: 'user@test.com', query: 'from:alice' });
+
+      // Verify list call
+      const listArgs = mockExecute.mock.calls[0][0];
+      const listParams = JSON.parse(listArgs[listArgs.indexOf('--params') + 1]);
+      expect(listParams.q).toBe('from:alice');
+      expect(listParams.userId).toBe('me');
+
+      // Verify hydration calls used metadata format
+      const getArgs = mockExecute.mock.calls[1][0];
+      const getParams = JSON.parse(getArgs[getArgs.indexOf('--params') + 1]);
+      expect(getParams.format).toBe('metadata');
+
+      // Verify formatted output has actual content
+      expect(result.text).toContain('alice@test.com');
+      expect(result.text).toContain('Hello');
+      expect(result.refs.count).toBe(2);
     });
 
     it('clamps maxResults to 50', async () => {
-      mockExecute.mockResolvedValue(mockGwsResponse(gmailMessageListResponse));
+      mockExecute
+        .mockResolvedValueOnce(mockGwsResponse({ messages: [] }));
       await handleEmail({ operation: 'search', email: 'user@test.com', maxResults: 200 });
 
       const args = mockExecute.mock.calls[0][0];
       const params = JSON.parse(args[args.indexOf('--params') + 1]);
       expect(params.maxResults).toBe(50);
+    });
+
+    it('handles empty search results without hydration calls', async () => {
+      mockExecute.mockResolvedValueOnce(mockGwsResponse({ messages: [] }));
+
+      const result = await handleEmail({ operation: 'search', email: 'user@test.com', query: 'nonexistent' });
+
+      expect(mockExecute).toHaveBeenCalledTimes(1); // only the list call
+      expect(result.text).toContain('No messages found');
     });
   });
 

--- a/src/server/handlers/email.ts
+++ b/src/server/handlers/email.ts
@@ -4,6 +4,46 @@ import { nextSteps } from '../formatting/next-steps.js';
 import { requireEmail, requireString, clamp } from './validate.js';
 import type { HandlerResponse } from '../handler.js';
 
+/**
+ * Gmail messages.list only returns IDs. This hydrates each message
+ * with metadata (From, Subject, Date, snippet) via parallel gets.
+ */
+async function hydrateMessages(
+  messageIds: Array<{ id: string }>,
+  account: string,
+): Promise<Record<string, unknown>[]> {
+  const hydrated = await Promise.all(
+    messageIds.map(async (msg) => {
+      try {
+        const result = await execute([
+          'gmail', 'users', 'messages', 'get',
+          '--params', JSON.stringify({
+            userId: 'me',
+            id: msg.id,
+            format: 'metadata',
+            metadataHeaders: ['From', 'Subject', 'Date'],
+          }),
+        ], { account });
+        const data = result.data as Record<string, unknown>;
+        const headers = ((data.payload as Record<string, unknown>)?.headers ?? []) as Array<{ name: string; value: string }>;
+        const getHeader = (name: string) => headers.find(h => h.name.toLowerCase() === name.toLowerCase())?.value;
+        return {
+          id: data.id,
+          threadId: data.threadId,
+          from: getHeader('from'),
+          subject: getHeader('subject'),
+          date: getHeader('date'),
+          snippet: data.snippet,
+        };
+      } catch {
+        // If individual hydration fails, return the bare ID
+        return { id: msg.id };
+      }
+    }),
+  );
+  return hydrated;
+}
+
 export async function handleEmail(params: Record<string, unknown>): Promise<HandlerResponse> {
   const operation = params.operation as string;
   const email = requireEmail(params);
@@ -18,7 +58,12 @@ export async function handleEmail(params: Record<string, unknown>): Promise<Hand
           maxResults: clamp(params.maxResults, 10, 50),
         }),
       ], { account: email });
-      const formatted = formatEmailList(result.data);
+
+      // messages.list only returns IDs — hydrate with metadata
+      const raw = result.data as Record<string, unknown>;
+      const ids = (raw?.messages ?? []) as Array<{ id: string }>;
+      const messages = ids.length > 0 ? await hydrateMessages(ids, email) : [];
+      const formatted = formatEmailList({ messages });
       return {
         text: formatted.text + nextSteps('email', 'search', { email }),
         refs: formatted.refs,


### PR DESCRIPTION
## Summary

Gmail `messages.list` only returns message IDs — no metadata. Email search results were showing empty From, Subject, and Date fields.

Now search hydrates each message ID with a parallel `messages.get` call using `format: metadata` to fetch From, Subject, Date, and snippet. Triage (`+triage` helper) was already returning full metadata and is unaffected.

## Test plan

- [x] `make test` — 195 unit tests pass
- [x] `make test-integration` — 10 integration tests pass
- [x] New test: search hydration verifies metadata format and populated fields
- [x] New test: empty search results skip hydration (1 API call, not N+1)