### PR TITLE
fix: accounts status returns correct account + startup warmup

### DIFF
--- a/src/accounts/auth.ts
+++ b/src/accounts/auth.ts
@@ -1,7 +1,7 @@
 import { spawn, execFile } from 'node:child_process';
 import { platform } from 'node:os';
 import { execute } from '../executor/gws.js';
-import { exportAndSaveCredential } from './credentials.js';
+import { exportAndSaveCredential, readCredential, hasCredential } from './credentials.js';
 
 export interface AuthResult {
   status: 'success' | 'error';
@@ -18,15 +18,61 @@ export interface AccountStatus {
   hasRefreshToken: boolean;
 }
 
+/**
+ * Check account status by reading our credential file and validating
+ * the token via a lightweight Gmail API call.
+ *
+ * Note: `gws auth status` is single-account (keyring-based) and ignores
+ * GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE. We bypass it entirely and
+ * validate against our own per-account credential files.
+ */
 export async function checkAccountStatus(email: string): Promise<AccountStatus> {
-  const result = await execute(['auth', 'status'], { account: email });
-  const data = result.data as Record<string, unknown>;
+  const hasCred = await hasCredential(email);
+  if (!hasCred) {
+    return {
+      email,
+      tokenValid: false,
+      scopes: [],
+      scopeCount: 0,
+      hasRefreshToken: false,
+    };
+  }
+
+  const cred = await readCredential(email);
+  const hasRefreshToken = Boolean(cred.refresh_token);
+
+  // Validate the token with a lightweight API call using this account's credential
+  let tokenValid = false;
+  try {
+    await execute(
+      ['gmail', 'users', 'getProfile', '--params', JSON.stringify({ userId: 'me' })],
+      { account: email },
+    );
+    tokenValid = true;
+  } catch {
+    tokenValid = false;
+  }
+
+  // Get scopes from gws auth status. These are the scopes granted to the
+  // OAuth app, not per-account — gws is single-account so we can't get
+  // per-account scopes. But they're useful for showing what services are enabled.
+  let scopes: string[] = [];
+  if (tokenValid) {
+    try {
+      const statusResult = await execute(['auth', 'status']);
+      const statusData = statusResult.data as Record<string, unknown>;
+      scopes = Array.isArray(statusData.scopes) ? statusData.scopes as string[] : [];
+    } catch {
+      // Non-critical — scopes are informational
+    }
+  }
+
   return {
-    email: (data.user as string) ?? email,
-    tokenValid: Boolean(data.token_valid),
-    scopes: Array.isArray(data.scopes) ? data.scopes as string[] : [],
-    scopeCount: Number(data.scope_count ?? 0),
-    hasRefreshToken: Boolean(data.has_refresh_token),
+    email,
+    tokenValid,
+    scopes,
+    scopeCount: scopes.length,
+    hasRefreshToken,
   };
 }
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -76,8 +76,43 @@ export function createServer(): Server {
   return server;
 }
 
+/** Warm up credentials on startup — validates accounts and refreshes tokens. */
+async function warmupAccounts(): Promise<void> {
+  try {
+    const { listAccounts } = await import('../accounts/registry.js');
+    const accounts = await listAccounts();
+    if (accounts.length === 0) {
+      log('startup: no accounts configured');
+      return;
+    }
+    log(`startup: warming ${accounts.length} account(s)`);
+    for (const account of accounts) {
+      const email = account.email;
+      try {
+        const { hasCredential } = await import('../accounts/credentials.js');
+        if (await hasCredential(email)) {
+          const { execute } = await import('../executor/gws.js');
+          await execute(
+            ['gmail', 'users', 'getProfile', '--params', JSON.stringify({ userId: 'me' })],
+            { account: email },
+          );
+          log(`startup: ${email} — token valid`);
+        } else {
+          log(`startup: ${email} — no credential file`);
+        }
+      } catch (err) {
+        log(`startup: ${email} — token invalid (${(err as Error).message})`);
+      }
+    }
+  } catch (err) {
+    log(`startup: warmup failed (${(err as Error).message})`);
+  }
+}
+
 export async function startServer(): Promise<void> {
   const server = createServer();
   const transport = new StdioServerTransport();
   await server.connect(transport);
+  // Non-blocking warmup — don't delay MCP handshake
+  warmupAccounts().catch(() => {});
 }


### PR DESCRIPTION
## Summary

- **Accounts status fix**: `checkAccountStatus` now validates against our per-account credential files instead of `gws auth status` (which is single-account/keyring-based and always reports the last-authenticated account regardless of which email was requested)
- **Startup warmup**: After MCP handshake, non-blocking credential validation runs for all registered accounts — catches stale tokens early and warms the gws binary's OAuth cache

## Root cause

`gws auth status` ignores `GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE` and always reports from its internal keyring. Since gws is single-account, it always returned the last-authenticated account. Our multi-account layer routes credentials via env var, but the status check bypassed that entirely.

## Fix

- Read credential file directly for `hasRefreshToken`
- Validate token via lightweight Gmail `getProfile` call (respects our credential routing)
- Get scopes from `gws auth status` (informational only — scopes are per-OAuth-app, not per-account)
- Always return the requested email, not whatever gws reports

## Test plan

- [x] 227 unit tests pass
- [x] Type-check clean
- [ ] Manual test: `manage_accounts status` for each account returns correct email