### PR TITLE
fix(executor): resolve gws binary from system PATH (#76)

### DIFF
--- a/src/__tests__/executor/resolve-binary.test.ts
+++ b/src/__tests__/executor/resolve-binary.test.ts
@@ -61,11 +61,12 @@ describe('resolveGwsBinary', () => {
     expect(mockExecFileSync).toHaveBeenCalledWith('which', ['gws'], expect.any(Object));
   });
 
-  it('throws GwsError with install instructions when binary not found anywhere', () => {
+  it('throws GwsError with agent-friendly instructions when binary not found', () => {
     mockExistsSync.mockReturnValue(false);
     mockExecFileSync.mockImplementation(() => { throw new Error('not found'); });
     expect(() => resolveGwsBinary()).toThrow(GwsError);
     expect(() => resolveGwsBinary()).toThrow(/gws binary not found/);
-    expect(() => resolveGwsBinary()).toThrow(/GWS_BINARY_PATH/);
+    expect(() => resolveGwsBinary()).toThrow(/Do not retry/);
+    expect(() => resolveGwsBinary()).toThrow(/@googleworkspace\/cli/);
   });
 });

--- a/src/executor/gws.ts
+++ b/src/executor/gws.ts
@@ -58,19 +58,22 @@ export function resolveGwsBinary(): string {
     }).trim().split('\n')[0]; // `where` on Windows may return multiple lines
     if (resolved) return resolved;
   } catch {
-    // Not on PATH either — fall through to return the local path
-    // so the existing ENOENT handling in execute() catches it
+    // Not on PATH either — throw descriptive error below
   }
 
   throw new GwsError(
-    `gws binary not found.\n\n` +
-    `This server requires the 'gws' CLI. Resolution order:\n` +
-    `  1. GWS_BINARY_PATH env var (set by .mcpx extension)\n` +
-    `  2. ./node_modules/.bin/gws (npm dependency)\n` +
-    `  3. System PATH (e.g. ~/.local/bin/gws)\n\n` +
-    `Install for the current user:\n` +
-    `  npm install -g @anthropic-ai/gws    # lands in ~/.local/bin/ or npm prefix\n\n` +
-    `Or set GWS_BINARY_PATH=/path/to/gws in your MCP server env config.`,
+    `gws binary not found — this tool cannot function without it.\n\n` +
+    `ACTION REQUIRED: The user must install the 'gws' CLI or fix the server configuration. ` +
+    `Do not retry — all operations will fail until this is resolved.\n\n` +
+    `Resolution order checked:\n` +
+    `  1. GWS_BINARY_PATH env var (set automatically by .mcpx extension) — not set\n` +
+    `  2. ./node_modules/.bin/gws (npm dependency) — not found\n` +
+    `  3. System PATH (e.g. ~/.local/bin/gws) — not found\n\n` +
+    `To fix, the user should either:\n` +
+    `  • Install gws: npm install -g @googleworkspace/cli\n` +
+    `  • Or set GWS_BINARY_PATH=/path/to/gws in the MCP server env config\n\n` +
+    `Note: The .mcpx extension distribution bundles gws automatically. ` +
+    `This error only occurs with the npx invocation pattern.`,
     GwsExitCode.InternalError,
     'binary_not_found',
     '',


### PR DESCRIPTION
## Changes
- `resolveGwsBinary()` now checks system PATH (via `which`/`where`) as a third resolution strategy after env var and node_modules
- When all resolution fails, throws a descriptive error with install instructions instead of surfacing a raw ENOENT from spawn
- Supports the `npx -y @aaronsb/google-workspace-mcp` invocation pattern where gws is installed globally (e.g. `~/.local/bin/gws`)

## Resolution order
1. `GWS_BINARY_PATH` env var (set by .mcpx extension)
2. `./node_modules/.bin/gws` (npm dependency)
3. System PATH lookup (`which gws` / `where gws.exe`)
4. Clear error with install guidance

Closes #76

## Test plan
- [x] All 334 existing tests pass
- [ ] Manual: remove node_modules/.bin/gws, install gws globally, verify npx invocation works
- [ ] Manual: remove gws entirely, verify actionable error message