### PR TITLE
fix: resolve CI lint errors and switch to OIDC trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -22,6 +22,14 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm test
-      - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Determine npm tag
+        id: npm-tag
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if echo "$VERSION" | grep -qE '(alpha|beta|rc)'; then
+            echo "tag=$(echo "$VERSION" | grep -oE '(alpha|beta|rc)')" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          fi
+
+      - run: npm publish --provenance --access public --tag ${{ steps.npm-tag.outputs.tag }}

--- a/src/accounts/registry.ts
+++ b/src/accounts/registry.ts
@@ -1,5 +1,4 @@
 import * as fs from 'node:fs/promises';
-import * as path from 'node:path';
 import { accountsFilePath, configDir } from '../executor/paths.js';
 import { hasCredential, removeCredential } from './credentials.js';
 import { authenticateAccount, type AuthResult } from './auth.js';

--- a/src/executor/workspace.ts
+++ b/src/executor/workspace.ts
@@ -117,6 +117,7 @@ export async function ensureWorkspaceDir(): Promise<WorkspaceStatus> {
 export function sanitizeFilename(filename: string): string {
   return filename
     // Remove null bytes and control characters
+    // eslint-disable-next-line no-control-regex
     .replace(/[\x00-\x1f\x7f]/g, '')
     // Remove path separators (prevent directory traversal via filename)
     .replace(/[/\\]/g, '_')

--- a/src/factory/generator.ts
+++ b/src/factory/generator.ts
@@ -12,7 +12,7 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { parse as parseYaml } from '../factory/yaml.js';
 import { execute } from '../executor/gws.js';
-import { requireEmail, requireString, clamp } from '../server/handlers/validate.js';
+import { requireEmail, clamp } from '../server/handlers/validate.js';
 import { formatDefault } from './defaults.js';
 import { nextSteps } from '../server/formatting/next-steps.js';
 import { evaluatePolicies } from './safety.js';
@@ -20,7 +20,6 @@ import type {
   Manifest,
   ServiceDef,
   OperationDef,
-  ParamDef,
   ServicePatch,
   PatchContext,
   GeneratedTool,


### PR DESCRIPTION
## Summary
- Remove unused imports (`path`, `requireString`, `ParamDef`) that caused lint warnings
- Add eslint-disable for intentional control character regex in `sanitizeFilename`
- Switch npm publish workflow from `NPM_TOKEN` secret to OIDC trusted publishing
- Auto-detect prerelease dist-tags (alpha/beta/rc) from package version

## Test plan
- [ ] CI lint job passes (was failing on `no-control-regex` and unused var warnings)
- [ ] CI test/build jobs pass
- [ ] Next tagged release publishes via OIDC without `NPM_TOKEN` secret