### PR TITLE
feat: publishing and packaging pipeline

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,27 @@
+name: Publish to npm
+
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: npm ci
+      - run: npm run build
+      - run: npm test
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,8 @@ logs/
 coverage/
 commit-message.txt
 discovered-manifest.yaml
+
+# MCPB build artifacts
+*.mcpb
+mcpb/server/
+mcpb/bin/

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,24 @@
 .DEFAULT_GOAL := help
 .PHONY: help test test-all test-unit test-integration build clean typecheck \
-        manifest-discover manifest-diff manifest-lint
+        manifest-discover manifest-diff manifest-lint \
+        mcpb mcpb-all version-sync publish-all \
+        release-patch release-minor release-major check
+
+VERSION = $(shell node -p 'require("./package.json").version')
+GWS_VERSION = $(shell node -p 'require("@googleworkspace/cli/package.json").version')
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
 		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}'
+
+# --- Build & Test ---
 
 test: test-unit ## Run unit tests (default)
 
 test-all: test-unit test-integration ## Run unit + integration tests
 
 test-unit: ## Run unit tests (mocked, fast, no network)
-	npx jest --config jest.config.cjs --testPathPattern='src/__tests__/(executor|accounts|server)' --runInBand
+	npx jest --config jest.config.cjs --testPathPattern='src/__tests__/(executor|accounts|server|factory)' --runInBand
 
 test-integration: ## Run integration tests (ACCOUNT=email optional)
 	$(if $(ACCOUNT),TEST_ACCOUNT=$(ACCOUNT)) npx jest --config jest.config.cjs --testPathPattern='src/__tests__/integration' --runInBand
@@ -20,10 +27,12 @@ typecheck: ## Type-check without emitting
 	npx tsc --noEmit --skipLibCheck
 
 build: ## Compile TypeScript to build/
-	npx tsc --skipLibCheck
+	npx tsc --skipLibCheck && cp src/factory/manifest.yaml build/factory/
+
+check: typecheck test build ## Lint, test, and build (CI gate)
 
 clean: ## Remove build artifacts
-	rm -rf build/
+	rm -rf build/ mcpb/server mcpb/bin *.mcpb
 
 # --- Manifest management ---
 
@@ -56,3 +65,88 @@ manifest-lint: ## Validate manifest YAML syntax and structure
 		} \
 		console.log('  Total: ' + ops + ' operations across ' + Object.keys(m.services).length + ' services'); \
 	"
+
+# --- MCPB packaging ---
+
+mcpb: build ## Build .mcpb for current platform (PLATFORM=linux-x64 etc.)
+	$(eval PLATFORM ?= $(shell node -e "const os=require('os'); const a=os.arch()==='arm64'?'arm64':'x64'; const p=os.platform()==='darwin'?'darwin':os.platform()==='win32'?'windows':'linux'; console.log(p+'-'+a)"))
+	@echo "Building mcpb v$(VERSION) with gws $(GWS_VERSION) for $(PLATFORM)"
+	rm -rf mcpb/server mcpb/bin
+	mkdir -p mcpb/server
+	cp -r build/* mcpb/server/
+	cp src/factory/manifest.yaml mcpb/server/factory/
+	cp package.json mcpb/server/package.json
+	cd mcpb/server && npm install --production --ignore-scripts --silent
+	rm -f mcpb/server/package.json mcpb/server/package-lock.json
+	./scripts/download-gws-binary.sh $(PLATFORM) $(GWS_VERSION)
+	mcpb pack mcpb google-workspace-mcp-$(PLATFORM).mcpb
+	@echo ""
+	@echo "Built: google-workspace-mcp-$(PLATFORM).mcpb ($$(du -h google-workspace-mcp-$(PLATFORM).mcpb | cut -f1))"
+
+mcpb-all: build ## Build .mcpb for all platforms
+	@for plat in darwin-arm64 darwin-x64 linux-arm64 linux-x64 windows-x64; do \
+		echo ""; \
+		echo "=== $$plat ==="; \
+		$(MAKE) mcpb PLATFORM=$$plat; \
+	done
+	@echo ""
+	@echo "All platform bundles built:"
+	@ls -lh google-workspace-mcp-*.mcpb 2>/dev/null
+
+# --- Version & Release ---
+
+version-sync: ## Sync version from package.json → server.json + mcpb/manifest.json
+	@echo "Syncing version $(VERSION) to server.json and mcpb/manifest.json"
+	@node scripts/version-sync.cjs
+
+release-patch: check ## Bump patch, sync, commit, tag, push
+	@echo "Current version: $(VERSION)"
+	npm version patch --no-git-tag-version
+	$(MAKE) version-sync
+	$(MAKE) _release-commit
+
+release-minor: check ## Bump minor, sync, commit, tag, push
+	@echo "Current version: $(VERSION)"
+	npm version minor --no-git-tag-version
+	$(MAKE) version-sync
+	$(MAKE) _release-commit
+
+release-major: check ## Bump major, sync, commit, tag, push
+	@echo "Current version: $(VERSION)"
+	npm version major --no-git-tag-version
+	$(MAKE) version-sync
+	$(MAKE) _release-commit
+
+_release-commit:
+	$(eval NEW_VERSION := $(shell node -p 'require("./package.json").version'))
+	git add package.json package-lock.json server.json mcpb/manifest.json
+	git commit -m "chore: release v$(NEW_VERSION)"
+	git tag -a "v$(NEW_VERSION)" -m "v$(NEW_VERSION)"
+	git push && git push --tags
+	@echo ""
+	@echo "Released v$(NEW_VERSION). Run 'make publish-all' to publish everywhere."
+
+# --- Publishing ---
+
+publish-all: mcpb-all ## Publish to npm, MCP Registry, GitHub Release
+	@echo ""
+	@echo "Publishing v$(VERSION) to all channels."
+	@echo "  1. npm (requires OTP)"
+	@echo "  2. MCP Registry (requires GitHub auth)"
+	@echo "  3. GitHub Release (with all .mcpb bundles)"
+	@echo ""
+	@read -p "Continue? [y/N] " confirm && [ "$$confirm" = "y" ] || (echo "Aborted." && exit 1)
+	@echo ""
+	@echo "── npm ──"
+	@read -p "npm OTP: " otp && npm publish --access public --otp "$$otp"
+	@echo ""
+	@echo "── MCP Registry ──"
+	mcp-publisher login github
+	mcp-publisher publish server.json
+	@echo ""
+	@echo "── GitHub Release ──"
+	@read -p "Release notes (one line, or empty for default): " notes; \
+	if [ -z "$$notes" ]; then notes="Release v$(VERSION)"; fi; \
+	gh release create "v$(VERSION)" --title "v$(VERSION)" --notes "$$notes" google-workspace-mcp-*.mcpb
+	@echo ""
+	@echo "v$(VERSION) published to all channels."

--- a/mcpb/.mcpbignore
+++ b/mcpb/.mcpbignore
@@ -1,0 +1,16 @@
+# Exclude dev artifacts from .mcpb bundle
+*.map
+*.test.js
+*.test.d.ts
+__tests__/
+.github/
+docs/
+scripts/
+src/
+*.md
+.eslintrc*
+tsconfig.json
+jest.config*
+Makefile
+discovered-manifest.yaml
+.claude/

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -1,0 +1,87 @@
+{
+  "manifest_version": "0.3",
+  "name": "google-workspace-mcp",
+  "display_name": "Google Workspace",
+  "version": "2.0.0-alpha.1",
+  "description": "Give AI agents access to Gmail, Calendar, Drive, and more — with multi-account support and manifest-driven API coverage",
+  "author": {
+    "name": "aaronsb",
+    "url": "https://github.com/aaronsb"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aaronsb/google-workspace-mcp.git"
+  },
+  "homepage": "https://github.com/aaronsb/google-workspace-mcp#readme",
+  "support": "https://github.com/aaronsb/google-workspace-mcp/issues",
+  "license": "MIT",
+  "keywords": [
+    "google-workspace",
+    "gmail",
+    "calendar",
+    "drive",
+    "email",
+    "oauth",
+    "multi-account"
+  ],
+  "server": {
+    "type": "node",
+    "entry_point": "server/index.js",
+    "mcp_config": {
+      "command": "node",
+      "args": [
+        "${__dirname}/server/index.js"
+      ],
+      "env": {
+        "GOOGLE_CLIENT_ID": "${user_config.google_client_id}",
+        "GOOGLE_CLIENT_SECRET": "${user_config.google_client_secret}",
+        "GWS_BINARY_PATH": "${__dirname}/bin/gws"
+      }
+    }
+  },
+  "tools": [
+    {
+      "name": "manage_accounts",
+      "description": "Manage Google Workspace account lifecycle: list, authenticate, check status, refresh credentials, update scopes"
+    },
+    {
+      "name": "manage_email",
+      "description": "Search, read, send, forward, trash, label, and manage Gmail messages and threads"
+    },
+    {
+      "name": "manage_calendar",
+      "description": "List events, view agenda, create, update, delete events, check availability"
+    },
+    {
+      "name": "manage_drive",
+      "description": "Search, upload, download, copy, delete, export, and share Google Drive files"
+    },
+    {
+      "name": "queue_operations",
+      "description": "Chain multiple operations sequentially with result references between steps"
+    }
+  ],
+  "user_config": {
+    "google_client_id": {
+      "type": "string",
+      "title": "Google OAuth Client ID",
+      "description": "Create at https://console.cloud.google.com/apis/credentials — OAuth 2.0 Client ID (Desktop application)",
+      "sensitive": true,
+      "required": true
+    },
+    "google_client_secret": {
+      "type": "string",
+      "title": "Google OAuth Client Secret",
+      "description": "The client secret from your OAuth 2.0 credentials",
+      "sensitive": true,
+      "required": true
+    }
+  },
+  "compatibility": {
+    "platforms": [
+      "darwin",
+      "win32",
+      "linux"
+    ]
+  }
+}

--- a/scripts/download-gws-binary.sh
+++ b/scripts/download-gws-binary.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# download-gws-binary.sh — Download gws binary for a target platform.
+#
+# Fetches the pre-built gws binary from Google's GitHub releases
+# and places it in mcpb/bin/ for bundling.
+#
+# Usage:
+#   ./scripts/download-gws-binary.sh <platform> [version]
+#
+# Platforms: darwin-arm64, darwin-x64, linux-arm64, linux-x64, windows-x64
+# Version defaults to the version in node_modules/@googleworkspace/cli
+
+set -euo pipefail
+
+PLATFORM="${1:-}"
+VERSION="${2:-$(node -p 'require("@googleworkspace/cli/package.json").version')}"
+BASE_URL="https://github.com/googleworkspace/cli/releases/download/v${VERSION}"
+OUT_DIR="mcpb/bin"
+
+if [[ -z "$PLATFORM" ]]; then
+  echo "Usage: $0 <platform> [version]"
+  echo "Platforms: darwin-arm64, darwin-x64, linux-arm64, linux-x64, windows-x64, all"
+  exit 1
+fi
+
+download_binary() {
+  local artifact="$1"
+  local binary_name="$2"
+  local url="${BASE_URL}/${artifact}"
+
+  echo "  Downloading: ${url}"
+  mkdir -p "${OUT_DIR}"
+
+  if [[ "$artifact" == *.zip ]]; then
+    local tmpzip
+    tmpzip=$(mktemp)
+    curl -sL "$url" -o "$tmpzip"
+    unzip -qo "$tmpzip" -d "${OUT_DIR}"
+    rm -f "$tmpzip"
+  else
+    curl -sL "$url" | tar xz -C "${OUT_DIR}"
+  fi
+
+  # Ensure binary is executable
+  chmod +x "${OUT_DIR}/${binary_name}" 2>/dev/null || true
+  echo "  Installed: ${OUT_DIR}/${binary_name}"
+}
+
+case "$PLATFORM" in
+  darwin-arm64)
+    echo "Fetching gws ${VERSION} for macOS ARM64..."
+    download_binary "gws-aarch64-apple-darwin.tar.gz" "gws"
+    ;;
+  darwin-x64)
+    echo "Fetching gws ${VERSION} for macOS x64..."
+    download_binary "gws-x86_64-apple-darwin.tar.gz" "gws"
+    ;;
+  linux-arm64)
+    echo "Fetching gws ${VERSION} for Linux ARM64..."
+    download_binary "gws-aarch64-unknown-linux-gnu.tar.gz" "gws"
+    ;;
+  linux-x64)
+    echo "Fetching gws ${VERSION} for Linux x64..."
+    download_binary "gws-x86_64-unknown-linux-gnu.tar.gz" "gws"
+    ;;
+  windows-x64)
+    echo "Fetching gws ${VERSION} for Windows x64..."
+    download_binary "gws-x86_64-pc-windows-msvc.zip" "gws.exe"
+    ;;
+  all)
+    # Build all platform bundles — creates one mcpb per platform
+    for plat in darwin-arm64 darwin-x64 linux-arm64 linux-x64 windows-x64; do
+      echo ""
+      echo "=== ${plat} ==="
+      rm -rf "${OUT_DIR}"
+      "$0" "$plat" "$VERSION"
+    done
+    echo ""
+    echo "All platforms downloaded."
+    ;;
+  *)
+    echo "Unknown platform: $PLATFORM"
+    echo "Valid: darwin-arm64, darwin-x64, linux-arm64, linux-x64, windows-x64, all"
+    exit 1
+    ;;
+esac

--- a/scripts/version-sync.cjs
+++ b/scripts/version-sync.cjs
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+// Sync version from package.json → server.json + mcpb/manifest.json
+const fs = require('fs');
+const version = require('../package.json').version;
+
+for (const file of ['server.json', 'mcpb/manifest.json']) {
+  if (!fs.existsSync(file)) continue;
+  const data = JSON.parse(fs.readFileSync(file, 'utf-8'));
+  data.version = version;
+  if (data.packages) data.packages.forEach(p => p.version = version);
+  fs.writeFileSync(file, JSON.stringify(data, null, 2) + '\n');
+  console.log(`  ${file} → ${version}`);
+}

--- a/server.json
+++ b/server.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.aaronsb/google-workspace",
+  "version": "2.0.0-alpha.1",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@aaronsb/google-workspace-mcp",
+      "version": "2.0.0-alpha.1",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "GOOGLE_CLIENT_ID",
+          "description": "Google OAuth 2.0 Client ID (Desktop application)",
+          "required": true,
+          "sensitive": true
+        },
+        {
+          "name": "GOOGLE_CLIENT_SECRET",
+          "description": "Google OAuth 2.0 Client Secret",
+          "required": true,
+          "sensitive": true
+        }
+      ]
+    }
+  ]
+}

--- a/src/executor/gws.ts
+++ b/src/executor/gws.ts
@@ -17,13 +17,22 @@ export interface GwsOptions {
 
 const DEFAULT_TIMEOUT = 30_000;
 
-// Resolve gws binary from node_modules relative to this package.
-// Walks up from this file's compiled location to find the project root.
-// Exported for testing.
+/**
+ * Resolve gws binary location.
+ *
+ * Priority:
+ * 1. GWS_BINARY_PATH env var (set by mcpb manifest for bundled binary)
+ * 2. node_modules/.bin/gws (npm dependency)
+ */
+export function resolveGwsBinary(): string {
+  if (process.env.GWS_BINARY_PATH) {
+    return process.env.GWS_BINARY_PATH;
+  }
+  return path.join(process.cwd(), 'node_modules', '.bin', 'gws');
+}
+
+// Kept for backward compatibility with tests
 export function resolvePackageBinDir(): string {
-  // In production (ESM), __dirname isn't available but we can derive from
-  // the build output structure: build/executor/gws.js → ../../node_modules/.bin
-  // In development, process.cwd() is the project root.
   return path.join(process.cwd(), 'node_modules', '.bin');
 }
 
@@ -51,14 +60,17 @@ export async function execute(args: string[], options: GwsOptions = {}): Promise
 
   const fullArgs = [...args, '--format', format];
 
-  // Prepend package-local bin dir to PATH
+  // Resolve gws binary — bundled (mcpb) or npm dependency
+  const gwsBinary = resolveGwsBinary();
+
+  // Still prepend bin dir to PATH for non-bundled case
   env.PATH = `${resolvePackageBinDir()}:${env.PATH || ''}`;
 
   return new Promise((resolve, reject) => {
     let settled = false;
     const settle = (fn: () => void) => { if (!settled) { settled = true; fn(); } };
 
-    const proc = spawn('gws', fullArgs, { env, stdio: ['ignore', 'pipe', 'pipe'] });
+    const proc = spawn(gwsBinary, fullArgs, { env, stdio: ['ignore', 'pipe', 'pipe'] });
 
     let stdout = '';
     let stderr = '';


### PR DESCRIPTION
## Summary

- **MCPB packaging** with platform-specific gws binaries — downloads Google's pre-built Rust binaries and bundles them alongside the JS server for a zero-dependency plugin experience
- **npm publishing** with OTP flow and automated CI on git tags
- **MCP registry** publishing via mcp-publisher + server.json
- **Version sync** keeps package.json, server.json, and mcpb/manifest.json aligned
- **GWS_BINARY_PATH** env var lets the mcpb bundle use its embedded binary instead of node_modules

### Platforms

| Platform | gws Binary | Bundle Size |
|----------|-----------|-------------|
| macOS ARM64 | `gws-aarch64-apple-darwin` | ~7MB |
| macOS x64 | `gws-x86_64-apple-darwin` | ~7MB |
| Linux ARM64 | `gws-aarch64-unknown-linux-gnu` | ~7MB |
| Linux x64 | `gws-x86_64-unknown-linux-gnu` | ~7MB |
| Windows x64 | `gws-x86_64-pc-windows-msvc` | ~7MB |

### Make targets

```
make mcpb              # Build for current platform
make mcpb-all          # Build all 5 platform bundles
make release-patch     # Bump version, sync, tag, push
make publish-all       # npm + MCP registry + GitHub release
make check             # CI gate (typecheck + test + build)
```

### Release workflow

```
make release-patch     # 1. bump, sync, commit, tag, push
make publish-all       # 2. npm (OTP) + mcp-publisher + gh release with .mcpb
```

## Test plan

- [x] 227 unit tests pass
- [x] Type-check clean
- [x] `make mcpb` builds successfully for linux-x64 (7.3MB)
- [x] gws binary downloads from Google's GitHub releases
- [x] mcpb manifest validates (`mcpb pack` reports schema pass)
- [x] `make help` shows all targets correctly
- [ ] Cross-platform mcpb builds (darwin, windows) — needs CI or cross-platform runner