### PR TITLE
feat: own OAuth flow, Meet service, multi-account credential fix

### DIFF
--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -20,4 +20,5 @@ _OAuth, credential management, multi-account_
 
 | ADR | Title | Status |
 |-----|-------|--------|
-| [ADR-200](./auth/ADR-200-unified-account-lifecycle-management-tool.md) | Unified account lifecycle management tool | Draft |
+| [ADR-200](./auth/ADR-200-unified-account-lifecycle-management-tool.md) | Unified account lifecycle management tool | Accepted |
+| [ADR-201](./auth/ADR-201-own-oauth-flow-with-token-service.md) | Own OAuth flow with per-account token service | Accepted |

--- a/docs/architecture/auth/ADR-200-unified-account-lifecycle-management-tool.md
+++ b/docs/architecture/auth/ADR-200-unified-account-lifecycle-management-tool.md
@@ -3,7 +3,8 @@ status: Accepted
 date: 2026-03-14
 deciders:
   - aaronsb
-related: []
+related:
+  - ADR-201
 ---
 
 # ADR-200: Unified account lifecycle management tool

--- a/docs/architecture/auth/ADR-201-own-oauth-flow-with-token-service.md
+++ b/docs/architecture/auth/ADR-201-own-oauth-flow-with-token-service.md
@@ -1,0 +1,109 @@
+---
+status: Accepted
+date: 2026-03-20
+deciders:
+  - aaronsb
+related:
+  - ADR-200
+---
+
+# ADR-201: Own OAuth flow with per-account token service
+
+## Context
+
+ADR-200 established `manage_accounts` as the unified auth lifecycle tool, wrapping `gws auth login` and `gws auth export` for credential acquisition. In practice, this approach has a fundamental flaw: **gws CLI has a single-account keyring**.
+
+Each `gws auth login` overwrites the previous token in gws's encrypted store. `gws auth export` always returns the last-authenticated credential regardless of which account is intended. In a multi-account setup, credential files silently contain the wrong refresh token.
+
+**Confirmed bug:** `bockeliea@praecipio.com` credential file resolved to `aaronsb@gmail.com` because gws export returned the wrong token after a re-auth sequence. Drive queries for the Workspace account returned personal Gmail Drive content.
+
+The root cause is architectural — we cannot safely use a single-account tool for multi-account credential management. No amount of sequencing or locking around `gws auth export` can guarantee correctness because gws offers no per-account export parameter.
+
+## Decision
+
+Replace gws's auth subsystem with our own OAuth2 authorization code flow. gws continues to execute all API calls — we only replace how tokens are acquired, stored, and delivered.
+
+### OAuth flow (`src/accounts/oauth.ts`)
+
+We run the standard OAuth2 authorization code grant ourselves:
+
+1. Start an HTTP server on `127.0.0.1` port 0 (OS-assigned random port)
+2. Build the Google consent URL with `access_type=offline`, `prompt=consent`, and a random `state` parameter for CSRF protection
+3. Open the user's browser to the consent screen
+4. Handle the redirect callback, validate state, extract the authorization code
+5. Exchange the code at `https://oauth2.googleapis.com/token` for tokens
+6. Resolve the authenticated user's email via `https://www.googleapis.com/oauth2/v3/userinfo`
+7. Write the credential file directly — no gws involvement
+
+The callback server has a 5-minute timeout and binds to localhost only.
+
+### Scope mapping
+
+A `SERVICE_SCOPE_MAP` constant maps service names to OAuth scope URLs. `scopesForServices("gmail,drive,meet")` produces deduplicated scope URLs plus base scopes (`openid`, `userinfo.email`). Default authentication requests all services at once — one consent screen, full access.
+
+### Token service (`src/accounts/token-service.ts`)
+
+An in-memory `Map<email, {accessToken, expiresAt}>` caches short-lived access tokens for the MCP session lifetime. `getAccessToken(email)` returns a cached token if >60 seconds remain, otherwise exchanges the stored refresh token at Google's token endpoint. Client credentials (client_id, client_secret) are read from the per-account credential file — no environment variable dependency at the execution layer.
+
+### Credential delivery to gws
+
+The executor switches from `GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE` (gws reads the file and refreshes internally) to `GOOGLE_WORKSPACE_CLI_TOKEN` (we provide a pre-minted access token). gws uses the token directly without touching its own auth subsystem.
+
+```
+# Before (broken for multi-account):
+env.GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE = credentialPath(account)
+
+# After:
+env.GOOGLE_WORKSPACE_CLI_TOKEN = await getAccessToken(account)
+```
+
+### Credential file format
+
+Extended with optional `scopes` field for per-account scope tracking:
+
+```json
+{
+  "type": "authorized_user",
+  "client_id": "...",
+  "client_secret": "...",
+  "refresh_token": "...",
+  "scopes": ["https://www.googleapis.com/auth/gmail.modify", "..."]
+}
+```
+
+Existing files without `scopes` continue to work — the field is read as `[]` when absent. No migration needed.
+
+### Status checking
+
+`checkAccountStatus` reads scopes from the credential file (per-account, not from gws's keyring) and validates the token by attempting a refresh via the token service. This replaces the previous approach of making a Gmail API probe call.
+
+### Startup warmup
+
+The server prefetches access tokens for all registered accounts at startup via `warmTokenCache()`. This runs non-blocking after the MCP handshake, so the first tool call for each account is a cache hit.
+
+## Consequences
+
+### Positive
+
+- **Multi-account correctness** — each account's refresh token is written directly by the OAuth flow that acquired it. No shared keyring, no export race.
+- **Per-account scopes** — stored in the credential file, not inferred from gws's global state.
+- **Faster execution** — access tokens are cached in memory. gws no longer does its own token refresh on every spawned process.
+- **No gws auth dependency** — `auth.ts` and `credentials.ts` no longer import from the executor. The auth layer is fully independent of the API execution layer.
+
+### Negative
+
+- **We own token refresh** — if Google changes their token endpoint behavior, we need to handle it. Previously gws abstracted this.
+- **Access tokens in environment** — `GOOGLE_WORKSPACE_CLI_TOKEN` is visible to the gws child process environment. The token is short-lived (~1 hour) and the process is local, but it's a different trust model than a file path.
+- **Localhost callback server** — briefly opens a port. Bound to 127.0.0.1 only, random port, 5-minute timeout, but it's a listening socket during auth.
+
+### Neutral
+
+- ADR-200's operation surface (list, authenticate, remove, status, refresh, scopes) remains unchanged. Only the internal implementation changes.
+- The `setup` operation (deferred in ADR-200) remains deferred — users still need a GCP project with OAuth credentials.
+- Integration tests now exercise the real token refresh path, which is more thorough than before.
+
+## Alternatives considered
+
+- **Lock around gws auth export** — serialize auth operations so only one account auths at a time, then immediately export. Rejected: still fragile (any external `gws auth login` would corrupt the sequence), and doesn't solve the per-account scope tracking problem.
+- **Patch gws to support per-account export** — upstream feature request. Rejected as a dependency: we can't wait for upstream, and the fix is straightforward to own.
+- **Use Google client libraries directly** — replace gws entirely with googleapis npm packages for API calls. Rejected as scope creep: gws handles discovery, pagination, media upload, and CLI helpers well. We only needed to replace the auth, not the API execution engine.

--- a/src/__tests__/accounts/credentials.test.ts
+++ b/src/__tests__/accounts/credentials.test.ts
@@ -1,13 +1,10 @@
 import * as fs from 'node:fs/promises';
 import * as credentials from '../../accounts/credentials.js';
 import { credentialPath, credentialsDir } from '../../executor/paths.js';
-import { execute } from '../../executor/gws.js';
 
 jest.mock('node:fs/promises');
-jest.mock('../../executor/gws.js');
 
 const mockFs = jest.mocked(fs);
-const mockExecute = execute as jest.MockedFunction<typeof execute>;
 
 describe('credentials', () => {
   beforeEach(() => {
@@ -77,12 +74,13 @@ describe('credentials', () => {
     });
   });
 
-  describe('exportAndSaveCredential', () => {
-    const validCredential = {
+  describe('saveCredential', () => {
+    const validCredential: credentials.AuthorizedUserCredential = {
       type: 'authorized_user',
       client_id: 'id-123',
       client_secret: 'secret-456',
       refresh_token: 'token-789',
+      scopes: ['https://www.googleapis.com/auth/gmail.modify'],
     };
 
     beforeEach(() => {
@@ -90,18 +88,8 @@ describe('credentials', () => {
       mockFs.writeFile.mockResolvedValue(undefined);
     });
 
-    it('calls gws auth export --unmasked', async () => {
-      mockExecute.mockResolvedValue({ success: true, data: validCredential, stderr: '' });
-
-      await credentials.exportAndSaveCredential('user@example.com');
-
-      expect(mockExecute).toHaveBeenCalledWith(['auth', 'export', '--unmasked']);
-    });
-
     it('creates credentials directory with 0700 permissions', async () => {
-      mockExecute.mockResolvedValue({ success: true, data: validCredential, stderr: '' });
-
-      await credentials.exportAndSaveCredential('user@example.com');
+      await credentials.saveCredential('user@example.com', validCredential);
 
       expect(mockFs.mkdir).toHaveBeenCalledWith(
         expect.any(String),
@@ -110,9 +98,7 @@ describe('credentials', () => {
     });
 
     it('writes credential file with 0600 permissions', async () => {
-      mockExecute.mockResolvedValue({ success: true, data: validCredential, stderr: '' });
-
-      await credentials.exportAndSaveCredential('user@example.com');
+      await credentials.saveCredential('user@example.com', validCredential);
 
       expect(mockFs.writeFile).toHaveBeenCalledWith(
         credentialPath('user@example.com'),
@@ -122,39 +108,26 @@ describe('credentials', () => {
     });
 
     it('returns the credential file path', async () => {
-      mockExecute.mockResolvedValue({ success: true, data: validCredential, stderr: '' });
-
-      const result = await credentials.exportAndSaveCredential('user@example.com');
-
+      const result = await credentials.saveCredential('user@example.com', validCredential);
       expect(result).toBe(credentialPath('user@example.com'));
     });
 
-    it('rejects when gws returns non-authorized_user type', async () => {
-      mockExecute.mockResolvedValue({
-        success: true,
-        data: { type: 'service_account', project_id: 'test' },
-        stderr: '',
-      });
-
-      await expect(
-        credentials.exportAndSaveCredential('user@example.com'),
-      ).rejects.toThrow('authorized_user');
+    it('rejects non-authorized_user type', async () => {
+      const bad = { type: 'service_account', client_id: 'x', client_secret: 'x', refresh_token: 'x' } as any;
+      await expect(credentials.saveCredential('user@example.com', bad)).rejects.toThrow('authorized_user');
     });
 
-    it('rejects when gws returns null data', async () => {
-      mockExecute.mockResolvedValue({ success: true, data: null, stderr: '' });
-
-      await expect(
-        credentials.exportAndSaveCredential('user@example.com'),
-      ).rejects.toThrow('authorized_user');
+    it('rejects null credential', async () => {
+      await expect(credentials.saveCredential('user@example.com', null as any)).rejects.toThrow('authorized_user');
     });
 
-    it('rejects when gws returns empty object', async () => {
-      mockExecute.mockResolvedValue({ success: true, data: {}, stderr: '' });
+    it('preserves scopes in written file', async () => {
+      await credentials.saveCredential('user@example.com', validCredential);
 
-      await expect(
-        credentials.exportAndSaveCredential('user@example.com'),
-      ).rejects.toThrow('authorized_user');
+      const written = JSON.parse(
+        (mockFs.writeFile as jest.Mock).mock.calls[0][1] as string,
+      );
+      expect(written.scopes).toEqual(['https://www.googleapis.com/auth/gmail.modify']);
     });
   });
 

--- a/src/__tests__/accounts/credentials.test.ts
+++ b/src/__tests__/accounts/credentials.test.ts
@@ -45,6 +45,21 @@ describe('credentials', () => {
       mockFs.readFile.mockResolvedValue('not-json{{{');
       await expect(credentials.readCredential('user@example.com')).rejects.toThrow();
     });
+
+    it('throws on wrong credential type', async () => {
+      mockFs.readFile.mockResolvedValue(JSON.stringify({ type: 'service_account', refresh_token: 'x', client_id: 'x', client_secret: 'x' }));
+      await expect(credentials.readCredential('user@example.com')).rejects.toThrow('authorized_user');
+    });
+
+    it('throws on missing refresh_token', async () => {
+      mockFs.readFile.mockResolvedValue(JSON.stringify({ type: 'authorized_user', client_id: 'x', client_secret: 'x' }));
+      await expect(credentials.readCredential('user@example.com')).rejects.toThrow('refresh_token');
+    });
+
+    it('throws on missing client_id', async () => {
+      mockFs.readFile.mockResolvedValue(JSON.stringify({ type: 'authorized_user', refresh_token: 'x', client_secret: 'x' }));
+      await expect(credentials.readCredential('user@example.com')).rejects.toThrow('client_id');
+    });
   });
 
   describe('removeCredential', () => {

--- a/src/__tests__/accounts/oauth.test.ts
+++ b/src/__tests__/accounts/oauth.test.ts
@@ -1,0 +1,84 @@
+import { scopesForServices, SERVICE_SCOPE_MAP, ALL_SERVICES } from '../../accounts/oauth.js';
+
+describe('oauth', () => {
+  describe('SERVICE_SCOPE_MAP', () => {
+    it('maps all expected services', () => {
+      expect(Object.keys(SERVICE_SCOPE_MAP)).toEqual(
+        expect.arrayContaining(['gmail', 'drive', 'calendar', 'sheets', 'docs', 'tasks', 'slides', 'meet']),
+      );
+    });
+
+    it('meet has three scopes', () => {
+      expect(SERVICE_SCOPE_MAP.meet).toHaveLength(3);
+      expect(SERVICE_SCOPE_MAP.meet).toContain('https://www.googleapis.com/auth/meetings.space.created');
+      expect(SERVICE_SCOPE_MAP.meet).toContain('https://www.googleapis.com/auth/meetings.space.readonly');
+      expect(SERVICE_SCOPE_MAP.meet).toContain('https://www.googleapis.com/auth/meetings.space.settings');
+    });
+  });
+
+  describe('ALL_SERVICES', () => {
+    it('contains all service names', () => {
+      for (const key of Object.keys(SERVICE_SCOPE_MAP)) {
+        expect(ALL_SERVICES).toContain(key);
+      }
+    });
+  });
+
+  describe('scopesForServices', () => {
+    it('returns base scopes plus service scopes', () => {
+      const scopes = scopesForServices('gmail');
+      expect(scopes).toContain('openid');
+      expect(scopes).toContain('https://www.googleapis.com/auth/userinfo.email');
+      expect(scopes).toContain('https://www.googleapis.com/auth/gmail.modify');
+    });
+
+    it('handles comma-separated services', () => {
+      const scopes = scopesForServices('gmail,drive,calendar');
+      expect(scopes).toContain('https://www.googleapis.com/auth/gmail.modify');
+      expect(scopes).toContain('https://www.googleapis.com/auth/drive');
+      expect(scopes).toContain('https://www.googleapis.com/auth/calendar');
+    });
+
+    it('deduplicates scopes', () => {
+      const scopes = scopesForServices('gmail,gmail');
+      const gmailCount = scopes.filter(s => s.includes('gmail')).length;
+      expect(gmailCount).toBe(1);
+    });
+
+    it('handles whitespace in service names', () => {
+      const scopes = scopesForServices(' gmail , drive ');
+      expect(scopes).toContain('https://www.googleapis.com/auth/gmail.modify');
+      expect(scopes).toContain('https://www.googleapis.com/auth/drive');
+    });
+
+    it('is case-insensitive', () => {
+      const scopes = scopesForServices('Gmail,DRIVE');
+      expect(scopes).toContain('https://www.googleapis.com/auth/gmail.modify');
+      expect(scopes).toContain('https://www.googleapis.com/auth/drive');
+    });
+
+    it('throws on unknown service', () => {
+      expect(() => scopesForServices('gmail,bogus')).toThrow('Unknown service');
+      expect(() => scopesForServices('gmail,bogus')).toThrow('bogus');
+    });
+
+    it('includes all meet scopes when meet is requested', () => {
+      const scopes = scopesForServices('meet');
+      expect(scopes).toContain('https://www.googleapis.com/auth/meetings.space.created');
+      expect(scopes).toContain('https://www.googleapis.com/auth/meetings.space.readonly');
+      expect(scopes).toContain('https://www.googleapis.com/auth/meetings.space.settings');
+    });
+
+    it('handles all services at once', () => {
+      const scopes = scopesForServices(ALL_SERVICES);
+      // base (2) + gmail(1) + drive(1) + calendar(1) + sheets(1) + docs(1) + tasks(1) + slides(1) + meet(3) = 12
+      expect(scopes.length).toBe(12);
+    });
+
+    it('ignores empty segments', () => {
+      const scopes = scopesForServices('gmail,,drive,');
+      expect(scopes).toContain('https://www.googleapis.com/auth/gmail.modify');
+      expect(scopes).toContain('https://www.googleapis.com/auth/drive');
+    });
+  });
+});

--- a/src/__tests__/accounts/token-service.test.ts
+++ b/src/__tests__/accounts/token-service.test.ts
@@ -1,0 +1,156 @@
+import { getAccessToken, invalidateToken, TokenRefreshError, _clearCache } from '../../accounts/token-service.js';
+import * as credentials from '../../accounts/credentials.js';
+
+jest.mock('../../accounts/credentials.js');
+
+const mockReadCredential = credentials.readCredential as jest.MockedFunction<typeof credentials.readCredential>;
+
+// Mock global fetch
+const mockFetch = jest.fn() as jest.MockedFunction<typeof fetch>;
+global.fetch = mockFetch;
+
+const TEST_CREDENTIAL: credentials.AuthorizedUserCredential = {
+  type: 'authorized_user',
+  client_id: 'test-client-id',
+  client_secret: 'test-client-secret',
+  refresh_token: 'test-refresh-token',
+};
+
+describe('token-service', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    _clearCache();
+    mockReadCredential.mockResolvedValue(TEST_CREDENTIAL);
+  });
+
+  describe('getAccessToken', () => {
+    it('exchanges refresh token for access token', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ access_token: 'fresh-token', expires_in: 3600 }),
+      } as Response);
+
+      const token = await getAccessToken('user@example.com');
+
+      expect(token).toBe('fresh-token');
+      expect(mockReadCredential).toHaveBeenCalledWith('user@example.com');
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://oauth2.googleapis.com/token',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+
+    it('returns cached token on subsequent calls', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ access_token: 'cached-token', expires_in: 3600 }),
+      } as Response);
+
+      const first = await getAccessToken('user@example.com');
+      const second = await getAccessToken('user@example.com');
+
+      expect(first).toBe('cached-token');
+      expect(second).toBe('cached-token');
+      expect(mockFetch).toHaveBeenCalledTimes(1); // only one fetch
+    });
+
+    it('caches per email', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ access_token: 'token-a', expires_in: 3600 }),
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ access_token: 'token-b', expires_in: 3600 }),
+        } as Response);
+
+      const a = await getAccessToken('a@test.com');
+      const b = await getAccessToken('b@test.com');
+
+      expect(a).toBe('token-a');
+      expect(b).toBe('token-b');
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('throws TokenRefreshError on invalid_grant', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 400,
+        json: async () => ({ error: 'invalid_grant' }),
+      } as Response);
+
+      await expect(getAccessToken('user@example.com')).rejects.toThrow(TokenRefreshError);
+      await expect(getAccessToken('user@example.com')).rejects.toThrow('revoked');
+    });
+
+    it('throws TokenRefreshError on other HTTP errors', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: async () => ({ error: 'server_error' }),
+      } as Response);
+
+      await expect(getAccessToken('user@example.com')).rejects.toThrow(TokenRefreshError);
+    });
+
+    it('sends correct body params', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ access_token: 'tok', expires_in: 3600 }),
+      } as Response);
+
+      await getAccessToken('user@example.com');
+
+      const fetchCall = mockFetch.mock.calls[0];
+      const body = fetchCall[1]?.body as URLSearchParams;
+      expect(body.get('client_id')).toBe('test-client-id');
+      expect(body.get('client_secret')).toBe('test-client-secret');
+      expect(body.get('refresh_token')).toBe('test-refresh-token');
+      expect(body.get('grant_type')).toBe('refresh_token');
+    });
+  });
+
+  describe('invalidateToken', () => {
+    it('forces re-fetch on next getAccessToken call', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ access_token: 'old-token', expires_in: 3600 }),
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ access_token: 'new-token', expires_in: 3600 }),
+        } as Response);
+
+      await getAccessToken('user@example.com');
+      invalidateToken('user@example.com');
+      const token = await getAccessToken('user@example.com');
+
+      expect(token).toBe('new-token');
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not affect other accounts', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ access_token: 'token-a', expires_in: 3600 }),
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ access_token: 'token-b', expires_in: 3600 }),
+        } as Response);
+
+      await getAccessToken('a@test.com');
+      await getAccessToken('b@test.com');
+
+      invalidateToken('a@test.com');
+
+      // b should still be cached
+      const bToken = await getAccessToken('b@test.com');
+      expect(bToken).toBe('token-b');
+      expect(mockFetch).toHaveBeenCalledTimes(2); // no new fetch for b
+    });
+  });
+});

--- a/src/__tests__/executor/gws.test.ts
+++ b/src/__tests__/executor/gws.test.ts
@@ -6,6 +6,14 @@ import { EventEmitter } from 'node:events';
 // Mock child_process.spawn
 jest.mock('node:child_process');
 
+// Mock token service — getAccessToken is called when account is provided
+jest.mock('../../accounts/token-service.js', () => ({
+  getAccessToken: jest.fn().mockResolvedValue('mock-access-token-123'),
+}));
+
+import { getAccessToken } from '../../accounts/token-service.js';
+const mockGetAccessToken = getAccessToken as jest.MockedFunction<typeof getAccessToken>;
+
 function createMockProcess() {
   const proc = new EventEmitter() as any;
   proc.stdout = new EventEmitter();
@@ -20,6 +28,7 @@ describe('execute', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetAccessToken.mockResolvedValue('mock-access-token-123');
   });
 
   it('returns parsed JSON on success', async () => {
@@ -91,20 +100,24 @@ describe('execute', () => {
     await expect(promise).rejects.toThrow('Failed to parse');
   });
 
-  it('sets credential file env var when account is provided', async () => {
+  it('sets GOOGLE_WORKSPACE_CLI_TOKEN when account is provided', async () => {
     const proc = createMockProcess();
     mockSpawn.mockReturnValue(proc as any);
 
     const promise = execute(['gmail', '+triage'], { account: 'user@example.com' });
+
+    // getAccessToken is async — wait a tick for spawn to be called
+    await new Promise(r => setImmediate(r));
 
     proc.stdout.emit('data', Buffer.from('{}'));
     proc.emit('close', 0);
 
     await promise;
 
+    expect(mockGetAccessToken).toHaveBeenCalledWith('user@example.com');
     const spawnCall = mockSpawn.mock.calls[0];
     const env = spawnCall[2]?.env as Record<string, string>;
-    expect(env.GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE).toContain('user_at_example_dot_com.json');
+    expect(env.GOOGLE_WORKSPACE_CLI_TOKEN).toBe('mock-access-token-123');
   });
 
   it('appends --format json by default', async () => {
@@ -154,7 +167,7 @@ describe('execute', () => {
     expect(result.data).toBe('ID  Summary\n1   Standup');
   });
 
-  it('does not set credential env var when no account', async () => {
+  it('does not set token env var when no account', async () => {
     const proc = createMockProcess();
     mockSpawn.mockReturnValue(proc as any);
 
@@ -166,7 +179,8 @@ describe('execute', () => {
     await promise;
 
     const env = mockSpawn.mock.calls[0][2]?.env as Record<string, string>;
-    expect(env.GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE).toBeUndefined();
+    expect(env.GOOGLE_WORKSPACE_CLI_TOKEN).toBeUndefined();
+    expect(mockGetAccessToken).not.toHaveBeenCalled();
   });
 
   it('handles empty stdout with json format as undefined data', async () => {
@@ -179,7 +193,6 @@ describe('execute', () => {
     proc.emit('close', 0);
 
     const result = await promise;
-    // Empty stdout with json format → data is the empty string (non-json branch)
     expect(result.success).toBe(true);
   });
 
@@ -190,7 +203,6 @@ describe('execute', () => {
     const promise = execute(['test']);
 
     proc.emit('error', new Error('ENOENT'));
-    // close fires after error in real Node.js
     proc.emit('close', 1);
 
     await expect(promise).rejects.toThrow('Failed to spawn gws');

--- a/src/__tests__/integration/executor.test.ts
+++ b/src/__tests__/integration/executor.test.ts
@@ -49,19 +49,14 @@ describeIf('executor (integration)', () => {
     ).rejects.toThrow(GwsError);
   }, 15_000);
 
-  it('maps exit codes correctly on auth error', async () => {
-    // Use a bogus credential file to trigger auth error
-    try {
-      await execute(
+  it('rejects with error for nonexistent account', async () => {
+    // With own OAuth flow, a bogus account fails at token service (no credential file)
+    // before gws is even called
+    await expect(
+      execute(
         ['gmail', 'users', 'messages', 'list', '--params', JSON.stringify({ userId: 'me', maxResults: 1 })],
         { account: 'nonexistent-account@bogus.invalid' },
-      );
-      fail('Should have thrown');
-    } catch (err) {
-      expect(err).toBeInstanceOf(GwsError);
-      // Could be AuthError (2) or InternalError (5) depending on gws behavior
-      // with a missing credential file — either way it should be a GwsError
-      expect((err as GwsError).exitCode).toBeGreaterThan(0);
-    }
+      ),
+    ).rejects.toThrow();
   }, 15_000);
 });

--- a/src/__tests__/server/handlers/accounts.test.ts
+++ b/src/__tests__/server/handlers/accounts.test.ts
@@ -11,17 +11,18 @@ import { handleAccounts } from '../../../server/handlers/accounts.js';
 // Mock dependencies
 jest.mock('../../../accounts/registry.js');
 jest.mock('../../../accounts/auth.js');
-jest.mock('../../../accounts/credentials.js');
+jest.mock('../../../accounts/token-service.js');
 
 import { listAccounts, removeAccount, authenticateAndAddAccount } from '../../../accounts/registry.js';
 import { checkAccountStatus, reauthWithServices } from '../../../accounts/auth.js';
-import { exportAndSaveCredential } from '../../../accounts/credentials.js';
+import { getAccessToken, invalidateToken } from '../../../accounts/token-service.js';
 
 const mockListAccounts = listAccounts as jest.MockedFunction<typeof listAccounts>;
 const mockRemoveAccount = removeAccount as jest.MockedFunction<typeof removeAccount>;
 const mockCheckStatus = checkAccountStatus as jest.MockedFunction<typeof checkAccountStatus>;
 const mockReauth = reauthWithServices as jest.MockedFunction<typeof reauthWithServices>;
-const mockExportCred = exportAndSaveCredential as jest.MockedFunction<typeof exportAndSaveCredential>;
+const mockGetAccessToken = getAccessToken as jest.MockedFunction<typeof getAccessToken>;
+const mockInvalidateToken = invalidateToken as jest.MockedFunction<typeof invalidateToken>;
 
 describe('handleAccounts', () => {
   beforeEach(() => jest.resetAllMocks());
@@ -110,14 +111,15 @@ describe('handleAccounts', () => {
   });
 
   describe('refresh', () => {
-    it('re-exports credentials and returns confirmation', async () => {
-      mockExportCred.mockResolvedValue('/path/to/cred.json');
+    it('invalidates cache and re-fetches token', async () => {
+      mockGetAccessToken.mockResolvedValue('fresh-token');
 
       const result = await handleAccounts({ operation: 'refresh', email: 'a@test.com' });
 
-      expect(result.text).toContain('Credentials refreshed for a@test.com');
+      expect(result.text).toContain('Token refreshed for a@test.com');
       expect(result.refs.status).toBe('refreshed');
-      expect(mockExportCred).toHaveBeenCalledWith('a@test.com');
+      expect(mockInvalidateToken).toHaveBeenCalledWith('a@test.com');
+      expect(mockGetAccessToken).toHaveBeenCalledWith('a@test.com');
     });
 
     it('requires email', async () => {

--- a/src/accounts/auth.ts
+++ b/src/accounts/auth.ts
@@ -1,7 +1,7 @@
-import { spawn, execFile } from 'node:child_process';
-import { platform } from 'node:os';
-import { execute, resolveGwsBinary, resolvePackageBinDir } from '../executor/gws.js';
-import { exportAndSaveCredential, readCredential, hasCredential } from './credentials.js';
+import { readCredential, saveCredential, hasCredential } from './credentials.js';
+import { credentialPath } from '../executor/paths.js';
+import { runOAuthFlow, scopesForServices, ALL_SERVICES } from './oauth.js';
+import { getAccessToken, invalidateToken } from './token-service.js';
 
 export interface AuthResult {
   status: 'success' | 'error';
@@ -19,12 +19,34 @@ export interface AccountStatus {
 }
 
 /**
- * Check account status by reading our credential file and validating
- * the token via a lightweight Gmail API call.
- *
- * Note: `gws auth status` is single-account (keyring-based) and ignores
- * GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE. We bypass it entirely and
- * validate against our own per-account credential files.
+ * Authenticate a new account via our own OAuth2 flow.
+ * Requests all service scopes by default.
+ */
+export async function authenticateAccount(
+  clientId: string,
+  clientSecret: string,
+): Promise<AuthResult> {
+  const scopes = scopesForServices(ALL_SERVICES);
+  return runOAuth(clientId, clientSecret, scopes);
+}
+
+/**
+ * Re-authenticate with a specific set of services.
+ * Used by the `scopes` operation as an escape hatch.
+ */
+export async function reauthWithServices(
+  clientId: string,
+  clientSecret: string,
+  services: string,
+): Promise<AuthResult> {
+  const scopes = scopesForServices(services);
+  return runOAuth(clientId, clientSecret, scopes);
+}
+
+/**
+ * Check account status: token validity and granted scopes.
+ * Reads scopes from the credential file (per-account, not from gws keyring).
+ * Validates token by attempting a refresh via the token service.
  */
 export async function checkAccountStatus(email: string): Promise<AccountStatus> {
   const hasCred = await hasCredential(email);
@@ -40,31 +62,14 @@ export async function checkAccountStatus(email: string): Promise<AccountStatus> 
 
   const cred = await readCredential(email);
   const hasRefreshToken = Boolean(cred.refresh_token);
+  const scopes = cred.scopes ?? [];
 
-  // Validate the token with a lightweight API call using this account's credential
   let tokenValid = false;
   try {
-    await execute(
-      ['gmail', 'users', 'getProfile', '--params', JSON.stringify({ userId: 'me' })],
-      { account: email },
-    );
+    await getAccessToken(email);
     tokenValid = true;
   } catch {
     tokenValid = false;
-  }
-
-  // Get scopes from gws auth status. These are the scopes granted to the
-  // OAuth app, not per-account — gws is single-account so we can't get
-  // per-account scopes. But they're useful for showing what services are enabled.
-  let scopes: string[] = [];
-  if (tokenValid) {
-    try {
-      const statusResult = await execute(['auth', 'status']);
-      const statusData = statusResult.data as Record<string, unknown>;
-      scopes = Array.isArray(statusData.scopes) ? statusData.scopes as string[] : [];
-    } catch {
-      // Non-critical — scopes are informational
-    }
   }
 
   return {
@@ -76,84 +81,35 @@ export async function checkAccountStatus(email: string): Promise<AccountStatus> 
   };
 }
 
-export async function authenticateAccount(
-  clientId: string,
-  clientSecret: string,
-): Promise<AuthResult> {
-  return runAuthLogin(clientId, clientSecret, ['auth', 'login']);
-}
-
-export async function reauthWithServices(
-  clientId: string,
-  clientSecret: string,
-  services: string,
-): Promise<AuthResult> {
-  return runAuthLogin(clientId, clientSecret, ['auth', 'login', '-s', services]);
-}
-
 // --- Internal ---
 
-function runAuthLogin(
+async function runOAuth(
   clientId: string,
   clientSecret: string,
-  args: string[],
+  scopes: string[],
 ): Promise<AuthResult> {
-  return new Promise((resolve, reject) => {
-    const env: Record<string, string> = {
-      ...process.env as Record<string, string>,
-      GOOGLE_WORKSPACE_CLI_CLIENT_ID: clientId,
-      GOOGLE_WORKSPACE_CLI_CLIENT_SECRET: clientSecret,
+  try {
+    const result = await runOAuthFlow(clientId, clientSecret, scopes);
+
+    await saveCredential(result.email, {
+      type: 'authorized_user',
+      client_id: clientId,
+      client_secret: clientSecret,
+      refresh_token: result.refreshToken,
+      scopes: result.scopes,
+    });
+
+    invalidateToken(result.email);
+
+    return {
+      status: 'success',
+      account: result.email,
+      credentialPath: credentialPath(result.email),
     };
-
-    const gwsBinary = resolveGwsBinary();
-    env.PATH = `${resolvePackageBinDir()}:${env.PATH || ''}`;
-
-    const proc = spawn(gwsBinary, args, {
-      env,
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
-
-    let stdout = '';
-
-    proc.stderr.on('data', (chunk: Buffer) => {
-      const text = chunk.toString();
-      const match = text.match(/https:\/\/accounts\.google\.com\S+/);
-      if (match) openBrowser(match[0]);
-    });
-
-    proc.stdout.on('data', (chunk: Buffer) => { stdout += chunk.toString(); });
-
-    proc.on('error', (err) => {
-      reject(new Error(`Failed to spawn gws auth login: ${err.message}`));
-    });
-
-    proc.on('close', async (code) => {
-      if (code !== 0) {
-        resolve({ status: 'error', error: `gws auth login exited with code ${code}` });
-        return;
-      }
-
-      try {
-        const result = JSON.parse(stdout);
-        const email = result.account as string;
-        if (!email) {
-          resolve({ status: 'error', error: 'No account email in gws auth login response' });
-          return;
-        }
-        const credPath = await exportAndSaveCredential(email);
-        resolve({ status: 'success', account: email, credentialPath: credPath });
-      } catch (err) {
-        resolve({ status: 'error', error: `Failed to process auth result: ${(err as Error).message}` });
-      }
-    });
-  });
-}
-
-function openBrowser(url: string): void {
-  const cmd = platform() === 'darwin' ? 'open'
-            : platform() === 'win32' ? 'start'
-            : 'xdg-open';
-  execFile(cmd, [url], (err) => {
-    if (err) process.stderr.write(`Failed to open browser: ${err.message}\n`);
-  });
+  } catch (err) {
+    return {
+      status: 'error',
+      error: (err as Error).message,
+    };
+  }
 }

--- a/src/accounts/auth.ts
+++ b/src/accounts/auth.ts
@@ -8,6 +8,7 @@ export interface AuthResult {
   account?: string;
   credentialPath?: string;
   error?: string;
+  errorType?: string;
 }
 
 export interface AccountStatus {
@@ -110,6 +111,7 @@ async function runOAuth(
     return {
       status: 'error',
       error: (err as Error).message,
+      errorType: (err as Error).name,
     };
   }
 }

--- a/src/accounts/credentials.ts
+++ b/src/accounts/credentials.ts
@@ -34,7 +34,19 @@ export async function saveCredential(email: string, credential: AuthorizedUserCr
 export async function readCredential(email: string): Promise<AuthorizedUserCredential> {
   const filePath = credentialPath(email);
   const content = await fs.readFile(filePath, 'utf-8');
-  return JSON.parse(content) as AuthorizedUserCredential;
+  const parsed = JSON.parse(content) as Record<string, unknown>;
+
+  if (parsed.type !== 'authorized_user') {
+    throw new Error(`Invalid credential for ${email}: expected type "authorized_user", got "${parsed.type}"`);
+  }
+  if (!parsed.refresh_token || typeof parsed.refresh_token !== 'string') {
+    throw new Error(`Invalid credential for ${email}: missing or invalid refresh_token`);
+  }
+  if (!parsed.client_id || !parsed.client_secret) {
+    throw new Error(`Invalid credential for ${email}: missing client_id or client_secret`);
+  }
+
+  return parsed as unknown as AuthorizedUserCredential;
 }
 
 export async function removeCredential(email: string): Promise<void> {

--- a/src/accounts/credentials.ts
+++ b/src/accounts/credentials.ts
@@ -1,13 +1,13 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { credentialPath, credentialsDir } from '../executor/paths.js';
-import { execute } from '../executor/gws.js';
 
 export interface AuthorizedUserCredential {
   type: 'authorized_user';
   client_id: string;
   client_secret: string;
   refresh_token: string;
+  scopes?: string[];
 }
 
 export async function hasCredential(email: string): Promise<boolean> {
@@ -19,13 +19,9 @@ export async function hasCredential(email: string): Promise<boolean> {
   }
 }
 
-export async function exportAndSaveCredential(email: string): Promise<string> {
-  // --unmasked is required; without it gws masks the client_secret
-  const result = await execute(['auth', 'export', '--unmasked']);
-  const credential = result.data as AuthorizedUserCredential;
-
+export async function saveCredential(email: string, credential: AuthorizedUserCredential): Promise<string> {
   if (credential?.type !== 'authorized_user') {
-    throw new Error('gws auth export did not return an authorized_user credential');
+    throw new Error('Credential must have type "authorized_user"');
   }
 
   const filePath = credentialPath(email);

--- a/src/accounts/index.ts
+++ b/src/accounts/index.ts
@@ -1,6 +1,8 @@
 export { authenticateAccount } from './auth.js';
 export type { AuthResult } from './auth.js';
-export { hasCredential, readCredential, removeCredential, listCredentials, exportAndSaveCredential } from './credentials.js';
+export { hasCredential, readCredential, removeCredential, listCredentials, saveCredential } from './credentials.js';
 export type { AuthorizedUserCredential } from './credentials.js';
 export { listAccounts, getAccount, addAccount, removeAccount, authenticateAndAddAccount } from './registry.js';
 export type { Account } from './registry.js';
+export { getAccessToken, invalidateToken, warmTokenCache } from './token-service.js';
+export { scopesForServices, ALL_SERVICES } from './oauth.js';

--- a/src/accounts/oauth.ts
+++ b/src/accounts/oauth.ts
@@ -1,0 +1,232 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { randomBytes } from 'node:crypto';
+import { execFile } from 'node:child_process';
+import { platform } from 'node:os';
+
+const GOOGLE_AUTH_URL = 'https://accounts.google.com/o/oauth2/auth';
+const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token';
+const GOOGLE_USERINFO_URL = 'https://www.googleapis.com/oauth2/v3/userinfo';
+
+const CALLBACK_TIMEOUT = 5 * 60_000; // 5 minutes
+
+/** Service name → OAuth scope URL(s). */
+export const SERVICE_SCOPE_MAP: Record<string, string[]> = {
+  gmail:    ['https://www.googleapis.com/auth/gmail.modify'],
+  drive:    ['https://www.googleapis.com/auth/drive'],
+  calendar: ['https://www.googleapis.com/auth/calendar'],
+  sheets:   ['https://www.googleapis.com/auth/spreadsheets'],
+  docs:     ['https://www.googleapis.com/auth/documents'],
+  tasks:    ['https://www.googleapis.com/auth/tasks'],
+  slides:   ['https://www.googleapis.com/auth/presentations'],
+  meet: [
+    'https://www.googleapis.com/auth/meetings.space.created',
+    'https://www.googleapis.com/auth/meetings.space.readonly',
+    'https://www.googleapis.com/auth/meetings.space.settings',
+  ],
+};
+
+const BASE_SCOPES = [
+  'openid',
+  'https://www.googleapis.com/auth/userinfo.email',
+];
+
+/** All service names that have scope mappings. */
+export const ALL_SERVICES = Object.keys(SERVICE_SCOPE_MAP).join(',');
+
+export interface OAuthResult {
+  email: string;
+  accessToken: string;
+  refreshToken: string;
+  expiresIn: number;
+  scopes: string[];
+}
+
+/**
+ * Convert comma-separated service names to deduplicated scope URLs.
+ * Always includes base scopes (openid, userinfo.email).
+ */
+export function scopesForServices(services: string): string[] {
+  const names = services.split(',').map(s => s.trim().toLowerCase()).filter(Boolean);
+  const scopes = new Set<string>(BASE_SCOPES);
+
+  for (const name of names) {
+    const mapped = SERVICE_SCOPE_MAP[name];
+    if (!mapped) {
+      throw new Error(`Unknown service: '${name}'. Known: ${Object.keys(SERVICE_SCOPE_MAP).join(', ')}`);
+    }
+    for (const scope of mapped) scopes.add(scope);
+  }
+
+  return [...scopes];
+}
+
+/**
+ * Run a full OAuth2 authorization code flow with a localhost callback server.
+ *
+ * 1. Start HTTP server on a random port
+ * 2. Open browser to Google consent screen
+ * 3. Handle redirect callback, exchange code for tokens
+ * 4. Resolve the authenticated user's email via userinfo
+ */
+export async function runOAuthFlow(
+  clientId: string,
+  clientSecret: string,
+  scopes: string[],
+): Promise<OAuthResult> {
+  const state = randomBytes(16).toString('hex');
+
+  const { code, redirectUri } = await listenForCallback(clientId, scopes, state);
+
+  // Exchange authorization code for tokens
+  const tokenResponse = await fetch(GOOGLE_TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      code,
+      client_id: clientId,
+      client_secret: clientSecret,
+      redirect_uri: redirectUri,
+      grant_type: 'authorization_code',
+    }),
+  });
+
+  if (!tokenResponse.ok) {
+    const body = await tokenResponse.text();
+    throw new Error(`Token exchange failed (${tokenResponse.status}): ${body}`);
+  }
+
+  const tokenData = await tokenResponse.json() as {
+    access_token: string;
+    refresh_token?: string;
+    expires_in: number;
+    scope: string;
+  };
+
+  if (!tokenData.refresh_token) {
+    throw new Error(
+      'No refresh_token returned. This usually means the user did not grant offline access. ' +
+      'Try revoking app access at https://myaccount.google.com/permissions and re-authenticating.',
+    );
+  }
+
+  // Resolve email from userinfo
+  const userinfoResponse = await fetch(GOOGLE_USERINFO_URL, {
+    headers: { Authorization: `Bearer ${tokenData.access_token}` },
+  });
+
+  if (!userinfoResponse.ok) {
+    throw new Error(`Userinfo request failed (${userinfoResponse.status})`);
+  }
+
+  const userinfo = await userinfoResponse.json() as { email: string };
+
+  return {
+    email: userinfo.email,
+    accessToken: tokenData.access_token,
+    refreshToken: tokenData.refresh_token,
+    expiresIn: tokenData.expires_in,
+    scopes: tokenData.scope.split(' '),
+  };
+}
+
+// --- Internal ---
+
+function listenForCallback(
+  clientId: string,
+  scopes: string[],
+  state: string,
+): Promise<{ code: string; redirectUri: string }> {
+  return new Promise((resolve, reject) => {
+    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      const url = new URL(req.url ?? '/', `http://localhost`);
+
+      // Ignore favicon and other requests
+      if (!url.pathname.includes('callback') && url.pathname !== '/') {
+        res.writeHead(404);
+        res.end();
+        return;
+      }
+
+      const error = url.searchParams.get('error');
+      if (error) {
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.end('<html><body><h2>Authentication failed</h2><p>You can close this tab.</p></body></html>');
+        cleanup();
+        reject(new Error(`OAuth error: ${error}`));
+        return;
+      }
+
+      const code = url.searchParams.get('code');
+      const returnedState = url.searchParams.get('state');
+
+      if (!code) return; // not the callback yet
+
+      if (returnedState !== state) {
+        res.writeHead(400, { 'Content-Type': 'text/html' });
+        res.end('<html><body><h2>Invalid state parameter</h2><p>Possible CSRF. Try again.</p></body></html>');
+        cleanup();
+        reject(new Error('OAuth state mismatch — possible CSRF'));
+        return;
+      }
+
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end('<html><body><h2>Authentication successful</h2><p>You can close this tab.</p></body></html>');
+      cleanup();
+      resolve({ code, redirectUri });
+    });
+
+    let redirectUri = '';
+    let timer: ReturnType<typeof setTimeout>;
+
+    const cleanup = () => {
+      clearTimeout(timer);
+      server.close();
+    };
+
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      if (!addr || typeof addr === 'string') {
+        reject(new Error('Failed to bind callback server'));
+        return;
+      }
+
+      redirectUri = `http://127.0.0.1:${addr.port}/callback`;
+
+      const authUrl = buildAuthUrl(clientId, redirectUri, scopes, state);
+      process.stderr.write(`[gws-mcp] OAuth: opening browser for consent\n`);
+      openBrowser(authUrl);
+    });
+
+    timer = setTimeout(() => {
+      cleanup();
+      reject(new Error('OAuth flow timed out — no callback received within 5 minutes'));
+    }, CALLBACK_TIMEOUT);
+  });
+}
+
+function buildAuthUrl(
+  clientId: string,
+  redirectUri: string,
+  scopes: string[],
+  state: string,
+): string {
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    response_type: 'code',
+    scope: scopes.join(' '),
+    access_type: 'offline',
+    prompt: 'consent',
+    state,
+  });
+  return `${GOOGLE_AUTH_URL}?${params.toString()}`;
+}
+
+export function openBrowser(url: string): void {
+  const cmd = platform() === 'darwin' ? 'open'
+            : platform() === 'win32' ? 'start'
+            : 'xdg-open';
+  execFile(cmd, [url], (err) => {
+    if (err) process.stderr.write(`[gws-mcp] Failed to open browser: ${err.message}\n`);
+  });
+}

--- a/src/accounts/token-service.ts
+++ b/src/accounts/token-service.ts
@@ -11,6 +11,9 @@ interface CachedToken {
 /** In-memory access token cache — lives for the MCP session. */
 const cache = new Map<string, CachedToken>();
 
+/** In-flight refresh promises — deduplicates concurrent requests for the same account. */
+const inflight = new Map<string, Promise<string>>();
+
 export class TokenRefreshError extends Error {
   constructor(
     message: string,
@@ -34,6 +37,20 @@ export async function getAccessToken(email: string): Promise<string> {
     return cached.accessToken;
   }
 
+  // Deduplicate concurrent refresh requests for the same account
+  const pending = inflight.get(email);
+  if (pending) return pending;
+
+  const promise = refreshAccessToken(email);
+  inflight.set(email, promise);
+  try {
+    return await promise;
+  } finally {
+    inflight.delete(email);
+  }
+}
+
+async function refreshAccessToken(email: string): Promise<string> {
   const credential = await readCredential(email);
 
   const response = await fetch(GOOGLE_TOKEN_URL, {
@@ -83,6 +100,7 @@ export async function getAccessToken(email: string): Promise<string> {
 /** Evict a cached token — forces next getAccessToken to refresh. */
 export function invalidateToken(email: string): void {
   cache.delete(email);
+  inflight.delete(email);
 }
 
 /** Prefetch tokens for all given accounts (fire-and-forget, logs errors). */
@@ -104,4 +122,5 @@ export async function warmTokenCache(emails: string[]): Promise<void> {
 /** Visible for testing — clear the entire cache. */
 export function _clearCache(): void {
   cache.clear();
+  inflight.clear();
 }

--- a/src/accounts/token-service.ts
+++ b/src/accounts/token-service.ts
@@ -1,0 +1,107 @@
+import { readCredential } from './credentials.js';
+
+const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token';
+const EXPIRY_BUFFER = 60_000; // refresh 1 minute before expiry
+
+interface CachedToken {
+  accessToken: string;
+  expiresAt: number;
+}
+
+/** In-memory access token cache — lives for the MCP session. */
+const cache = new Map<string, CachedToken>();
+
+export class TokenRefreshError extends Error {
+  constructor(
+    message: string,
+    public readonly email: string,
+    public readonly googleError?: string,
+  ) {
+    super(message);
+    this.name = 'TokenRefreshError';
+  }
+}
+
+/**
+ * Get a valid access token for an account.
+ *
+ * Returns from cache if >60s remaining, otherwise exchanges
+ * the stored refresh token for a fresh access token.
+ */
+export async function getAccessToken(email: string): Promise<string> {
+  const cached = cache.get(email);
+  if (cached && cached.expiresAt > Date.now() + EXPIRY_BUFFER) {
+    return cached.accessToken;
+  }
+
+  const credential = await readCredential(email);
+
+  const response = await fetch(GOOGLE_TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      client_id: credential.client_id,
+      client_secret: credential.client_secret,
+      refresh_token: credential.refresh_token,
+      grant_type: 'refresh_token',
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.json().catch(() => ({})) as Record<string, unknown>;
+    const googleError = body.error as string | undefined;
+
+    if (response.status === 400 && googleError === 'invalid_grant') {
+      cache.delete(email);
+      throw new TokenRefreshError(
+        `Refresh token revoked or expired for ${email}. Re-authenticate with manage_accounts → authenticate.`,
+        email,
+        googleError,
+      );
+    }
+
+    throw new TokenRefreshError(
+      `Token refresh failed for ${email} (${response.status}): ${JSON.stringify(body)}`,
+      email,
+      googleError,
+    );
+  }
+
+  const data = await response.json() as {
+    access_token: string;
+    expires_in: number;
+  };
+
+  cache.set(email, {
+    accessToken: data.access_token,
+    expiresAt: Date.now() + (data.expires_in * 1000),
+  });
+
+  return data.access_token;
+}
+
+/** Evict a cached token — forces next getAccessToken to refresh. */
+export function invalidateToken(email: string): void {
+  cache.delete(email);
+}
+
+/** Prefetch tokens for all given accounts (fire-and-forget, logs errors). */
+export async function warmTokenCache(emails: string[]): Promise<void> {
+  const results = await Promise.allSettled(
+    emails.map(email => getAccessToken(email)),
+  );
+
+  for (let i = 0; i < results.length; i++) {
+    const result = results[i];
+    if (result.status === 'rejected') {
+      process.stderr.write(
+        `[gws-mcp] token warmup failed for ${emails[i]}: ${(result.reason as Error).message}\n`,
+      );
+    }
+  }
+}
+
+/** Visible for testing — clear the entire cache. */
+export function _clearCache(): void {
+  cache.clear();
+}

--- a/src/executor/gws.ts
+++ b/src/executor/gws.ts
@@ -1,7 +1,7 @@
 import { spawn } from 'node:child_process';
 import * as path from 'node:path';
-import { credentialPath } from './paths.js';
 import { GwsExitCode, GwsError, parseGwsError } from './errors.js';
+import { getAccessToken } from '../accounts/token-service.js';
 
 export interface GwsResult {
   success: boolean;
@@ -67,7 +67,8 @@ export async function execute(args: string[], options: GwsOptions = {}): Promise
   const env: Record<string, string> = { ...process.env as Record<string, string> };
 
   if (account) {
-    env.GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE = credentialPath(account);
+    const accessToken = await getAccessToken(account);
+    env.GOOGLE_WORKSPACE_CLI_TOKEN = accessToken;
   }
 
   const fullArgs = [...args, '--format', format];
@@ -76,7 +77,7 @@ export async function execute(args: string[], options: GwsOptions = {}): Promise
   const gwsBinary = resolveGwsBinary();
   process.stderr.write(`[gws-mcp] exec: ${gwsBinary} ${fullArgs.join(' ')}\n`);
   if (account) {
-    process.stderr.write(`[gws-mcp] cred: ${env.GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE}\n`);
+    process.stderr.write(`[gws-mcp] token: [access token for ${account}]\n`);
   }
 
   // Still prepend bin dir to PATH for non-bundled case

--- a/src/executor/paths.ts
+++ b/src/executor/paths.ts
@@ -18,8 +18,9 @@ export function credentialsDir(): string {
 }
 
 export function emailToSlug(email: string): string {
-  // Preserve uniqueness: @ → _at_, dots → _dot_, hyphens stay as-is
-  return email.replace(/@/g, '_at_').replace(/\./g, '_dot_');
+  // Strip path separators to prevent traversal, then preserve uniqueness
+  const safe = email.replace(/[/\\]/g, '');
+  return safe.replace(/@/g, '_at_').replace(/\./g, '_dot_');
 }
 
 export function credentialPath(email: string): string {

--- a/src/factory/manifest.yaml
+++ b/src/factory/manifest.yaml
@@ -1,11 +1,11 @@
 # Service manifest — declarative registry for the tool factory (ADR-300).
 # Each entry produces one MCP tool via the generator.
-# gws 0.13.3 — 6 services, 51 operations
+# gws 0.13.3 — 7 services, 62 operations
 #
-# Note: People (contacts) and Meet are supported by gws but excluded here
-# because gws auth login doesn't offer their required OAuth scopes.
+# Note: People (contacts) are supported by gws but excluded here
+# because gws auth login doesn't offer contacts.readonly scope.
 # See https://github.com/googleworkspace/cli/issues/556
-# Re-add when gws supports contacts.readonly and meetings.space.created scopes.
+# Meet scopes resolved — use `gws auth login -s ...,meet` to authorize.
 
 services:
   gmail:
@@ -853,6 +853,155 @@ services:
             required: true
             maps_to: task
 
-  # People (contacts) and Meet are excluded pending gws auth scope support.
+  # ========================================================================
+  # Meet
+  # ========================================================================
+
+  meet:
+    tool_name: manage_meet
+    description: "Browse past Google Meet conferences, participants, transcripts, recordings, and AI-generated smart notes. Requires Workspace Business Standard+ for transcripts/recordings."
+    requires_email: true
+    gws_service: meet
+    operations:
+
+      # --- Conference records ---
+
+      listConferences:
+        type: list
+        description: "list recent meeting conferences (default: descending by start time)"
+        resource: conferenceRecords.list
+        params:
+          filter:
+            type: string
+            description: "EBNF filter (e.g. 'space.meeting_code = \"abc-mnop-xyz\"' or 'start_time>=\"2026-01-01T00:00:00Z\"')"
+          maxResults:
+            type: number
+            description: "Max conferences to return (default: 25, max: 100)"
+            default: 25
+            max: 100
+            maps_to: pageSize
+
+      getConference:
+        type: detail
+        description: "get details of a specific conference"
+        resource: conferenceRecords.get
+        params:
+          conferenceId:
+            type: string
+            description: "Conference record ID (from listConferences)"
+            required: true
+            maps_to: name
+
+      # --- Participants ---
+
+      listParticipants:
+        type: list
+        description: "list who attended a conference"
+        resource: conferenceRecords.participants.list
+        params:
+          conferenceId:
+            type: string
+            description: "Conference record ID"
+            required: true
+            maps_to: parent
+          filter:
+            type: string
+            description: "Filter (e.g. 'latest_end_time IS NULL' for active participants)"
+          maxResults:
+            type: number
+            description: "Max participants (default: 100, max: 250)"
+            default: 100
+            max: 250
+            maps_to: pageSize
+
+      # --- Transcripts ---
+
+      listTranscripts:
+        type: list
+        description: "list transcripts for a conference (requires Workspace Business Standard+)"
+        resource: conferenceRecords.transcripts.list
+        params:
+          conferenceId:
+            type: string
+            description: "Conference record ID"
+            required: true
+            maps_to: parent
+
+      getTranscript:
+        type: detail
+        description: "get transcript metadata including Google Docs destination"
+        resource: conferenceRecords.transcripts.get
+        params:
+          transcriptName:
+            type: string
+            description: "Transcript resource name (from listTranscripts)"
+            required: true
+            maps_to: name
+
+      listTranscriptEntries:
+        type: list
+        description: "get structured transcript text — who said what, with timestamps"
+        resource: conferenceRecords.transcripts.entries.list
+        params:
+          transcriptName:
+            type: string
+            description: "Transcript resource name (e.g. conferenceRecords/.../transcripts/...)"
+            required: true
+            maps_to: parent
+          maxResults:
+            type: number
+            description: "Max entries per page (default: 10, max: 100)"
+            default: 100
+            max: 100
+            maps_to: pageSize
+
+      # --- Recordings ---
+
+      listRecordings:
+        type: list
+        description: "list recordings for a conference (saved as MP4 in Drive)"
+        resource: conferenceRecords.recordings.list
+        params:
+          conferenceId:
+            type: string
+            description: "Conference record ID"
+            required: true
+            maps_to: parent
+
+      getRecording:
+        type: detail
+        description: "get recording metadata including Drive file ID and playback link"
+        resource: conferenceRecords.recordings.get
+        params:
+          recordingName:
+            type: string
+            description: "Recording resource name (from listRecordings)"
+            required: true
+            maps_to: name
+
+      # --- Smart Notes (Gemini) ---
+
+      listSmartNotes:
+        type: list
+        description: "list Gemini-generated smart notes for a conference"
+        resource: conferenceRecords.smartNotes.list
+        params:
+          conferenceId:
+            type: string
+            description: "Conference record ID"
+            required: true
+            maps_to: parent
+
+      getSmartNote:
+        type: detail
+        description: "get smart note metadata including Google Docs destination"
+        resource: conferenceRecords.smartNotes.get
+        params:
+          smartNoteName:
+            type: string
+            description: "Smart note resource name (from listSmartNotes)"
+            required: true
+            maps_to: name
+
+  # People (contacts) excluded pending gws auth scope support for contacts.readonly.
   # See https://github.com/googleworkspace/cli/issues/556
-  # Manifest entries ready at git tag pre-contacts-meet-removal if needed.

--- a/src/server/handlers/accounts.ts
+++ b/src/server/handlers/accounts.ts
@@ -1,6 +1,6 @@
 import { listAccounts, removeAccount, authenticateAndAddAccount, type Account } from '../../accounts/registry.js';
 import { checkAccountStatus, reauthWithServices } from '../../accounts/auth.js';
-import { exportAndSaveCredential } from '../../accounts/credentials.js';
+import { getAccessToken, invalidateToken } from '../../accounts/token-service.js';
 import { nextSteps } from '../formatting/next-steps.js';
 import { getActivePolicies } from '../../factory/safety.js';
 import { manifest } from '../../factory/registry.js';
@@ -123,10 +123,11 @@ export async function handleAccounts(params: Record<string, unknown>): Promise<H
     case 'refresh': {
       const email = params.email as string;
       if (!email) throw new Error('email is required for refresh');
-      const credPath = await exportAndSaveCredential(email);
+      invalidateToken(email);
+      await getAccessToken(email);
       return {
-        text: `Credentials refreshed for ${email}` + nextSteps('accounts', 'refresh', { email }),
-        refs: { status: 'refreshed', email, credentialPath: credPath },
+        text: `Token refreshed for ${email}` + nextSteps('accounts', 'refresh', { email }),
+        refs: { status: 'refreshed', email },
       };
     }
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -208,33 +208,29 @@ export function createServer(): Server {
   return server;
 }
 
-/** Warm up credentials on startup — validates accounts and refreshes tokens. */
+/** Warm up token cache on startup — prefetch access tokens for all accounts. */
 async function warmupAccounts(): Promise<void> {
   try {
     const { listAccounts } = await import('../accounts/registry.js');
+    const { hasCredential } = await import('../accounts/credentials.js');
+    const { warmTokenCache } = await import('../accounts/token-service.js');
     const accounts = await listAccounts();
     if (accounts.length === 0) {
       log('startup: no accounts configured');
       return;
     }
-    log(`startup: warming ${accounts.length} account(s)`);
+    const withCreds: string[] = [];
     for (const account of accounts) {
-      const email = account.email;
-      try {
-        const { hasCredential } = await import('../accounts/credentials.js');
-        if (await hasCredential(email)) {
-          const { execute } = await import('../executor/gws.js');
-          await execute(
-            ['gmail', 'users', 'getProfile', '--params', JSON.stringify({ userId: 'me' })],
-            { account: email },
-          );
-          log(`startup: ${email} — token valid`);
-        } else {
-          log(`startup: ${email} — no credential file`);
-        }
-      } catch (err) {
-        log(`startup: ${email} — token invalid (${(err as Error).message})`);
+      if (await hasCredential(account.email)) {
+        withCreds.push(account.email);
+      } else {
+        log(`startup: ${account.email} — no credential file`);
       }
+    }
+    if (withCreds.length > 0) {
+      log(`startup: warming tokens for ${withCreds.length} account(s)`);
+      await warmTokenCache(withCreds);
+      log(`startup: token warmup complete`);
     }
   } catch (err) {
     log(`startup: warmup failed (${(err as Error).message})`);


### PR DESCRIPTION
## Summary

- **Own OAuth2 flow** replaces `gws auth login` + `gws auth export`. Each account gets its own refresh token written directly by a localhost callback server — eliminates the single-account keyring contamination bug where `bockeliea@praecipio.com` credentials silently resolved to `aaronsb@gmail.com`.
- **Token service** with in-memory cache mints short-lived access tokens per-account, passed to gws via `GOOGLE_WORKSPACE_CLI_TOKEN` instead of `CREDENTIALS_FILE`. Tokens are cached ~1hr with automatic refresh.
- **Meet service** added to manifest — 10 operations covering conferences, participants, transcripts (structured ASR entries), recordings, and Gemini smart notes. Requires `gws auth login -s ...,meet` scopes (now included by default in our OAuth flow).
- **Credential format** extended with optional `scopes` field for per-account scope tracking.

## What changed

| Area | Before | After |
|------|--------|-------|
| Auth acquisition | `gws auth login` → keyring → `gws auth export` | Our localhost OAuth callback → direct file write |
| Token delivery | `CREDENTIALS_FILE` (gws refreshes internally) | `GOOGLE_WORKSPACE_CLI_TOKEN` (we mint access tokens) |
| Scope tracking | Global (from gws keyring, wrong account) | Per-account (stored in credential file) |
| Meet | Excluded (stale manifest comment) | 10 operations, fully functional |

## New files

- `src/accounts/oauth.ts` — OAuth2 authorization code flow, scope mapping, browser opener
- `src/accounts/token-service.ts` — access token cache + refresh-to-access exchange
- `src/__tests__/accounts/oauth.test.ts` — scope mapping + URL builder tests
- `src/__tests__/accounts/token-service.test.ts` — cache, refresh, revocation tests

## Test plan

- [x] `npm run build` — clean compile
- [x] `npx jest` — 303 tests pass (was 284, +19 new)
- [x] Manual: authenticate 3 accounts via browser consent flow
- [x] Manual: `manage_drive search` per account returns correct Drive content
- [x] Manual: `manage_meet listConferences` returns conferences
- [x] Manual: `manage_meet listTranscriptEntries` returns structured ASR data
- [x] Manual: confirmed credential files contain `scopes` field after new OAuth flow