### PR TITLE
feat(scratchpad): service-agnostic content authoring buffer (ADR-301)

### DIFF
--- a/.claude/ways/api-design/dual-modes/way.md
+++ b/.claude/ways/api-design/dual-modes/way.md
@@ -1,0 +1,25 @@
+---
+description: Offering both readable and lossless modes when there's a fidelity trade-off
+vocabulary: markdown json fidelity lossy lossless readable opaque mode format import export csv rich text plain
+pattern: import|export|format.*mode|markdown.*json|fidelity
+files: src/services/|src/server/
+---
+# Dual Modes at Fidelity Boundaries
+
+When a content format has a genuine trade-off between human readability and structural fidelity, don't force one choice. Offer both modes and let the agent or user pick based on the task.
+
+**The pattern:**
+
+| Mode | Properties | When to use |
+|------|-----------|-------------|
+| Readable (markdown, CSV, plain text) | Lossy but editable, inspectable, cross-service portable | Rewriting, extracting, composing, human review |
+| Lossless (JSON, native API structures) | Full fidelity but opaque, harder to navigate | Targeted edits preserving formatting, round-trip mutations |
+
+**Where this applies in GWS:**
+
+- Google Docs: markdown export vs Docs API JSON
+- Google Sheets: CSV lines vs Sheets API JSON
+- Email: plain text body vs MIME structure
+- Drive files: text extraction vs native format
+
+**When adding a new import/export path**, check whether both modes are feasible. If the lossy mode drops information the agent might need, the lossless mode should exist too — even if it's added later.

--- a/.claude/ways/api-design/full-coverage/way.md
+++ b/.claude/ways/api-design/full-coverage/way.md
@@ -1,0 +1,13 @@
+---
+description: Cross-cutting features should cover all services, not a subset
+vocabulary: cross-cutting coverage services partial complete scope horizontal all seven email docs drive sheets calendar tasks meet scratchpad
+pattern: cross.cutting|all.*service|coverage|scratchpad.*service
+files: src/services/|src/factory/manifest\.yaml
+---
+# Full Coverage for Cross-Cutting Features
+
+When a capability spans multiple GWS services — the scratchpad, batch operations, account management, or anything horizontal — commit to covering all supported services. Partial coverage creates confusion about when the feature applies and when to fall back to direct operations.
+
+- **At design time:** Map the feature to every service. Some mappings may be trivial (calendar events are text, no special adapter needed). Document which services are covered and which are deferred with a reason.
+- **At implementation time:** It's fine to ship incrementally — email and docs first, then sheets, then the rest. But the design should account for all services from the start so later additions don't require rearchitecting.
+- **The anti-pattern:** Building a feature for 2-3 services and calling it done. Agents can't predict which services support the feature and which don't — they'll try it everywhere and hit confusing errors on uncovered services.

--- a/.claude/ways/api-design/late-binding/way.md
+++ b/.claude/ways/api-design/late-binding/way.md
@@ -1,0 +1,15 @@
+---
+description: Decoupling composition from delivery, late-bound targets, deferred binding
+vocabulary: bind target send deliver compose buffer scratchpad decouple recipient dispatch late early creation
+pattern: send|target|deliver|bind|scratchpad
+files: src/services/|src/server/
+---
+# Late-Bound Targets
+
+In this project, content composition and content delivery are separate concerns. When designing operations that create content and then deliver it somewhere:
+
+- **Bind the target at send time, not at creation time.** A piece of content should not know where it's going until the agent explicitly delivers it.
+- **Why:** Retry resilience (failed sends don't lose content), multi-recipient delivery (same content to N targets), cross-service reuse (email content becomes a doc), and simpler agent logic (compose first, decide destination later).
+- **The anti-pattern:** Requiring a destination when the buffer/draft is created. This couples the lifecycle of the content to a single delivery path. If that path fails or changes, the content is stranded.
+
+This applies to the scratchpad (ADR-301) and to any future primitive that holds agent-authored content before delivery.

--- a/.claude/ways/api-design/tool-surface/way.md
+++ b/.claude/ways/api-design/tool-surface/way.md
@@ -1,0 +1,27 @@
+---
+description: Tool response design, what agents see, hiding plumbing, binary references, clean output
+vocabulary: tool response format output agent surface visible opaque plumbing implementation detail binary base64 reference marker attachment blob
+pattern: tool.*response|format.*output|patch\.ts|formatter
+files: src/services/.*patch\.ts|src/factory/
+---
+# Tool Surface Design
+
+Tool responses are the agent's entire view of what happened. Two principles govern what goes into them:
+
+## Hide the plumbing
+
+The agent doesn't need to know *how* data reaches the API — whether it's a live JSON sync, a queued batch, or a direct CLI call. The tool interface should look the same regardless of the backend path. When writing patch formatters or custom handlers:
+
+- Return the same shape whether the operation was synchronous or queued.
+- Don't expose internal state (buffer IDs, sync status, retry counts) unless the agent needs to act on it.
+- If the backend changes, the tool response shouldn't.
+
+## Keep binary out of agent-visible content
+
+Base64-encoded images, file blobs, and other uneditable binary data never belong in text the agent will read or edit. Instead:
+
+- Use **reference markers** in text content (e.g., `att:att-1` in the scratchpad, file references in responses).
+- Store the actual binary in the workspace or attachment side-table.
+- The agent can move, copy, or remove markers — it never needs to parse or re-encode binary content.
+
+This applies to scratchpad buffers, tool response text, and any formatted output the agent consumes.

--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -22,3 +22,11 @@ _OAuth, credential management, multi-account_
 |-----|-------|--------|
 | [ADR-200](./auth/ADR-200-unified-account-lifecycle-management-tool.md) | Unified account lifecycle management tool | Accepted |
 | [ADR-201](./auth/ADR-201-own-oauth-flow-with-token-service.md) | Own OAuth flow with per-account token service | Accepted |
+
+## API Surface
+_MCP tools, schemas, progressive disclosure_
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [ADR-300](./api/ADR-300-service-tool-factory-with-manifest-driven-generation.md) | Service tool factory with manifest-driven generation | Draft |
+| [ADR-301](./api/ADR-301-scratchpad-buffer-for-service-agnostic-content-authoring.md) | Scratchpad Buffer — Service-Agnostic Content Authoring | Draft |

--- a/docs/architecture/api/ADR-301-scratchpad-buffer-for-service-agnostic-content-authoring.md
+++ b/docs/architecture/api/ADR-301-scratchpad-buffer-for-service-agnostic-content-authoring.md
@@ -1,0 +1,383 @@
+---
+status: Draft
+date: 2026-03-26
+deciders:
+  - aaronsb
+related:
+  - ADR-300
+---
+
+# ADR-301: Scratchpad Buffer — Service-Agnostic Content Authoring
+
+## Context
+
+The GWS MCP server currently treats every content operation as a direct API call. `manage_docs write` appends text to a live document. `manage_email send` streams the full body in a single tool call. There is no intermediate buffer — content goes straight from the LLM's output tokens to the Google API.
+
+This creates three problems:
+
+**1. No retry resilience.** When a send or write fails (wrong account, missing auth, bad parameter), the content is gone. The agent must recompose the entire message in a new tool call — re-streaming every token. For a 500-word email that fails because the agent picked the wrong account, that's ~700 tokens wasted and re-spent.
+
+**2. No incremental composition.** The LLM must produce complete content in a single tool call argument. It cannot draft a section, review it, revise a paragraph, then send. This forces one-shot authoring for every content type.
+
+**3. No content reuse across targets.** Writing the same announcement as an email to three recipients requires three full content payloads. Drafting a document and then emailing its contents requires producing the content twice.
+
+### Reference: Confluence MCP Scratchpad (ADR-304)
+
+The Confluence Cloud MCP server solved an analogous problem with a line-addressed scratchpad buffer. Key observations:
+
+- Line-addressed editing reduced tool call payload size by 5-10x for typical edits
+- Deferred creation eliminated unnecessary API round-trips
+- Validate-on-mutate gave the LLM ambient parse health without separate validation calls
+
+Their scratchpad is tightly coupled to Confluence: target bound at creation, content format tied to ADF serialization, buffer discarded on submit. The GWS server needs a more general primitive.
+
+## Decision
+
+Introduce a **scratchpad buffer** as a service-agnostic content authoring primitive, exposed as a new `manage_scratchpad` MCP tool. The scratchpad is an in-memory, line-addressed text buffer that decouples content composition from delivery.
+
+### Core design: late-bound targets
+
+The GWS scratchpad **binds targets at send time, not creation time.** A scratchpad starts as a content buffer with no destination. The agent composes, edits, and reviews. When content is ready, the agent sends it to any supported target — or multiple targets, or the same target with different parameters after a failure.
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  LLM Tool Calls (small, line-addressed or path-addressed)│
+│    view, insert_lines, replace_lines, json_set, ...      │
+└──────────────────┬──────────────────────────────────────┘
+                   │
+         ┌─────────▼──────────┐
+         │  Scratchpad Buffer  │  ← lines[] + attachments + format
+         │  (no target yet)    │
+         └─────────┬──────────┘
+                   │  send(target, params)
+         ┌─────────▼──────────┐
+         │  Target Adapter     │  ← resolves attachments, converts format
+         │  (email│doc│ws│...) │
+         └─────────┬──────────┘
+                   │
+         ┌─────────▼──────────┐
+         │  GWS API (via gws)  │
+         └────────────────────┘
+```
+
+### Scratchpad lifecycle
+
+```
+1. CREATE:    Allocate buffer (empty or pre-filled) → returns scratchpad ID
+2. IMPORT:    (optional) Load content from a GWS resource into the buffer
+3. ATTACH:    (optional) Reference files from workspace or Drive
+4. EDIT:      Line-based or path-based mutations — no API calls
+5. SEND:      Specify target + params → adapter converts + delivers
+              On failure: buffer persists, agent fixes params or content, retries
+              On success: buffer persists (default) or discards (keep=false)
+6. DISCARD:   Explicit cleanup, or epoch-based GC
+```
+
+### Scratchpad data model
+
+```typescript
+interface Scratchpad {
+  id: string;                    // sp-{random12}
+  lines: string[];               // the content, line-addressed
+  format: ScratchpadFormat;      // controls validation + addressing mode
+  attachments: Map<string, AttachmentRef>;  // namespaced: sp-xxx/att-1
+  binding?: LiveBinding;         // present when scratchpad is a live view
+  label?: string;                // optional human-readable label
+  lastTouchedEpoch: number;      // server-wide tool call counter at last touch
+  createdAt: Date;
+}
+
+type ScratchpadFormat = 'text' | 'markdown' | 'json' | 'csv';
+
+// Present when scratchpad is bound to a live GWS resource (JSON mode)
+interface LiveBinding {
+  service: 'docs' | 'sheets';
+  resourceId: string;            // documentId or spreadsheetId
+  account: string;               // email for API calls
+}
+
+interface AttachmentRef {
+  refId: string;           // "att-1", "att-2" — scoped to scratchpad ID
+  source: 'workspace' | 'drive' | 'import';
+  filename: string;
+  mimeType: string;
+  size: number;
+  location: string;        // workspace file path or Drive fileId
+}
+```
+
+**Format** defaults to `text` on `create`. Import operations set it based on the source (doc markdown export → `markdown`, doc JSON → `json`, sheet → `csv`). The format controls which validator runs on mutation and whether path-addressed operations are available.
+
+**Attachments** are a side-table mapping reference IDs to file metadata. The combination of scratchpad ID + attachment ID (`sp-abc123/att-1`) is globally unique — no complex naming needed. In the buffer, attachments appear as reference markers:
+
+```markdown
+![quarterly chart](att:att-1 "chart.png, 45 KB, from workspace")
+```
+
+The agent can move, copy, or remove marker lines using normal line operations. The side-table is the source of truth for what's attached; markers are for visibility and positioning.
+
+### MCP tool: `manage_scratchpad`
+
+Follows the operation-based pattern from ADR-300.
+
+**Buffer operations:**
+
+| Operation | Parameters | Effect |
+|-----------|-----------|--------|
+| `create` | `label?`, `content?`, `format?` | Allocate buffer. Returns scratchpad ID. |
+| `view` | `scratchpadId`, `startLine?`, `endLine?` | Show content with line numbers + validation status. |
+| `insert_lines` | `scratchpadId`, `afterLine`, `content` | Insert text after line N (0 = prepend). |
+| `append_lines` | `scratchpadId`, `content` | Append text at end. |
+| `replace_lines` | `scratchpadId`, `startLine`, `endLine`, `content` | Replace line range. |
+| `remove_lines` | `scratchpadId`, `startLine`, `endLine?` | Remove line(s). |
+| `copy_lines` | `scratchpadId`, `fromScratchpadId`, `startLine`, `endLine`, `afterLine` | Copy lines from another scratchpad (source unmodified). |
+| `discard` | `scratchpadId` | Free the buffer and attachments. |
+| `list` | — | List active scratchpads with line counts and attachment counts. |
+
+**JSON path operations** (only when format is `json`):
+
+| Operation | Parameters | Effect |
+|---|---|---|
+| `json_get` | `scratchpadId`, `path` | Read value at JSON path. Returns value + line span. |
+| `json_set` | `scratchpadId`, `path`, `value` | Set value at path. If live-bound: fires API mutation + reloads buffer. If unbound: local mutation + re-serialize. |
+| `json_delete` | `scratchpadId`, `path` | Remove key or array element. Same live/local behavior as `json_set`. |
+| `json_insert` | `scratchpadId`, `path`, `value` | Push value into array. Same live/local behavior as `json_set`. |
+
+Path syntax: JSONPath-like dot/bracket notation (`$.body.content[0].paragraph.elements[0].textRun.content`). Line operations remain available — the agent can mix both addressing modes.
+
+**Live-bound JSON scratchpads.** When a JSON scratchpad has a `LiveBinding` (set during `import` from a doc or sheet in JSON mode), every `json_set`/`json_delete`/`json_insert` mutation does three things:
+
+1. Translates the path operation to the appropriate API call (`batchUpdate` for Docs, `values.update` for Sheets)
+2. Fires the API call immediately
+3. Reloads the full resource JSON into the buffer
+
+This means the buffer always reflects the live state of the document. There is no divergence, no deferred send, no merge conflicts. Each mutation is atomic — if the API call fails, the buffer reloads to the last good state and the error is returned with context.
+
+```
+json_set(sp, "$.body.content[2]...textRun.content", "New heading")
+  → batchUpdate: replaceText at computed index range
+  → API call fires
+  → reload: documents.get → re-parse into buffer
+  → return: "Set $.body.content[2]...textRun.content. Buffer: 847 lines.\nStatus: valid"
+```
+
+This model is more API calls than deferred send, but each call is small and the reload prevents impossible-to-debug ordering collisions. The trade-off is deliberate: correctness over efficiency for structured document editing.
+
+**Unbound JSON scratchpads** (created with `format: json` but no import from a live resource) work like text mode — mutations are local, and `send` delivers the buffer. This covers composing JSON payloads, config files, or structured data that doesn't back a live resource.
+
+**Import and attachment operations:**
+
+| Operation | Parameters | Effect |
+|---|---|---|
+| `import` | `scratchpadId`, `source`, `sourceParams` | Load content from a GWS resource. Sets format. |
+| `attach` | `scratchpadId`, `source` (`workspace`\|`drive`), `filename` or `fileId`, `afterLine?` | Add file to side-table, insert reference marker. |
+| `detach` | `scratchpadId`, `refId` | Remove from side-table. Marker line left for agent to remove. |
+
+**Delivery operations:**
+
+| Operation | Parameters | Effect |
+|---|---|---|
+| `send` | `scratchpadId`, `target`, `targetParams`, `keep?` | Deliver to a GWS target. `keep` defaults to `true`. |
+
+### Line operations
+
+Identical semantics to the proven Confluence scratchpad pattern:
+
+- **Line numbers are 1-based** — matches `view` display and editor conventions.
+- **Content parameter accepts multi-line text** — split on `\n`, CRLF/CR normalized.
+- **Mutation responses include context markers** — the edit site plus one line of surrounding context, not the full buffer.
+- **Validation status appended** — every mutation response ends with a format-specific status line.
+
+### Epoch-based garbage collection
+
+Time-based timeouts are wrong for a multi-service MCP server where the agent may do calendar, email, and drive operations between edits. Instead, use an **epoch counter**: a server-wide integer that increments on every tool call.
+
+The counter lives at the `handleToolCall` dispatch layer — the single entry point for all tool calls. For `queue_operations`, each batched operation also increments the counter.
+
+```typescript
+let epoch = 0;
+
+export function advanceEpoch(): number { return ++epoch; }
+export function getEpoch(): number { return epoch; }
+```
+
+Each scratchpad records `lastTouchedEpoch`. Any scratchpad operation resets it.
+
+```
+GC rule: if (currentEpoch - sp.lastTouchedEpoch > 100) → collect
+```
+
+The threshold of 100 reflects the asymmetry of failure modes: premature collection loses composed content (expensive), while late collection holds a few KB in memory longer than needed (free). GC runs lazily at the start of any `manage_scratchpad` call.
+
+### Import: loading from GWS resources
+
+The `import` operation loads content from a GWS resource into the buffer. It sets the scratchpad format and, for docs, offers two modes.
+
+| Source | Mode | What gets loaded |
+|--------|------|-----------------|
+| `doc` | `markdown` (default) | Markdown export via `gws docs export --mime text/markdown`. Headings, lists, bold/italic, tables, links preserved as markdown. Sets format to `markdown`. |
+| `doc` | `json` | Native Docs API JSON via `documents.get`. Full rich structure preserved. Sets format to `json`. Enables round-trip via `doc_update`. |
+| `email` | — | Email body as plain text. Email attachments optionally registered in the side-table. |
+| `sheet` | — | Sheet data as CSV lines. Sets format to `csv`. |
+| `drive_file` | — | Text content of a Drive file. |
+
+Import appends to the existing buffer (does not replace). Multiple imports can compose into one scratchpad.
+
+**Markdown mode** is for rewriting, extracting text, and cross-service delivery. It's lossy — rich formatting markdown can't represent is dropped. But embedded images survive: binary content (base64 data URIs in the export) is extracted to the workspace directory and registered in the attachment side-table. The buffer gets a reference marker, not a blob.
+
+**JSON mode** is for targeted edits to rich documents where formatting must be preserved. The agent uses `json_set`/`json_get` to modify specific fields. Mutations apply live to the API — the buffer reloads after each change, always reflecting the real document state. From the agent's perspective, it's just editing a JSON scratchpad.
+
+### Send: delivering to GWS targets
+
+| Target | `targetParams` | What happens |
+|--------|----------------|--------------|
+| `email` | `email`, `to`, `subject`, `cc?`, `bcc?` | Content becomes email body. Attachments become file attachments. |
+| `email_draft` | `email`, `to?`, `subject?` | Content becomes draft body. |
+| `doc_create` | `email`, `title` | New document from content. Attachments uploaded as inline images. |
+| `doc_write` | `email`, `documentId` | Content appended to existing document. |
+| `workspace` | `filename` | Writes content to workspace file. Attachments copied alongside. |
+
+**No `doc_replace` for text/markdown.** Overwriting a rich doc with flat text destroys formatting. For new content: `doc_create`. For appending: `doc_write`. For in-place edits preserving formatting: import in JSON mode — mutations apply live, no explicit send needed.
+
+The `keep` parameter (default: `true`) controls whether the scratchpad survives after send:
+
+- **Retry on failure**: send fails → fix params → send again (content never lost)
+- **Multi-recipient email**: send to alice → send to bob → discard
+- **Cross-service delivery**: send as email → also create as doc → discard
+- **One-shot cleanup**: `keep: false` for fire-and-forget
+
+The `workspace` target enables a rewrite workflow: import a document, edit in the scratchpad, write as `.md` with the same root name. The human gets markdown alongside the original and owns the formatting merge.
+
+### Validation (format-driven)
+
+Every mutation appends a format-specific status line. Validation is **informational, not blocking**.
+
+| Format | Checks | Error example |
+|---|---|---|
+| `text` | None — always valid | `Status: valid (N lines)` |
+| `markdown` | Unclosed code fences | `Status: invalid at line 12 — unclosed code fence` |
+| `json` | `JSON.parse()` with line/column extraction | `Status: invalid at line 8:3 — Expected ','` |
+| `csv` | Column count consistency, unmatched quotes | `Status: invalid at line 5 — expected 4 columns, got 3` |
+
+### Error-trap-and-fix on send
+
+When `send` fails due to a content problem, the error response includes **line-level attribution** when the adapter can map the error to a source line:
+
+```
+Send failed (target: sheet): Invalid character U+0000 in cell data.
+  Content line 14 → Sheet row 12, column C
+  14 | Revenue Q3,450000,\x00bad-data
+Scratchpad sp-abc123 is still active (42 lines).
+```
+
+This creates a tight fix loop: `send → error at line 14 → replace_lines 14 → send → success`. The buffer always survives failed sends.
+
+### Cross-scratchpad assembly
+
+The `copy_lines` operation enables assembly: load multiple sources, cherry-pick sections into a combined buffer, deliver the result.
+
+```
+import(sp-A, source: doc, docId: report)      → Q3 report
+import(sp-B, source: email, messageId: notes)  → meeting notes
+create(sp-C, label: "combined briefing")        → empty
+
+copy_lines(sp-C, from: sp-A, lines: 1-15, afterLine: 0)
+append_lines(sp-C, "\n---\n\n## Discussion Notes\n")
+copy_lines(sp-C, from: sp-B, lines: 8-30, afterLine: 20)
+
+send(sp-C, target: email, to: execs@co.com, subject: "Q3 Briefing")
+send(sp-C, target: doc_create, title: "Q3 Briefing")
+```
+
+`copy_lines` reads from the source without modifying it. This composes naturally with `queue_operations` for batch assembly and delivery.
+
+### Integration with queue_operations
+
+Scratchpad operations are regular tool calls that work with the queue:
+
+```json
+{
+  "tool": "queue_operations",
+  "operations": [
+    { "tool": "manage_scratchpad", "operation": "send",
+      "scratchpadId": "sp-abc123", "target": "email",
+      "targetParams": { "email": "me@co.com", "to": "team-a@co.com", "subject": "Update" }},
+    { "tool": "manage_scratchpad", "operation": "send",
+      "scratchpadId": "sp-abc123", "target": "email",
+      "targetParams": { "email": "me@co.com", "to": "team-b@co.com", "subject": "Update" }},
+    { "tool": "manage_scratchpad", "operation": "discard",
+      "scratchpadId": "sp-abc123" }
+  ]
+}
+```
+
+The `$N.field` result-reference syntax works across scratchpad operations.
+
+### Implementation approach
+
+The scratchpad is a **hand-written handler** (like `manage_accounts` and `manage_workspace`), not a factory-generated tool:
+
+- In-memory state (buffer map + epoch) doesn't fit the stateless factory pattern.
+- Operations don't map to `gws` CLI calls — they're local mutations with `send`/`import` as the API touchpoints.
+- The tool schema is custom, not derivable from the gws CLI manifest.
+
+### Tool instruction changes
+
+The scratchpad only works if the agent reaches for it. Tool descriptions must **promote scratchpad-first authoring** for multi-line content, keeping direct operations for simple one-shot cases.
+
+**Route by content complexity, not service type:**
+
+| Scenario | Route |
+|---|---|
+| Quick reply ("Sounds good, thanks.") | Direct `manage_email send` |
+| Multi-paragraph email | Scratchpad → `send` to email |
+| Single line append to a doc | Direct `manage_docs write` |
+| Writing or rewriting sections | Scratchpad → `send` to doc |
+| Cross-service content (email → doc) | Scratchpad `import` → edit → `send` |
+| Batch document rewrites | Scratchpad `import` → edit → `send` to workspace |
+
+Tool descriptions and next-steps guidance updated to reference scratchpad workflows at natural discovery points (after reading an email, after a failed send, after reading a doc).
+
+## Consequences
+
+### Positive
+
+- **Token efficient**: Line-level edits send changed text only. A typo fix is ~20 tokens, not ~700 for a re-streamed email body.
+- **Retry resilient**: Failed sends preserve content. Fix parameters or content and retry without recomposing.
+- **Composable**: Same content targets email, docs, workspace, multiple recipients. Compose once, deliver many.
+- **Dual addressing**: Line operations for prose, JSON path operations for structured data. Mix freely.
+- **Attachments without blobs**: Files referenced by ID, resolved at send time. No base64 in the buffer.
+- **Round-trip for rich docs**: Live-bound JSON mode applies mutations directly to the API — no deferred send, no merge conflicts, always consistent.
+- **Queue-compatible**: Composes with `queue_operations` for batch assembly and delivery.
+- **Activity-based lifecycle**: Epoch GC ties buffer lifetime to server activity, not wall clock.
+
+### Negative
+
+- **Memory consumption**: Each scratchpad holds content in memory. Typical use (a few buffers of a few hundred lines) is negligible. Pathological use would need a cap.
+- **No persistence**: Scratchpads are lost on server restart. Intentional — they are session artifacts. The agent can re-import.
+- **Import complexity**: Doc markdown export may need image extraction; JSON import loads the full Docs API structure. Both are new code.
+- **Adapter surface**: Each send target needs an adapter. Initial scope: email, email_draft, doc_create, doc_write, doc_update, workspace.
+
+### Neutral
+
+- The scratchpad is additive — existing tools unchanged. `manage_docs write` and `manage_email send` still work for one-shot use.
+- The workspace handler remains for file I/O. The scratchpad is for content that will be delivered or exported, not raw file storage.
+- The hand-written handler pattern is established (`manage_accounts`, `manage_workspace`).
+
+## Alternatives Considered
+
+### Port the Confluence scratchpad directly
+
+Bind target at creation, discard on submit, time-based timeout. Misses the key GWS scenarios: retry with different parameters, multi-recipient delivery, cross-service reuse, attachment handling. The Confluence model is a starting point, not the destination.
+
+### Add drafting to each service tool
+
+`manage_email` gets a `draft` operation, `manage_docs` gets a `buffer` mode. This distributes the problem: the agent learns different drafting APIs per service, content can't move between services, every handler grows a mini buffer system. A single scratchpad is simpler and more composable.
+
+### Use the workspace (filesystem) as the buffer
+
+Write drafts to files, edit via workspace `read`/`write`. Awkward: full-file replacement (not line-addressed), no validation, no lifecycle management, no attachment tracking. The scratchpad provides what the filesystem lacks.
+
+### Validate strictly (block on invalid content)
+
+Reject mutations that produce invalid state. Prevents the LLM from working through intermediate invalid states — scaffolding, out-of-order composition, paste-then-refine. Informational validation is better: report status, don't block.

--- a/src/server/formatting/markdown.ts
+++ b/src/server/formatting/markdown.ts
@@ -155,7 +155,7 @@ export function formatEmailList(data: unknown): HandlerResponse {
 }
 
 /** Extract attachments from message payload parts (recursive). */
-function extractAttachments(parts: unknown[]): Array<{ filename: string; mimeType: string; size: number; attachmentId: string }> {
+export function extractAttachments(parts: unknown[]): Array<{ filename: string; mimeType: string; size: number; attachmentId: string }> {
   const attachments: Array<{ filename: string; mimeType: string; size: number; attachmentId: string }> = [];
   for (const part of parts) {
     const p = part as Record<string, unknown>;

--- a/src/server/formatting/next-steps.ts
+++ b/src/server/formatting/next-steps.ts
@@ -49,6 +49,7 @@ const suggestions: Record<string, Record<string, NextStep[]>> = {
     ],
     read: [
       { description: 'Reply to this email', tool: 'manage_email', example: { operation: 'reply', email: '<email>', messageId: '<messageId>', body: '<reply text>' } },
+      { description: 'Import into scratchpad for editing', tool: 'manage_scratchpad', example: { operation: 'import', source: 'email', sourceParams: { email: '<email>', messageId: '<messageId>' } } },
       { description: 'Search for related emails', tool: 'manage_email', example: { operation: 'search', email: '<email>', query: 'thread:<threadId>' } },
     ],
     send: [
@@ -124,6 +125,24 @@ const suggestions: Record<string, Record<string, NextStep[]>> = {
     ],
     download: [
       { description: 'Search for more files', tool: 'manage_drive', example: { operation: 'search', email: '<email>' } },
+    ],
+  },
+  scratchpad: {
+    create: [
+      { description: 'Add content', tool: 'manage_scratchpad', example: { operation: 'append_lines', scratchpadId: '<scratchpadId>', content: '<text>' } },
+      { description: 'Import from a document', tool: 'manage_scratchpad', example: { operation: 'import', scratchpadId: '<scratchpadId>', source: 'doc', sourceParams: { email: '<email>', documentId: '<documentId>' } } },
+    ],
+    append_lines: [
+      { description: 'View buffer', tool: 'manage_scratchpad', example: { operation: 'view', scratchpadId: '<scratchpadId>' } },
+      { description: 'Send as email', tool: 'manage_scratchpad', example: { operation: 'send', scratchpadId: '<scratchpadId>', target: 'email', targetParams: { email: '<email>', to: '<recipient>', subject: '<subject>' } } },
+    ],
+    send: [
+      { description: 'Send to another target', tool: 'manage_scratchpad', example: { operation: 'send', scratchpadId: '<scratchpadId>', target: 'workspace', targetParams: { filename: '<name>.md' } } },
+      { description: 'Discard scratchpad', tool: 'manage_scratchpad', example: { operation: 'discard', scratchpadId: '<scratchpadId>' } },
+    ],
+    import: [
+      { description: 'View imported content', tool: 'manage_scratchpad', example: { operation: 'view', scratchpadId: '<scratchpadId>' } },
+      { description: 'Edit content', tool: 'manage_scratchpad', example: { operation: 'replace_lines', scratchpadId: '<scratchpadId>', startLine: 1, endLine: 1, content: '<new text>' } },
     ],
   },
 };

--- a/src/server/handler.ts
+++ b/src/server/handler.ts
@@ -1,5 +1,6 @@
 import { handleAccounts } from './handlers/accounts.js';
 import { handleWorkspace } from './handlers/workspace.js';
+import { handleScratchpad } from './scratchpad/handler.js';
 import { handleQueue } from './queue.js';
 import { generatedTools } from '../factory/registry.js';
 
@@ -8,9 +9,28 @@ import type { HandlerResponse } from './formatting/markdown.js';
 
 type ToolHandler = (params: Record<string, unknown>) => Promise<HandlerResponse>;
 
+// ── Epoch counter ─────────────────────────────────────────
+// Server-wide monotonic counter incremented on every tool call.
+// Used by ScratchpadManager for activity-based garbage collection.
+
+let epoch = 0;
+
+/** Current epoch value. */
+export function getEpoch(): number {
+  return epoch;
+}
+
+/** Increment and return the new epoch. Called once per tool dispatch. */
+export function advanceEpoch(): number {
+  return ++epoch;
+}
+
+// ── Handler dispatch ──────────────────────────────────────
+
 const domainHandlers: Record<string, ToolHandler> = {
   manage_accounts: handleAccounts,
   manage_workspace: handleWorkspace,
+  manage_scratchpad: handleScratchpad,
 };
 
 // Register factory-generated handlers
@@ -22,7 +42,9 @@ export async function handleToolCall(
   toolName: string,
   params: Record<string, unknown>,
 ): Promise<HandlerResponse> {
-  // Queue wraps the domain handlers
+  advanceEpoch();
+
+  // Queue wraps the domain handlers (each queued op also advances the epoch)
   if (toolName === 'queue_operations') {
     return handleQueue(params, domainHandlers);
   }

--- a/src/server/queue.ts
+++ b/src/server/queue.ts
@@ -6,6 +6,7 @@
  * resolution and text for the final response.
  */
 
+import { advanceEpoch } from './handler.js';
 import type { HandlerResponse } from './handler.js';
 
 type ToolHandler = (params: Record<string, unknown>) => Promise<HandlerResponse>;
@@ -75,6 +76,7 @@ export async function handleQueue(
     }
 
     try {
+      advanceEpoch(); // Each queued operation is a logical tool call
       const response = await handler(resolvedArgs);
       const text = stripNextSteps(response.text);
       results.push({ index: i, tool: op.tool, status: 'success', text, refs: response.refs });

--- a/src/server/scratchpad/__tests__/json-path.test.ts
+++ b/src/server/scratchpad/__tests__/json-path.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Tests for json-path.ts — JSON path parsing and manipulation helpers.
+ */
+
+import { parsePath, getByPath, setByPath, deleteByPath } from '../json-path.js';
+
+describe('parsePath', () => {
+  it('parses $.foo.bar into string segments', () => {
+    expect(parsePath('$.foo.bar')).toEqual(['foo', 'bar']);
+  });
+
+  it('parses $.items[0] into mixed segments', () => {
+    expect(parsePath('$.items[0]')).toEqual(['items', 0]);
+  });
+
+  it('returns empty array for bare $', () => {
+    expect(parsePath('$')).toEqual([]);
+  });
+
+  it('returns empty array for empty string', () => {
+    expect(parsePath('')).toEqual([]);
+  });
+
+  it('parses deeply nested path with mixed access', () => {
+    expect(parsePath('$.a[1].b[2].c')).toEqual(['a', 1, 'b', 2, 'c']);
+  });
+
+  it('parses path without $ prefix', () => {
+    expect(parsePath('foo.bar')).toEqual(['foo', 'bar']);
+  });
+
+  it('distinguishes numeric strings from indices', () => {
+    // "01" is not a pure integer representation so stays as string
+    expect(parsePath('$.items[01]')).toEqual(['items', '01']);
+  });
+});
+
+describe('getByPath', () => {
+  const obj = {
+    name: 'test',
+    nested: { deep: { value: 42 } },
+    items: ['a', 'b', 'c'],
+    matrix: [[1, 2], [3, 4]],
+  };
+
+  it('gets a top-level key', () => {
+    expect(getByPath(obj, '$.name')).toBe('test');
+  });
+
+  it('gets a nested value', () => {
+    expect(getByPath(obj, '$.nested.deep.value')).toBe(42);
+  });
+
+  it('gets an array element by index', () => {
+    expect(getByPath(obj, '$.items[1]')).toBe('b');
+  });
+
+  it('gets nested array element', () => {
+    expect(getByPath(obj, '$.matrix[0][1]')).toBe(2);
+  });
+
+  it('returns undefined for missing key', () => {
+    expect(getByPath(obj, '$.missing')).toBeUndefined();
+  });
+
+  it('returns the root object for bare $', () => {
+    expect(getByPath(obj, '$')).toBe(obj);
+  });
+
+  it('throws on non-object traversal', () => {
+    expect(() => getByPath(obj, '$.name.child')).toThrow('cannot traverse into string');
+  });
+
+  it('throws when traversing through null', () => {
+    const o = { a: null };
+    expect(() => getByPath(o, '$.a.b')).toThrow('cannot traverse');
+  });
+});
+
+describe('setByPath', () => {
+  it('sets a top-level key', () => {
+    const obj: Record<string, unknown> = { a: 1 };
+    setByPath(obj, '$.b', 2);
+    expect(obj.b).toBe(2);
+  });
+
+  it('sets a nested value', () => {
+    const obj = { nested: { deep: { value: 0 } } };
+    setByPath(obj, '$.nested.deep.value', 99);
+    expect(obj.nested.deep.value).toBe(99);
+  });
+
+  it('sets an array element', () => {
+    const obj = { items: ['a', 'b', 'c'] };
+    setByPath(obj, '$.items[1]', 'B');
+    expect(obj.items[1]).toBe('B');
+  });
+
+  it('creates a new key on existing object', () => {
+    const obj = { existing: {} as Record<string, unknown> };
+    setByPath(obj, '$.existing.newKey', 'hello');
+    expect(obj.existing.newKey).toBe('hello');
+  });
+
+  it('throws on root path', () => {
+    expect(() => setByPath({}, '$', 'nope')).toThrow('Cannot set at root path');
+  });
+
+  it('throws when traversing through non-object', () => {
+    const obj = { a: 'string' };
+    expect(() => setByPath(obj, '$.a.b', 1)).toThrow('parent is not an object');
+  });
+});
+
+describe('deleteByPath', () => {
+  it('deletes an object key', () => {
+    const obj = { a: 1, b: 2 } as Record<string, unknown>;
+    deleteByPath(obj, '$.b');
+    expect(obj).toEqual({ a: 1 });
+    expect('b' in obj).toBe(false);
+  });
+
+  it('deletes an array element by index (splice)', () => {
+    const obj = { items: [10, 20, 30] };
+    deleteByPath(obj, '$.items[1]');
+    expect(obj.items).toEqual([10, 30]);
+  });
+
+  it('deletes a nested key', () => {
+    const obj = { nested: { x: 1, y: 2 } as Record<string, unknown> };
+    deleteByPath(obj, '$.nested.x');
+    expect(obj.nested).toEqual({ y: 2 });
+  });
+
+  it('throws on root path', () => {
+    expect(() => deleteByPath({}, '$')).toThrow('Cannot delete root');
+  });
+
+  it('throws when traversing through non-object', () => {
+    const obj = { a: 42 };
+    expect(() => deleteByPath(obj, '$.a.b')).toThrow('parent is not an object');
+  });
+
+  it('deletes first array element', () => {
+    const obj = { items: ['x', 'y', 'z'] };
+    deleteByPath(obj, '$.items[0]');
+    expect(obj.items).toEqual(['y', 'z']);
+  });
+});

--- a/src/server/scratchpad/__tests__/manager.test.ts
+++ b/src/server/scratchpad/__tests__/manager.test.ts
@@ -1,0 +1,1022 @@
+/**
+ * Tests for ScratchpadManager — line-addressed content authoring buffer.
+ * See ADR-301.
+ */
+
+import { ScratchpadManager } from '../manager.js';
+import type { LiveBinding, MutationResult } from '../manager.js';
+
+// ── Mock getEpoch ──────────────────────────────────────────
+// The manager imports getEpoch from '../handler.js' which resolves
+// to '../../handler.js' from the manager's location.
+
+let mockEpoch = 0;
+
+jest.mock('../../handler.js', () => ({
+  getEpoch: () => mockEpoch,
+}));
+
+beforeEach(() => {
+  mockEpoch = 0;
+});
+
+// ── Helpers ────────────────────────────────────────────────
+
+function createManager(): ScratchpadManager {
+  return new ScratchpadManager();
+}
+
+// ── 1. create() ────────────────────────────────────────────
+
+describe('ScratchpadManager', () => {
+  describe('create()', () => {
+    it('creates an empty scratchpad with defaults', () => {
+      const mgr = createManager();
+      const id = mgr.create();
+      expect(id).toMatch(/^sp-/);
+      const sp = mgr.get(id);
+      expect(sp).not.toBeNull();
+      expect(sp!.lines).toEqual([]);
+      expect(sp!.format).toBe('text');
+      expect(sp!.label).toBeUndefined();
+      expect(sp!.attachments.size).toBe(0);
+    });
+
+    it('creates a scratchpad with content', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: 'hello\nworld' });
+      const sp = mgr.get(id)!;
+      expect(sp.lines).toEqual(['hello', 'world']);
+    });
+
+    it('creates a scratchpad with a specific format', () => {
+      const mgr = createManager();
+      const id = mgr.create({ format: 'json' });
+      expect(mgr.get(id)!.format).toBe('json');
+    });
+
+    it('creates a scratchpad with a label', () => {
+      const mgr = createManager();
+      const id = mgr.create({ label: 'Draft email' });
+      expect(mgr.get(id)!.label).toBe('Draft email');
+    });
+
+    it('creates a scratchpad with all options combined', () => {
+      const mgr = createManager();
+      const id = mgr.create({
+        content: '{"key": "value"}',
+        format: 'json',
+        label: 'Config',
+      });
+      const sp = mgr.get(id)!;
+      expect(sp.lines).toEqual(['{"key": "value"}']);
+      expect(sp.format).toBe('json');
+      expect(sp.label).toBe('Config');
+    });
+
+    it('generates unique IDs for each scratchpad', () => {
+      const mgr = createManager();
+      const ids = new Set<string>();
+      for (let i = 0; i < 50; i++) {
+        ids.add(mgr.create());
+      }
+      expect(ids.size).toBe(50);
+    });
+  });
+
+  // ── 2. view() ──────────────────────────────────────────────
+
+  describe('view()', () => {
+    it('returns full view with header and line numbers', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: 'line one\nline two\nline three' });
+      const view = mgr.view(id)!;
+      expect(view).toContain(id);
+      expect(view).toContain('text');
+      expect(view).toContain('3 lines');
+      expect(view).toContain('1 | line one');
+      expect(view).toContain('2 | line two');
+      expect(view).toContain('3 | line three');
+    });
+
+    it('returns windowed view for a line range', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: 'a\nb\nc\nd\ne' });
+      const view = mgr.view(id, 2, 4)!;
+      expect(view).toContain('2 | b');
+      expect(view).toContain('3 | c');
+      expect(view).toContain('4 | d');
+      expect(view).not.toContain('1 | a');
+      expect(view).not.toContain('5 | e');
+    });
+
+    it('displays empty buffer message', () => {
+      const mgr = createManager();
+      const id = mgr.create();
+      const view = mgr.view(id)!;
+      expect(view).toContain('(empty buffer)');
+    });
+
+    it('returns null for unknown id', () => {
+      const mgr = createManager();
+      expect(mgr.view('sp-nonexistent')).toBeNull();
+    });
+
+    it('clamps window boundaries', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: 'a\nb\nc' });
+      // startLine below 1 gets clamped to 1, endLine above length clamped
+      const view = mgr.view(id, -5, 100)!;
+      expect(view).toContain('1 | a');
+      expect(view).toContain('3 | c');
+    });
+
+    it('includes label in header when present', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: 'x', label: 'My Label' });
+      const view = mgr.view(id)!;
+      expect(view).toContain('"My Label"');
+    });
+
+    it('includes attachment count in header', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: 'x' });
+      mgr.attach(id, {
+        source: 'drive',
+        filename: 'file.pdf',
+        mimeType: 'application/pdf',
+        size: 1024,
+        location: 'drive://abc',
+      });
+      const view = mgr.view(id)!;
+      expect(view).toContain('1 attachment(s)');
+    });
+
+    it('includes binding info in header', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: 'x' });
+      mgr.setBinding(id, { service: 'docs', resourceId: 'doc123', account: 'a@b.com' });
+      const view = mgr.view(id)!;
+      expect(view).toContain('bound: docs/doc123');
+    });
+  });
+
+  // ── 3. Line operations ─────────────────────────────────────
+
+  describe('insertLines()', () => {
+    it('inserts after a given line', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: 'a\nc' });
+      const result = mgr.insertLines(id, 1, 'b')!;
+      expect(result.message).toContain('Inserted 1 line(s)');
+      expect(mgr.getContent(id)).toBe('a\nb\nc');
+    });
+
+    it('prepends when afterLine=0', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: 'b\nc' });
+      mgr.insertLines(id, 0, 'a');
+      expect(mgr.getContent(id)).toBe('a\nb\nc');
+    });
+
+    it('inserts multi-line content', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: 'a\nd' });
+      mgr.insertLines(id, 1, 'b\nc');
+      expect(mgr.getContent(id)).toBe('a\nb\nc\nd');
+    });
+
+    it('returns error for afterLine out of range (negative)', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: 'a' });
+      const result = mgr.insertLines(id, -1, 'x')!;
+      expect(result.message).toContain('Error');
+      expect(result.message).toContain('out of range');
+    });
+
+    it('returns error for afterLine out of range (too high)', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: 'a' });
+      const result = mgr.insertLines(id, 5, 'x')!;
+      expect(result.message).toContain('Error');
+    });
+
+    it('returns null for unknown scratchpad', () => {
+      const mgr = createManager();
+      expect(mgr.insertLines('sp-nope', 0, 'x')).toBeNull();
+    });
+  });
+
+  describe('appendLines()', () => {
+    it('appends to the end of the buffer', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: 'a' });
+      const result = mgr.appendLines(id, 'b\nc')!;
+      expect(result.message).toContain('Appended 2 line(s)');
+      expect(mgr.getContent(id)).toBe('a\nb\nc');
+    });
+
+    it('appends to an empty buffer', () => {
+      const mgr = createManager();
+      const id = mgr.create();
+      mgr.appendLines(id, 'first');
+      expect(mgr.getContent(id)).toBe('first');
+    });
+
+    it('returns null for unknown scratchpad', () => {
+      const mgr = createManager();
+      expect(mgr.appendLines('sp-nope', 'x')).toBeNull();
+    });
+  });
+
+  describe('replaceLines()', () => {
+    it('replaces a single line', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: 'a\nb\nc' });
+      const result = mgr.replaceLines(id, 2, 2, 'B')!;
+      expect(result.message).toContain('Replaced lines 2-2');
+      expect(mgr.getContent(id)).toBe('a\nB\nc');
+    });
+
+    it('replaces a range with more lines', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: 'a\nb\nc' });
+      mgr.replaceLines(id, 2, 2, 'x\ny\nz');
+      expect(mgr.getContent(id)).toBe('a\nx\ny\nz\nc');
+    });
+
+    it('replaces a range with fewer lines', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: 'a\nb\nc\nd' });
+      mgr.replaceLines(id, 2, 3, 'X');
+      expect(mgr.getContent(id)).toBe('a\nX\nd');
+    });
+
+    it('returns error for startLine out of range', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: 'a' });
+      const result = mgr.replaceLines(id, 0, 1, 'x')!;
+      expect(result.message).toContain('Error');
+    });
+
+    it('returns error for endLine out of range', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: 'a\nb' });
+      const result = mgr.replaceLines(id, 1, 5, 'x')!;
+      expect(result.message).toContain('Error');
+    });
+
+    it('returns error when endLine < startLine', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: 'a\nb\nc' });
+      const result = mgr.replaceLines(id, 3, 1, 'x')!;
+      expect(result.message).toContain('Error');
+    });
+
+    it('returns null for unknown scratchpad', () => {
+      const mgr = createManager();
+      expect(mgr.replaceLines('sp-nope', 1, 1, 'x')).toBeNull();
+    });
+  });
+
+  describe('removeLines()', () => {
+    it('removes a single line', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: 'a\nb\nc' });
+      const result = mgr.removeLines(id, 2)!;
+      expect(result.message).toContain('Removed 1 line(s)');
+      expect(mgr.getContent(id)).toBe('a\nc');
+    });
+
+    it('removes a range of lines', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: 'a\nb\nc\nd' });
+      mgr.removeLines(id, 2, 3);
+      expect(mgr.getContent(id)).toBe('a\nd');
+    });
+
+    it('removes all lines', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: 'a\nb' });
+      mgr.removeLines(id, 1, 2);
+      expect(mgr.getContent(id)).toBe('');
+    });
+
+    it('returns error for startLine out of range', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: 'a' });
+      const result = mgr.removeLines(id, 0)!;
+      expect(result.message).toContain('Error');
+    });
+
+    it('returns error for endLine out of range', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: 'a\nb' });
+      const result = mgr.removeLines(id, 1, 5)!;
+      expect(result.message).toContain('Error');
+    });
+
+    it('returns context showing buffer now empty', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: 'only' });
+      const result = mgr.removeLines(id, 1)!;
+      expect(result.context).toContain('(buffer now empty)');
+    });
+
+    it('returns null for unknown scratchpad', () => {
+      const mgr = createManager();
+      expect(mgr.removeLines('sp-nope', 1)).toBeNull();
+    });
+  });
+
+  // ── 4. copyLines() ────────────────────────────────────────
+
+  describe('copyLines()', () => {
+    it('copies lines between scratchpads', () => {
+      const mgr = createManager();
+      const src = mgr.create({ content: 'alpha\nbeta\ngamma' });
+      const tgt = mgr.create({ content: 'one\ntwo' });
+      const result = mgr.copyLines(tgt, src, 1, 2, 1)!;
+      expect(result.message).toContain('Copied 2 line(s)');
+      expect(mgr.getContent(tgt)).toBe('one\nalpha\nbeta\ntwo');
+    });
+
+    it('does not modify the source scratchpad', () => {
+      const mgr = createManager();
+      const src = mgr.create({ content: 'a\nb\nc' });
+      const tgt = mgr.create();
+      mgr.copyLines(tgt, src, 1, 3, 0);
+      expect(mgr.getContent(src)).toBe('a\nb\nc');
+    });
+
+    it('returns error for invalid source range', () => {
+      const mgr = createManager();
+      const src = mgr.create({ content: 'a' });
+      const tgt = mgr.create();
+      const result = mgr.copyLines(tgt, src, 0, 1, 0)!;
+      expect(result.message).toContain('Error');
+    });
+
+    it('returns error for source endLine out of range', () => {
+      const mgr = createManager();
+      const src = mgr.create({ content: 'a' });
+      const tgt = mgr.create();
+      const result = mgr.copyLines(tgt, src, 1, 5, 0)!;
+      expect(result.message).toContain('Error');
+    });
+
+    it('returns error for target afterLine out of range', () => {
+      const mgr = createManager();
+      const src = mgr.create({ content: 'a' });
+      const tgt = mgr.create({ content: 'b' });
+      const result = mgr.copyLines(tgt, src, 1, 1, 99)!;
+      expect(result.message).toContain('Error');
+    });
+
+    it('returns error when source scratchpad does not exist', () => {
+      const mgr = createManager();
+      const tgt = mgr.create();
+      const result = mgr.copyLines(tgt, 'sp-nonexistent', 1, 1, 0)!;
+      expect(result.message).toContain('Error');
+      expect(result.message).toContain('not found');
+    });
+
+    it('returns null when target scratchpad does not exist', () => {
+      const mgr = createManager();
+      const src = mgr.create({ content: 'a' });
+      expect(mgr.copyLines('sp-nope', src, 1, 1, 0)).toBeNull();
+    });
+
+    it('copies to afterLine=0 (prepend)', () => {
+      const mgr = createManager();
+      const src = mgr.create({ content: 'x' });
+      const tgt = mgr.create({ content: 'y' });
+      mgr.copyLines(tgt, src, 1, 1, 0);
+      expect(mgr.getContent(tgt)).toBe('x\ny');
+    });
+  });
+
+  // ── 5. JSON path operations ────────────────────────────────
+
+  describe('jsonGet()', () => {
+    it('retrieves a value at a path', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: '{"a": {"b": 42}}', format: 'json' });
+      const result = mgr.jsonGet(id, '$.a.b')!;
+      expect('value' in result).toBe(true);
+      if ('value' in result) {
+        expect(result.value).toBe(42);
+      }
+    });
+
+    it('retrieves nested objects', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: '{"a": {"b": {"c": true}}}', format: 'json' });
+      const result = mgr.jsonGet(id, '$.a.b')!;
+      if ('value' in result) {
+        expect(result.value).toEqual({ c: true });
+      }
+    });
+
+    it('retrieves array elements', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: '{"items": [10, 20, 30]}', format: 'json' });
+      const result = mgr.jsonGet(id, '$.items[1]')!;
+      if ('value' in result) {
+        expect(result.value).toBe(20);
+      }
+    });
+
+    it('returns error for non-json format', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: 'hello', format: 'text' });
+      const result = mgr.jsonGet(id, '$.foo')!;
+      expect('error' in result).toBe(true);
+      if ('error' in result) {
+        expect(result.error).toContain('json');
+      }
+    });
+
+    it('returns error for invalid JSON in buffer', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: '{broken', format: 'json' });
+      const result = mgr.jsonGet(id, '$.foo')!;
+      expect('error' in result).toBe(true);
+      if ('error' in result) {
+        expect(result.error).toContain('not valid JSON');
+      }
+    });
+
+    it('returns error for bad path traversal', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: '{"a": 1}', format: 'json' });
+      const result = mgr.jsonGet(id, '$.a.b.c')!;
+      expect('error' in result).toBe(true);
+    });
+
+    it('returns null for unknown scratchpad', () => {
+      const mgr = createManager();
+      expect(mgr.jsonGet('sp-nope', '$.a')).toBeNull();
+    });
+  });
+
+  describe('jsonSet()', () => {
+    it('sets a value at a path', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: '{"a": 1}', format: 'json' });
+      const result = mgr.jsonSet(id, '$.a', 99)!;
+      expect(result.message).toContain('Set $.a');
+      const content = mgr.getContent(id)!;
+      expect(JSON.parse(content).a).toBe(99);
+    });
+
+    it('sets a nested value', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: '{"a": {"b": 1}}', format: 'json' });
+      mgr.jsonSet(id, '$.a.b', 'new');
+      expect(JSON.parse(mgr.getContent(id)!).a.b).toBe('new');
+    });
+
+    it('returns error for non-json format', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: 'hello', format: 'text' });
+      const result = mgr.jsonSet(id, '$.a', 1)!;
+      expect(result.message).toContain('Error');
+    });
+
+    it('returns error for invalid JSON in buffer', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: '{bad', format: 'json' });
+      const result = mgr.jsonSet(id, '$.a', 1)!;
+      expect(result.message).toContain('Error');
+    });
+
+    it('returns null for unknown scratchpad', () => {
+      const mgr = createManager();
+      expect(mgr.jsonSet('sp-nope', '$.a', 1)).toBeNull();
+    });
+  });
+
+  describe('jsonDelete()', () => {
+    it('deletes a key from an object', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: '{"a": 1, "b": 2}', format: 'json' });
+      const result = mgr.jsonDelete(id, '$.a')!;
+      expect(result.message).toContain('Deleted $.a');
+      const parsed = JSON.parse(mgr.getContent(id)!);
+      expect(parsed.a).toBeUndefined();
+      expect(parsed.b).toBe(2);
+    });
+
+    it('deletes an array element by index', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: '{"items": [1, 2, 3]}', format: 'json' });
+      mgr.jsonDelete(id, '$.items[1]');
+      expect(JSON.parse(mgr.getContent(id)!).items).toEqual([1, 3]);
+    });
+
+    it('returns error for non-json format', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: 'x', format: 'text' });
+      const result = mgr.jsonDelete(id, '$.a')!;
+      expect(result.message).toContain('Error');
+    });
+
+    it('returns error for invalid JSON in buffer', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: '{bad', format: 'json' });
+      const result = mgr.jsonDelete(id, '$.a')!;
+      expect(result.message).toContain('Error');
+    });
+
+    it('returns null for unknown scratchpad', () => {
+      const mgr = createManager();
+      expect(mgr.jsonDelete('sp-nope', '$.a')).toBeNull();
+    });
+  });
+
+  describe('jsonInsert()', () => {
+    it('pushes a value into an array', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: '{"items": [1, 2]}', format: 'json' });
+      const result = mgr.jsonInsert(id, '$.items', 3)!;
+      expect(result.message).toContain('Inserted into $.items');
+      expect(JSON.parse(mgr.getContent(id)!).items).toEqual([1, 2, 3]);
+    });
+
+    it('returns error when target is not an array', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: '{"a": "string"}', format: 'json' });
+      const result = mgr.jsonInsert(id, '$.a', 'val')!;
+      expect(result.message).toContain('not an array');
+    });
+
+    it('returns error for non-json format', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: 'x', format: 'text' });
+      const result = mgr.jsonInsert(id, '$.a', 1)!;
+      expect(result.message).toContain('Error');
+    });
+
+    it('returns error for invalid JSON in buffer', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: '{bad', format: 'json' });
+      const result = mgr.jsonInsert(id, '$.a', 1)!;
+      expect(result.message).toContain('Error');
+    });
+
+    it('returns error for bad path', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: '{"a": 1}', format: 'json' });
+      const result = mgr.jsonInsert(id, '$.a.b.c', 1)!;
+      expect(result.message).toContain('Error');
+    });
+
+    it('returns null for unknown scratchpad', () => {
+      const mgr = createManager();
+      expect(mgr.jsonInsert('sp-nope', '$.a', 1)).toBeNull();
+    });
+  });
+
+  // ── 6. Attachments ─────────────────────────────────────────
+
+  describe('attach()', () => {
+    const sampleRef = {
+      source: 'drive' as const,
+      filename: 'report.pdf',
+      mimeType: 'application/pdf',
+      size: 2048,
+      location: 'drive://abc123',
+    };
+
+    it('attaches a file and inserts a marker line at the end', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: 'hello' });
+      const result = mgr.attach(id, sampleRef)!;
+      expect(result.refId).toBe('att-1');
+      expect(result.message).toContain('report.pdf');
+      expect(result.message).toContain('att-1');
+      // Marker inserted at end (line 2)
+      const sp = mgr.get(id)!;
+      expect(sp.lines.length).toBe(2);
+      expect(sp.lines[1]).toContain('att:att-1');
+    });
+
+    it('attaches a file after a specific line', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: 'a\nb' });
+      mgr.attach(id, sampleRef, 1);
+      const sp = mgr.get(id)!;
+      expect(sp.lines.length).toBe(3);
+      // Marker inserted between a and b
+      expect(sp.lines[0]).toBe('a');
+      expect(sp.lines[1]).toContain('report.pdf');
+      expect(sp.lines[2]).toBe('b');
+    });
+
+    it('formats size in the marker (KB)', () => {
+      const mgr = createManager();
+      const id = mgr.create();
+      mgr.attach(id, { ...sampleRef, size: 2048 });
+      const sp = mgr.get(id)!;
+      expect(sp.lines[0]).toContain('2.0 KB');
+    });
+
+    it('formats size in the marker (MB)', () => {
+      const mgr = createManager();
+      const id = mgr.create();
+      mgr.attach(id, { ...sampleRef, size: 5 * 1024 * 1024 });
+      const sp = mgr.get(id)!;
+      expect(sp.lines[0]).toContain('5.0 MB');
+    });
+
+    it('formats size in bytes for small files', () => {
+      const mgr = createManager();
+      const id = mgr.create();
+      mgr.attach(id, { ...sampleRef, size: 500 });
+      const sp = mgr.get(id)!;
+      expect(sp.lines[0]).toContain('500 B');
+    });
+
+    it('increments refId for multiple attachments', () => {
+      const mgr = createManager();
+      const id = mgr.create();
+      const r1 = mgr.attach(id, sampleRef)!;
+      const r2 = mgr.attach(id, { ...sampleRef, filename: 'second.pdf' })!;
+      expect(r1.refId).toBe('att-1');
+      expect(r2.refId).toBe('att-2');
+    });
+
+    it('returns null for unknown scratchpad', () => {
+      const mgr = createManager();
+      expect(mgr.attach('sp-nope', sampleRef)).toBeNull();
+    });
+  });
+
+  describe('detach()', () => {
+    it('removes attachment from side-table but leaves marker', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: 'hello' });
+      mgr.attach(id, {
+        source: 'drive',
+        filename: 'file.pdf',
+        mimeType: 'application/pdf',
+        size: 100,
+        location: 'x',
+      });
+      const result = mgr.detach(id, 'att-1')!;
+      expect(result).toContain('Detached');
+      expect(result).toContain('file.pdf');
+      // Marker line still in buffer
+      expect(mgr.get(id)!.lines.length).toBe(2);
+      // But attachment removed from map
+      expect(mgr.getAttachments(id)!.size).toBe(0);
+    });
+
+    it('returns error when refId not found', () => {
+      const mgr = createManager();
+      const id = mgr.create();
+      const result = mgr.detach(id, 'att-999')!;
+      expect(result).toContain('Error');
+    });
+
+    it('returns null for unknown scratchpad', () => {
+      const mgr = createManager();
+      expect(mgr.detach('sp-nope', 'att-1')).toBeNull();
+    });
+  });
+
+  describe('getAttachments()', () => {
+    it('returns attachment map', () => {
+      const mgr = createManager();
+      const id = mgr.create();
+      mgr.attach(id, {
+        source: 'workspace',
+        filename: 'a.txt',
+        mimeType: 'text/plain',
+        size: 10,
+        location: '/a.txt',
+      });
+      const atts = mgr.getAttachments(id)!;
+      expect(atts.size).toBe(1);
+      expect(atts.get('att-1')!.filename).toBe('a.txt');
+    });
+
+    it('returns null for unknown scratchpad', () => {
+      const mgr = createManager();
+      expect(mgr.getAttachments('sp-nope')).toBeNull();
+    });
+  });
+
+  // ── 7. Live binding ────────────────────────────────────────
+
+  describe('setBinding() / getBinding()', () => {
+    const binding: LiveBinding = {
+      service: 'docs',
+      resourceId: 'doc-abc',
+      account: 'user@example.com',
+    };
+
+    it('sets and retrieves a binding', () => {
+      const mgr = createManager();
+      const id = mgr.create();
+      expect(mgr.setBinding(id, binding)).toBe(true);
+      expect(mgr.getBinding(id)).toEqual(binding);
+    });
+
+    it('returns false for setBinding on unknown scratchpad', () => {
+      const mgr = createManager();
+      expect(mgr.setBinding('sp-nope', binding)).toBe(false);
+    });
+
+    it('returns undefined for getBinding on unknown scratchpad', () => {
+      const mgr = createManager();
+      expect(mgr.getBinding('sp-nope')).toBeUndefined();
+    });
+
+    it('returns undefined when no binding is set', () => {
+      const mgr = createManager();
+      const id = mgr.create();
+      expect(mgr.getBinding(id)).toBeUndefined();
+    });
+  });
+
+  // ── 8. Format validation ──────────────────────────────────
+
+  describe('format validation', () => {
+    it('text format is always valid', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: 'anything goes {{{{', format: 'text' });
+      const view = mgr.view(id)!;
+      expect(view).toContain('Status: valid');
+    });
+
+    it('empty buffer shows status empty', () => {
+      const mgr = createManager();
+      const id = mgr.create({ format: 'json' });
+      const view = mgr.view(id)!;
+      expect(view).toContain('Status: empty');
+    });
+
+    it('markdown detects unclosed code fence', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: '# Title\n```js\ncode', format: 'markdown' });
+      const view = mgr.view(id)!;
+      expect(view).toContain('Status: invalid');
+      expect(view).toContain('unclosed code fence');
+    });
+
+    it('markdown is valid with matched fences', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: '```\ncode\n```', format: 'markdown' });
+      const view = mgr.view(id)!;
+      expect(view).toContain('Status: valid');
+    });
+
+    it('json shows parse error with line info', () => {
+      const mgr = createManager();
+      // Missing closing brace — error at some position
+      const id = mgr.create({ content: '{\n  "a": 1,\n  "b":\n}', format: 'json' });
+      const view = mgr.view(id)!;
+      expect(view).toContain('Status: invalid');
+    });
+
+    it('json is valid for correct JSON', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: '{"a": 1}', format: 'json' });
+      const view = mgr.view(id)!;
+      expect(view).toContain('Status: valid');
+    });
+
+    it('csv detects column inconsistency', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: 'a,b,c\n1,2\n3,4,5', format: 'csv' });
+      const view = mgr.view(id)!;
+      expect(view).toContain('Status: invalid');
+      expect(view).toContain('expected 3 columns, got 2');
+    });
+
+    it('csv is valid with consistent columns', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: 'a,b,c\n1,2,3\n4,5,6', format: 'csv' });
+      const view = mgr.view(id)!;
+      expect(view).toContain('Status: valid');
+      expect(view).toContain('3 columns');
+    });
+
+    it('csv handles quoted fields with commas', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: 'name,value\n"Smith, John",42', format: 'csv' });
+      const view = mgr.view(id)!;
+      expect(view).toContain('Status: valid');
+      expect(view).toContain('2 columns');
+    });
+  });
+
+  // ── 9. Epoch-based GC ─────────────────────────────────────
+
+  describe('epoch-based garbage collection', () => {
+    it('scratchpad is accessible when epoch is within range', () => {
+      const mgr = createManager();
+      mockEpoch = 10;
+      const id = mgr.create();
+      mockEpoch = 110; // 100 epochs later — exactly at boundary
+      expect(mgr.get(id)).not.toBeNull();
+    });
+
+    it('scratchpad expires after 100 epochs without touch', () => {
+      const mgr = createManager();
+      mockEpoch = 0;
+      const id = mgr.create();
+      mockEpoch = 101; // 101 > 100, expired
+      expect(mgr.get(id)).toBeNull();
+    });
+
+    it('touching a scratchpad resets its epoch', () => {
+      const mgr = createManager();
+      mockEpoch = 0;
+      const id = mgr.create({ content: 'data' });
+      mockEpoch = 50;
+      mgr.view(id); // touches it, resetting to epoch 50
+      mockEpoch = 150; // 100 from creation, but only 100 from touch — at boundary
+      expect(mgr.get(id)).not.toBeNull();
+      mockEpoch = 151; // now expired
+      expect(mgr.get(id)).toBeNull();
+    });
+
+    it('gc runs during create() and removes expired pads', () => {
+      const mgr = createManager();
+      mockEpoch = 0;
+      const old = mgr.create({ label: 'old' });
+      mockEpoch = 200;
+      mgr.create({ label: 'new' }); // triggers gc
+      expect(mgr.get(old)).toBeNull();
+    });
+
+    it('gc runs during list() and removes expired pads', () => {
+      const mgr = createManager();
+      mockEpoch = 0;
+      mgr.create({ label: 'old' });
+      mockEpoch = 200;
+      const items = mgr.list();
+      expect(items.length).toBe(0);
+    });
+
+    it('mutation operations touch the scratchpad', () => {
+      const mgr = createManager();
+      mockEpoch = 0;
+      const id = mgr.create({ content: 'a' });
+      mockEpoch = 50;
+      mgr.appendLines(id, 'b'); // touch at 50
+      mockEpoch = 150;
+      expect(mgr.get(id)).not.toBeNull(); // 150 - 50 = 100, at boundary
+      mockEpoch = 151;
+      expect(mgr.get(id)).toBeNull();
+    });
+  });
+
+  // ── 10. Mutation response format ──────────────────────────
+
+  describe('mutation response format', () => {
+    it('includes context markers showing affected lines', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: 'a\nb\nc\nd\ne' });
+      const result = mgr.insertLines(id, 2, 'x')!;
+      // Context should show surrounding lines
+      expect(result.context).toBeTruthy();
+      expect(result.context).toContain('x');
+    });
+
+    it('includes validation status in every mutation result', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: '{"a": 1}', format: 'json' });
+      const result = mgr.appendLines(id, '"b": 2}')!;
+      expect(result.validation).toBeTruthy();
+      // After appending broken JSON, validation should flag it
+      expect(result.validation).toContain('Status:');
+    });
+
+    it('context elides middle for large insertions', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: 'before\nafter' });
+      const result = mgr.insertLines(id, 1, 'x\ny\nz')!;
+      // 3 affected lines — the middle should be elided (> 2 affected)
+      expect(result.context).toContain('...');
+    });
+
+    it('context shows one line before and after', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: 'before\nold\nafter' });
+      const result = mgr.replaceLines(id, 2, 2, 'new')!;
+      expect(result.context).toContain('before');
+      expect(result.context).toContain('new');
+      expect(result.context).toContain('after');
+    });
+  });
+
+  // ── 11. CRLF normalization ─────────────────────────────────
+
+  describe('CRLF normalization', () => {
+    it('normalizes CRLF to LF on create', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: 'line1\r\nline2\r\nline3' });
+      expect(mgr.get(id)!.lines).toEqual(['line1', 'line2', 'line3']);
+    });
+
+    it('normalizes CR to LF on create', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: 'line1\rline2' });
+      expect(mgr.get(id)!.lines).toEqual(['line1', 'line2']);
+    });
+
+    it('normalizes CRLF on insertLines', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: 'a' });
+      mgr.insertLines(id, 1, 'b\r\nc');
+      expect(mgr.getContent(id)).toBe('a\nb\nc');
+    });
+
+    it('normalizes CRLF on appendLines', () => {
+      const mgr = createManager();
+      const id = mgr.create();
+      mgr.appendLines(id, 'x\r\ny');
+      expect(mgr.getContent(id)).toBe('x\ny');
+    });
+
+    it('normalizes CRLF on replaceLines', () => {
+      const mgr = createManager();
+      const id = mgr.create({ content: 'a\nb' });
+      mgr.replaceLines(id, 1, 1, 'x\r\ny');
+      expect(mgr.getContent(id)).toBe('x\ny\nb');
+    });
+  });
+
+  // ── 12. discard() and list() lifecycle ─────────────────────
+
+  describe('discard() and list()', () => {
+    it('discard removes a scratchpad', () => {
+      const mgr = createManager();
+      const id = mgr.create();
+      expect(mgr.discard(id)).toBe(true);
+      expect(mgr.get(id)).toBeNull();
+    });
+
+    it('discard returns false for unknown id', () => {
+      const mgr = createManager();
+      expect(mgr.discard('sp-nonexistent')).toBe(false);
+    });
+
+    it('list returns summaries of all active scratchpads', () => {
+      const mgr = createManager();
+      mgr.create({ label: 'first', content: 'a\nb', format: 'text' });
+      mgr.create({ label: 'second', format: 'json' });
+      const items = mgr.list();
+      expect(items.length).toBe(2);
+      expect(items[0].label).toBe('first');
+      expect(items[0].lineCount).toBe(2);
+      expect(items[0].format).toBe('text');
+      expect(items[0].bound).toBe(false);
+      expect(items[1].label).toBe('second');
+      expect(items[1].lineCount).toBe(0);
+    });
+
+    it('list excludes discarded scratchpads', () => {
+      const mgr = createManager();
+      const id1 = mgr.create({ label: 'keep' });
+      const id2 = mgr.create({ label: 'drop' });
+      mgr.discard(id2);
+      const items = mgr.list();
+      expect(items.length).toBe(1);
+      expect(items[0].label).toBe('keep');
+    });
+
+    it('list includes validation status', () => {
+      const mgr = createManager();
+      mgr.create({ content: '{"a": 1}', format: 'json' });
+      const items = mgr.list();
+      expect(items[0].validation).toContain('Status: valid');
+    });
+
+    it('list includes attachment count', () => {
+      const mgr = createManager();
+      const id = mgr.create();
+      mgr.attach(id, {
+        source: 'drive',
+        filename: 'f.txt',
+        mimeType: 'text/plain',
+        size: 10,
+        location: 'x',
+      });
+      const items = mgr.list();
+      expect(items[0].attachmentCount).toBe(1);
+    });
+
+    it('list shows bound status', () => {
+      const mgr = createManager();
+      const id = mgr.create();
+      mgr.setBinding(id, { service: 'sheets', resourceId: 's1', account: 'a@b.com' });
+      const items = mgr.list();
+      expect(items[0].bound).toBe(true);
+    });
+  });
+});

--- a/src/server/scratchpad/__tests__/validate.test.ts
+++ b/src/server/scratchpad/__tests__/validate.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for validate.ts — format-specific content validation.
+ */
+
+import { validate } from '../validate.js';
+
+describe('validate', () => {
+  describe('text format', () => {
+    it('always returns valid with line count', () => {
+      expect(validate(['hello', 'world'], 'text')).toBe('Status: valid (2 lines)');
+    });
+
+    it('is valid for a single line', () => {
+      expect(validate(['one'], 'text')).toBe('Status: valid (1 lines)');
+    });
+  });
+
+  describe('empty content', () => {
+    it('returns Status: empty for all formats', () => {
+      for (const fmt of ['text', 'markdown', 'json', 'csv'] as const) {
+        expect(validate([], fmt)).toBe('Status: empty');
+      }
+    });
+  });
+
+  describe('markdown format', () => {
+    it('is valid with matched code fences', () => {
+      const lines = ['# Title', '```js', 'const x = 1;', '```', 'Done'];
+      expect(validate(lines, 'markdown')).toBe('Status: valid (5 lines)');
+    });
+
+    it('is valid with multiple fence pairs', () => {
+      const lines = ['```', 'a', '```', '```', 'b', '```'];
+      expect(validate(lines, 'markdown')).toBe('Status: valid (6 lines)');
+    });
+
+    it('is invalid with unclosed code fence', () => {
+      const lines = ['Some text', '```python', 'print("hi")', 'more text'];
+      const result = validate(lines, 'markdown');
+      expect(result).toContain('invalid');
+      expect(result).toContain('unclosed code fence');
+    });
+
+    it('reports the line number of the unclosed fence', () => {
+      const lines = ['line 1', '```', 'inside'];
+      // The fence is on line index 1, reported as line 2 (1-indexed)
+      expect(validate(lines, 'markdown')).toBe('Status: invalid at line 2 — unclosed code fence');
+    });
+
+    it('is valid with no fences', () => {
+      const lines = ['# Just a heading', 'Some paragraph text'];
+      expect(validate(lines, 'markdown')).toBe('Status: valid (2 lines)');
+    });
+
+    it('handles indented code fences', () => {
+      const lines = ['  ```', 'code', '  ```'];
+      expect(validate(lines, 'markdown')).toBe('Status: valid (3 lines)');
+    });
+  });
+
+  describe('json format', () => {
+    it('is valid for valid JSON', () => {
+      const lines = ['{', '  "key": "value"', '}'];
+      expect(validate(lines, 'json')).toBe('Status: valid (3 lines)');
+    });
+
+    it('is valid for JSON array', () => {
+      const lines = ['[1, 2, 3]'];
+      expect(validate(lines, 'json')).toBe('Status: valid (1 lines)');
+    });
+
+    it('is invalid for malformed JSON', () => {
+      const lines = ['{ "a": 1,', '"b": }'];
+      const result = validate(lines, 'json');
+      expect(result).toContain('invalid');
+    });
+
+    it('is invalid for completely broken JSON', () => {
+      const lines = ['not json at all'];
+      const result = validate(lines, 'json');
+      expect(result).toContain('invalid');
+    });
+
+    it('is valid for simple primitives', () => {
+      expect(validate(['"hello"'], 'json')).toBe('Status: valid (1 lines)');
+      expect(validate(['42'], 'json')).toBe('Status: valid (1 lines)');
+      expect(validate(['true'], 'json')).toBe('Status: valid (1 lines)');
+      expect(validate(['null'], 'json')).toBe('Status: valid (1 lines)');
+    });
+  });
+
+  describe('csv format', () => {
+    it('is valid with consistent column count', () => {
+      const lines = ['name,age,email', 'Alice,30,a@b.com', 'Bob,25,b@c.com'];
+      expect(validate(lines, 'csv')).toBe('Status: valid (3 lines, 3 columns)');
+    });
+
+    it('is invalid with mismatched column count', () => {
+      const lines = ['a,b,c', 'x,y'];
+      const result = validate(lines, 'csv');
+      expect(result).toContain('invalid');
+      expect(result).toContain('expected 3 columns, got 2');
+    });
+
+    it('handles quoted fields with commas', () => {
+      const lines = ['"name","address"', '"Alice","123 Main, Apt 4"'];
+      // Both rows have 2 columns despite the comma inside quotes
+      expect(validate(lines, 'csv')).toBe('Status: valid (2 lines, 2 columns)');
+    });
+
+    it('reports the correct line number for mismatches', () => {
+      const lines = ['a,b', 'x,y', 'only_one'];
+      const result = validate(lines, 'csv');
+      expect(result).toContain('line 3');
+      expect(result).toContain('expected 2 columns, got 1');
+    });
+
+    it('is valid for single-column CSV', () => {
+      const lines = ['header', 'row1', 'row2'];
+      expect(validate(lines, 'csv')).toBe('Status: valid (3 lines, 1 columns)');
+    });
+
+    it('skips blank lines when checking columns', () => {
+      const lines = ['a,b', '', 'x,y'];
+      expect(validate(lines, 'csv')).toBe('Status: valid (3 lines, 2 columns)');
+    });
+
+    it('is valid when all lines are blank', () => {
+      const lines = ['', '  ', ''];
+      expect(validate(lines, 'csv')).toBe('Status: valid (3 lines)');
+    });
+  });
+});

--- a/src/server/scratchpad/adapters/import-doc.ts
+++ b/src/server/scratchpad/adapters/import-doc.ts
@@ -135,15 +135,16 @@ async function stripBase64Images(
   for (let i = 0; i < matches.length; i++) {
     const { full, alt, mimeType, data } = matches[i];
     const ext = mimeType.split('/')[1] ?? 'png';
-    const filename = `image-${i + 1}.${ext}`;
+    const shortId = scratchpadId.replace('sp-', '');
+    const filename = `${shortId}-image-${i + 1}.${ext}`;
 
     // Decode and write to workspace
     const buffer = Buffer.from(data.replace(/\s/g, ''), 'base64');
     const filePath = resolveWorkspacePath(filename);
     await fs.writeFile(filePath, buffer);
 
-    // Register in side-table with real size and location
-    scratchpads.attach(scratchpadId, {
+    // Register in side-table — use returned refId to avoid mismatch
+    const attachResult = scratchpads.attach(scratchpadId, {
       source: 'import',
       filename,
       mimeType,
@@ -151,7 +152,7 @@ async function stripBase64Images(
       location: filePath,
     });
 
-    const refId = `att-${i + 1}`;
+    const refId = attachResult?.refId ?? `att-${i + 1}`;
     cleaned = cleaned.replace(full, `![${alt}](att:${refId} "${filename}, ${formatBytes(buffer.length)}, from import")`);
   }
 

--- a/src/server/scratchpad/adapters/import-doc.ts
+++ b/src/server/scratchpad/adapters/import-doc.ts
@@ -1,0 +1,143 @@
+/**
+ * Import adapter: doc — loads a Google Doc into a scratchpad.
+ *
+ * Two modes:
+ * - markdown (default): exports as markdown, strips base64 images to attachments
+ * - json: loads native Docs API JSON, sets live binding for round-trip editing
+ */
+
+import { execute } from '../../../executor/gws.js';
+import type { HandlerResponse } from '../../handler.js';
+import type { ScratchpadManager } from '../manager.js';
+
+interface DocImportParams {
+  email: string;
+  documentId: string;
+  mode?: 'markdown' | 'json';
+}
+
+export async function importDoc(
+  scratchpads: ScratchpadManager,
+  scratchpadId: string,
+  sourceParams: DocImportParams,
+): Promise<HandlerResponse> {
+  const { email, documentId, mode = 'markdown' } = sourceParams;
+  if (!email || !documentId) {
+    return { text: 'email and documentId are required for doc import.', refs: { error: true } };
+  }
+
+  if (mode === 'json') {
+    return importDocJson(scratchpads, scratchpadId, email, documentId);
+  }
+
+  return importDocMarkdown(scratchpads, scratchpadId, email, documentId);
+}
+
+async function importDocMarkdown(
+  scratchpads: ScratchpadManager,
+  scratchpadId: string,
+  email: string,
+  documentId: string,
+): Promise<HandlerResponse> {
+  try {
+    // Export as markdown via gws docs export
+    const result = await execute([
+      'docs', '+export',
+      '--document', documentId,
+      '--mime', 'text/markdown',
+    ], { account: email });
+
+    const markdown = typeof result.data === 'string' ? result.data : JSON.stringify(result.data);
+
+    // Strip base64 data URIs and register as attachment references
+    const { cleanedLines, attachmentCount } = stripBase64Images(markdown, scratchpads, scratchpadId);
+
+    scratchpads.appendRawLines(scratchpadId, cleanedLines);
+    scratchpads.setFormat(scratchpadId, 'markdown');
+
+    const attNote = attachmentCount > 0 ? ` (${attachmentCount} embedded image(s) extracted as attachments)` : '';
+    return {
+      text: `Imported doc as markdown (${cleanedLines.length} lines) into scratchpad ${scratchpadId}.${attNote}`,
+      refs: { scratchpadId, documentId, format: 'markdown', linesImported: cleanedLines.length },
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      text: `Import failed: ${message}`,
+      refs: { error: true, scratchpadId },
+    };
+  }
+}
+
+async function importDocJson(
+  scratchpads: ScratchpadManager,
+  scratchpadId: string,
+  email: string,
+  documentId: string,
+): Promise<HandlerResponse> {
+  try {
+    const result = await execute([
+      'docs', 'documents', 'get',
+      '--params', JSON.stringify({ documentId }),
+    ], { account: email });
+
+    const json = JSON.stringify(result.data, null, 2);
+    const lines = json.split('\n');
+
+    scratchpads.appendRawLines(scratchpadId, lines);
+    scratchpads.setFormat(scratchpadId, 'json');
+    scratchpads.setBinding(scratchpadId, {
+      service: 'docs',
+      resourceId: documentId,
+      account: email,
+    });
+
+    return {
+      text: `Imported doc as JSON (${lines.length} lines) into scratchpad ${scratchpadId}.\nLive-bound to docs/${documentId} — json_set mutations will apply directly.`,
+      refs: { scratchpadId, documentId, format: 'json', linesImported: lines.length, bound: true },
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      text: `Import failed: ${message}`,
+      refs: { error: true, scratchpadId },
+    };
+  }
+}
+
+/**
+ * Strip base64 data URIs from markdown and replace with attachment markers.
+ * Registers each extracted image in the scratchpad attachment side-table.
+ */
+function stripBase64Images(
+  markdown: string,
+  scratchpads: ScratchpadManager,
+  scratchpadId: string,
+): { cleanedLines: string[]; attachmentCount: number } {
+  let attachmentCount = 0;
+
+  // Match ![alt](data:image/...;base64,...) patterns
+  const cleaned = markdown.replace(
+    /!\[([^\]]*)\]\(data:(image\/[^;]+);base64,[A-Za-z0-9+/=\s]+\)/g,
+    (_match, alt: string, mimeType: string) => {
+      attachmentCount++;
+      const refId = `att-${attachmentCount}`;
+      const filename = `image-${attachmentCount}.${mimeType.split('/')[1] ?? 'png'}`;
+
+      // Register in side-table (location is empty — image was inline, not on disk)
+      // TODO: Write base64 data to workspace file and set location
+      scratchpads.attach(scratchpadId, {
+        source: 'import',
+        filename,
+        mimeType,
+        size: 0, // Unknown until extracted to file
+        location: '',
+      });
+
+      // Return the marker (attach() also inserts a marker line, so we return just the alt ref)
+      return `![${alt}](att:${refId} "${filename}, from import")`;
+    },
+  );
+
+  return { cleanedLines: cleaned.split('\n'), attachmentCount };
+}

--- a/src/server/scratchpad/adapters/import-doc.ts
+++ b/src/server/scratchpad/adapters/import-doc.ts
@@ -6,7 +6,10 @@
  * - json: loads native Docs API JSON, sets live binding for round-trip editing
  */
 
+import * as fs from 'node:fs/promises';
 import { execute } from '../../../executor/gws.js';
+import { resolveWorkspacePath } from '../../../executor/workspace.js';
+import { ensureWorkspaceDir } from '../../../executor/workspace.js';
 import type { HandlerResponse } from '../../handler.js';
 import type { ScratchpadManager } from '../manager.js';
 
@@ -49,8 +52,8 @@ async function importDocMarkdown(
 
     const markdown = typeof result.data === 'string' ? result.data : JSON.stringify(result.data);
 
-    // Strip base64 data URIs and register as attachment references
-    const { cleanedLines, attachmentCount } = stripBase64Images(markdown, scratchpads, scratchpadId);
+    // Strip base64 data URIs, save to workspace, register as attachments
+    const { cleanedLines, attachmentCount } = await stripBase64Images(markdown, scratchpads, scratchpadId);
 
     scratchpads.appendRawLines(scratchpadId, cleanedLines);
     scratchpads.setFormat(scratchpadId, 'markdown');
@@ -106,38 +109,57 @@ async function importDocJson(
 }
 
 /**
- * Strip base64 data URIs from markdown and replace with attachment markers.
- * Registers each extracted image in the scratchpad attachment side-table.
+ * Strip base64 data URIs from markdown, save images to workspace,
+ * and register as attachments in the scratchpad side-table.
  */
-function stripBase64Images(
+async function stripBase64Images(
   markdown: string,
   scratchpads: ScratchpadManager,
   scratchpadId: string,
-): { cleanedLines: string[]; attachmentCount: number } {
-  let attachmentCount = 0;
+): Promise<{ cleanedLines: string[]; attachmentCount: number }> {
+  // Collect all matches first (can't use async in replace callback)
+  const pattern = /!\[([^\]]*)\]\(data:(image\/[^;]+);base64,([A-Za-z0-9+/=\s]+)\)/g;
+  const matches: Array<{ full: string; alt: string; mimeType: string; data: string }> = [];
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(markdown)) !== null) {
+    matches.push({ full: match[0], alt: match[1], mimeType: match[2], data: match[3] });
+  }
 
-  // Match ![alt](data:image/...;base64,...) patterns
-  const cleaned = markdown.replace(
-    /!\[([^\]]*)\]\(data:(image\/[^;]+);base64,[A-Za-z0-9+/=\s]+\)/g,
-    (_match, alt: string, mimeType: string) => {
-      attachmentCount++;
-      const refId = `att-${attachmentCount}`;
-      const filename = `image-${attachmentCount}.${mimeType.split('/')[1] ?? 'png'}`;
+  if (matches.length === 0) {
+    return { cleanedLines: markdown.split('\n'), attachmentCount: 0 };
+  }
 
-      // Register in side-table (location is empty — image was inline, not on disk)
-      // TODO: Write base64 data to workspace file and set location
-      scratchpads.attach(scratchpadId, {
-        source: 'import',
-        filename,
-        mimeType,
-        size: 0, // Unknown until extracted to file
-        location: '',
-      });
+  await ensureWorkspaceDir();
+  let cleaned = markdown;
 
-      // Return the marker (attach() also inserts a marker line, so we return just the alt ref)
-      return `![${alt}](att:${refId} "${filename}, from import")`;
-    },
-  );
+  for (let i = 0; i < matches.length; i++) {
+    const { full, alt, mimeType, data } = matches[i];
+    const ext = mimeType.split('/')[1] ?? 'png';
+    const filename = `image-${i + 1}.${ext}`;
 
-  return { cleanedLines: cleaned.split('\n'), attachmentCount };
+    // Decode and write to workspace
+    const buffer = Buffer.from(data.replace(/\s/g, ''), 'base64');
+    const filePath = resolveWorkspacePath(filename);
+    await fs.writeFile(filePath, buffer);
+
+    // Register in side-table with real size and location
+    scratchpads.attach(scratchpadId, {
+      source: 'import',
+      filename,
+      mimeType,
+      size: buffer.length,
+      location: filePath,
+    });
+
+    const refId = `att-${i + 1}`;
+    cleaned = cleaned.replace(full, `![${alt}](att:${refId} "${filename}, ${formatBytes(buffer.length)}, from import")`);
+  }
+
+  return { cleanedLines: cleaned.split('\n'), attachmentCount: matches.length };
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }

--- a/src/server/scratchpad/adapters/import-drive.ts
+++ b/src/server/scratchpad/adapters/import-drive.ts
@@ -1,0 +1,71 @@
+/**
+ * Import adapter: drive_file — loads text content from a Drive file into a scratchpad.
+ * Only supports text-based files. Binary files return an error with guidance.
+ */
+
+import * as fs from 'node:fs/promises';
+import { execute } from '../../../executor/gws.js';
+import { ensureWorkspaceDir, resolveWorkspacePath } from '../../../executor/workspace.js';
+import type { HandlerResponse } from '../../handler.js';
+import type { ScratchpadManager } from '../manager.js';
+
+const TEXT_MIME_PREFIXES = ['text/', 'application/json', 'application/xml', 'application/x-yaml'];
+
+interface DriveImportParams {
+  email: string;
+  fileId: string;
+}
+
+export async function importDriveFile(
+  scratchpads: ScratchpadManager,
+  scratchpadId: string,
+  sourceParams: DriveImportParams,
+): Promise<HandlerResponse> {
+  const { email, fileId } = sourceParams;
+  if (!email || !fileId) {
+    return { text: 'email and fileId are required for drive_file import.', refs: { error: true } };
+  }
+
+  try {
+    // Get file metadata to check type
+    const metaResult = await execute([
+      'drive', 'files', 'get',
+      '--params', JSON.stringify({ fileId, fields: 'id,name,mimeType,size' }),
+    ], { account: email });
+
+    const meta = metaResult.data as Record<string, unknown>;
+    const mimeType = String(meta.mimeType ?? '');
+    const name = String(meta.name ?? fileId);
+
+    const isText = TEXT_MIME_PREFIXES.some(p => mimeType.startsWith(p));
+    if (!isText) {
+      return {
+        text: `File "${name}" is ${mimeType} — not a text format.\nUse manage_drive download to get the file, then attach it to the scratchpad instead.`,
+        refs: { error: true, scratchpadId, fileId, mimeType },
+      };
+    }
+
+    // Download to workspace, then read
+    await ensureWorkspaceDir();
+    await execute([
+      'drive', '+download', '--file-id', fileId,
+    ], { account: email });
+
+    const filePath = resolveWorkspacePath(name);
+    const content = await fs.readFile(filePath, 'utf-8');
+    const lines = content.split('\n');
+
+    scratchpads.appendRawLines(scratchpadId, lines);
+
+    return {
+      text: `Imported "${name}" (${lines.length} lines) into scratchpad ${scratchpadId}.`,
+      refs: { scratchpadId, fileId, filename: name, linesImported: lines.length },
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      text: `Import failed: ${message}`,
+      refs: { error: true, scratchpadId },
+    };
+  }
+}

--- a/src/server/scratchpad/adapters/import-email.ts
+++ b/src/server/scratchpad/adapters/import-email.ts
@@ -1,16 +1,19 @@
 /**
  * Import adapter: email — loads email body text into a scratchpad.
- * Extracts plain text body (or strips HTML as fallback).
+ * Extracts plain text body and registers file attachments in the side-table.
  */
 
+import * as fs from 'node:fs/promises';
 import { execute } from '../../../executor/gws.js';
-import { extractBodyFromPayload } from '../../formatting/markdown.js';
+import { ensureWorkspaceDir, resolveWorkspacePath } from '../../../executor/workspace.js';
+import { extractBodyFromPayload, extractAttachments } from '../../formatting/markdown.js';
 import type { HandlerResponse } from '../../handler.js';
 import type { ScratchpadManager } from '../manager.js';
 
 interface EmailImportParams {
   email: string;
   messageId: string;
+  includeAttachments?: boolean;
 }
 
 export async function importEmail(
@@ -18,7 +21,7 @@ export async function importEmail(
   scratchpadId: string,
   sourceParams: EmailImportParams,
 ): Promise<HandlerResponse> {
-  const { email, messageId } = sourceParams;
+  const { email, messageId, includeAttachments = true } = sourceParams;
   if (!email || !messageId) {
     return { text: 'email and messageId are required for email import.', refs: { error: true } };
   }
@@ -43,11 +46,54 @@ export async function importEmail(
     const lines = body.split('\n');
     scratchpads.appendRawLines(scratchpadId, lines);
 
-    // TODO: Register email file attachments in scratchpad side-table
+    // Register email file attachments in scratchpad side-table
+    let attCount = 0;
+    if (includeAttachments && payload?.parts) {
+      const emailAttachments = extractAttachments(payload.parts as unknown[]);
+      if (emailAttachments.length > 0) {
+        await ensureWorkspaceDir();
 
+        for (const att of emailAttachments) {
+          try {
+            // Download attachment data
+            const attResult = await execute([
+              'gmail', 'users', 'messages', 'attachments', 'get',
+              '--params', JSON.stringify({
+                userId: 'me',
+                messageId,
+                id: att.attachmentId,
+              }),
+            ], { account: email });
+
+            const attData = attResult.data as Record<string, unknown>;
+            const base64Data = String(attData.data ?? '');
+            if (!base64Data) continue;
+
+            // Decode and save to workspace
+            const buffer = Buffer.from(base64Data, 'base64url');
+            const filePath = resolveWorkspacePath(att.filename);
+            await fs.writeFile(filePath, buffer);
+
+            // Register in scratchpad
+            scratchpads.attach(scratchpadId, {
+              source: 'import',
+              filename: att.filename,
+              mimeType: att.mimeType,
+              size: buffer.length,
+              location: filePath,
+            });
+            attCount++;
+          } catch {
+            // Non-fatal: skip individual attachment failures
+          }
+        }
+      }
+    }
+
+    const attNote = attCount > 0 ? ` with ${attCount} attachment(s)` : '';
     return {
-      text: `Imported email body (${lines.length} lines) into scratchpad ${scratchpadId}.`,
-      refs: { scratchpadId, messageId, linesImported: lines.length },
+      text: `Imported email body (${lines.length} lines)${attNote} into scratchpad ${scratchpadId}.`,
+      refs: { scratchpadId, messageId, linesImported: lines.length, attachmentsImported: attCount },
     };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/src/server/scratchpad/adapters/import-email.ts
+++ b/src/server/scratchpad/adapters/import-email.ts
@@ -69,15 +69,17 @@ export async function importEmail(
             const base64Data = String(attData.data ?? '');
             if (!base64Data) continue;
 
-            // Decode and save to workspace
+            // Decode and save to workspace (prefixed to avoid collisions)
             const buffer = Buffer.from(base64Data, 'base64url');
-            const filePath = resolveWorkspacePath(att.filename);
+            const shortId = scratchpadId.replace('sp-', '');
+            const safeFilename = `${shortId}-${att.filename}`;
+            const filePath = resolveWorkspacePath(safeFilename);
             await fs.writeFile(filePath, buffer);
 
             // Register in scratchpad
             scratchpads.attach(scratchpadId, {
               source: 'import',
-              filename: att.filename,
+              filename: safeFilename,
               mimeType: att.mimeType,
               size: buffer.length,
               location: filePath,

--- a/src/server/scratchpad/adapters/import-email.ts
+++ b/src/server/scratchpad/adapters/import-email.ts
@@ -1,0 +1,59 @@
+/**
+ * Import adapter: email — loads email body text into a scratchpad.
+ * Extracts plain text body (or strips HTML as fallback).
+ */
+
+import { execute } from '../../../executor/gws.js';
+import { extractBodyFromPayload } from '../../formatting/markdown.js';
+import type { HandlerResponse } from '../../handler.js';
+import type { ScratchpadManager } from '../manager.js';
+
+interface EmailImportParams {
+  email: string;
+  messageId: string;
+}
+
+export async function importEmail(
+  scratchpads: ScratchpadManager,
+  scratchpadId: string,
+  sourceParams: EmailImportParams,
+): Promise<HandlerResponse> {
+  const { email, messageId } = sourceParams;
+  if (!email || !messageId) {
+    return { text: 'email and messageId are required for email import.', refs: { error: true } };
+  }
+
+  try {
+    const result = await execute([
+      'gmail', 'users', 'messages', 'get',
+      '--params', JSON.stringify({ userId: 'me', id: messageId }),
+    ], { account: email });
+
+    const msg = result.data as Record<string, unknown>;
+    const payload = msg.payload as Record<string, unknown> | undefined;
+    const body = extractBodyFromPayload(payload);
+
+    if (!body.trim()) {
+      return {
+        text: `Email ${messageId} has no text body to import.\nScratchpad ${scratchpadId} unchanged.`,
+        refs: { scratchpadId, messageId },
+      };
+    }
+
+    const lines = body.split('\n');
+    scratchpads.appendRawLines(scratchpadId, lines);
+
+    // TODO: Register email file attachments in scratchpad side-table
+
+    return {
+      text: `Imported email body (${lines.length} lines) into scratchpad ${scratchpadId}.`,
+      refs: { scratchpadId, messageId, linesImported: lines.length },
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      text: `Import failed: ${message}`,
+      refs: { error: true, scratchpadId },
+    };
+  }
+}

--- a/src/server/scratchpad/adapters/import-meet.ts
+++ b/src/server/scratchpad/adapters/import-meet.ts
@@ -1,0 +1,130 @@
+/**
+ * Import adapter: meet — loads a Meet conference transcript into a scratchpad.
+ * Imports as markdown with speaker attribution. No live binding (transcripts are read-only).
+ */
+
+import { execute } from '../../../executor/gws.js';
+import type { HandlerResponse } from '../../handler.js';
+import type { ScratchpadManager } from '../manager.js';
+
+interface MeetImportParams {
+  email: string;
+  conferenceId: string;
+}
+
+export async function importMeet(
+  scratchpads: ScratchpadManager,
+  scratchpadId: string,
+  sourceParams: MeetImportParams,
+): Promise<HandlerResponse> {
+  const { email, conferenceId } = sourceParams;
+  if (!email || !conferenceId) {
+    return { text: 'email and conferenceId are required for meet import.', refs: { error: true } };
+  }
+
+  try {
+    const parent = conferenceId.startsWith('conferenceRecords/')
+      ? conferenceId
+      : `conferenceRecords/${conferenceId}`;
+
+    // Step 1: List transcripts
+    const transcriptsResult = await execute([
+      'meet', 'conferenceRecords', 'transcripts', 'list',
+      '--params', JSON.stringify({ parent }),
+    ], { account: email, format: 'json' });
+
+    const transcriptsData = transcriptsResult.data as Record<string, unknown>;
+    const transcripts = (transcriptsData?.transcripts ?? []) as Array<Record<string, unknown>>;
+
+    if (transcripts.length === 0) {
+      return {
+        text: `No transcripts found for conference ${conferenceId}.\nScratchpad ${scratchpadId} unchanged.`,
+        refs: { scratchpadId, conferenceId },
+      };
+    }
+
+    // Step 2: Fetch entries and participants in parallel
+    const transcriptName = String(transcripts[0].name ?? '');
+    const [entriesResult, participantsResult] = await Promise.all([
+      execute([
+        'meet', 'conferenceRecords', 'transcripts', 'entries', 'list',
+        '--params', JSON.stringify({ parent: transcriptName, pageSize: 100 }),
+      ], { account: email, format: 'json' }),
+      execute([
+        'meet', 'conferenceRecords', 'participants', 'list',
+        '--params', JSON.stringify({ parent, pageSize: 100 }),
+      ], { account: email, format: 'json' }),
+    ]);
+
+    const entriesData = entriesResult.data as Record<string, unknown>;
+    const entries = (entriesData?.transcriptEntries ?? []) as Array<Record<string, unknown>>;
+
+    if (entries.length === 0) {
+      return {
+        text: `Transcript found but no entries available yet (may still be processing).\nScratchpad ${scratchpadId} unchanged.`,
+        refs: { scratchpadId, conferenceId, transcriptName },
+      };
+    }
+
+    // Step 3: Build participant lookup
+    const participantsData = participantsResult.data as Record<string, unknown>;
+    const participants = (participantsData?.participants ?? []) as Array<Record<string, unknown>>;
+    const nameMap = new Map<string, string>();
+    for (const p of participants) {
+      const name = String(p.name ?? '');
+      const signedinUser = p.signedinUser as Record<string, unknown> | undefined;
+      const displayName = String(signedinUser?.displayName ?? p.name ?? 'Unknown');
+      if (name) nameMap.set(name, displayName);
+    }
+
+    // Step 4: Format as markdown transcript
+    const lines: string[] = [
+      `# Meeting Transcript`,
+      ``,
+      `**Conference:** ${conferenceId}`,
+      `**Entries:** ${entries.length}`,
+      ``,
+    ];
+
+    let currentSpeaker = '';
+    for (const entry of entries) {
+      const participantName = String(entry.participant ?? '');
+      const speaker = nameMap.get(participantName) ?? String(entry.participantDisplayName ?? participantName);
+      const text = String(entry.text ?? '');
+      const time = formatTime(entry.startTime);
+
+      if (speaker !== currentSpeaker) {
+        if (currentSpeaker) lines.push('');
+        lines.push(`**${speaker}** (${time}):`);
+        currentSpeaker = speaker;
+      }
+      lines.push(text);
+    }
+
+    scratchpads.appendRawLines(scratchpadId, lines);
+    scratchpads.setFormat(scratchpadId, 'markdown');
+    // No live binding — transcripts are read-only
+
+    return {
+      text: `Imported transcript (${entries.length} entries, ${lines.length} lines) into scratchpad ${scratchpadId}.`,
+      refs: { scratchpadId, conferenceId, entries: entries.length, linesImported: lines.length },
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      text: `Import failed: ${message}`,
+      refs: { error: true, scratchpadId },
+    };
+  }
+}
+
+function formatTime(time: unknown): string {
+  if (!time) return '';
+  const s = String(time);
+  try {
+    const d = new Date(s);
+    return d.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' });
+  } catch {
+    return s;
+  }
+}

--- a/src/server/scratchpad/adapters/import-sheet.ts
+++ b/src/server/scratchpad/adapters/import-sheet.ts
@@ -1,0 +1,74 @@
+/**
+ * Import adapter: sheet — loads a Google Sheet as CSV lines into a scratchpad.
+ */
+
+import { execute } from '../../../executor/gws.js';
+import type { HandlerResponse } from '../../handler.js';
+import type { ScratchpadManager } from '../manager.js';
+
+interface SheetImportParams {
+  email: string;
+  spreadsheetId: string;
+  range?: string;
+}
+
+export async function importSheet(
+  scratchpads: ScratchpadManager,
+  scratchpadId: string,
+  sourceParams: SheetImportParams,
+): Promise<HandlerResponse> {
+  const { email, spreadsheetId, range } = sourceParams;
+  if (!email || !spreadsheetId) {
+    return { text: 'email and spreadsheetId are required for sheet import.', refs: { error: true } };
+  }
+
+  try {
+    const params: Record<string, unknown> = { spreadsheetId };
+    if (range) params.range = range;
+
+    // Default to first sheet if no range specified
+    const rangeArg = range ?? 'Sheet1';
+
+    const result = await execute([
+      'sheets', 'spreadsheets', 'values', 'get',
+      '--params', JSON.stringify({ spreadsheetId, range: rangeArg }),
+    ], { account: email });
+
+    const data = result.data as Record<string, unknown>;
+    const values = (data.values ?? []) as string[][];
+
+    if (values.length === 0) {
+      return {
+        text: `Sheet ${spreadsheetId} (${rangeArg}) has no data.\nScratchpad ${scratchpadId} unchanged.`,
+        refs: { scratchpadId, spreadsheetId },
+      };
+    }
+
+    // Convert to CSV lines
+    const csvLines = values.map(row => row.map(escapeCsvField).join(','));
+
+    scratchpads.appendRawLines(scratchpadId, csvLines);
+    scratchpads.setFormat(scratchpadId, 'csv');
+
+    return {
+      text: `Imported sheet as CSV (${csvLines.length} rows) into scratchpad ${scratchpadId}.`,
+      refs: { scratchpadId, spreadsheetId, range: rangeArg, rowsImported: csvLines.length },
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      text: `Import failed: ${message}`,
+      refs: { error: true, scratchpadId },
+    };
+  }
+}
+
+/** Escape a CSV field: quote if it contains comma, newline, or double-quote. */
+function escapeCsvField(field: string): string {
+  if (field === undefined || field === null) return '';
+  const s = String(field);
+  if (s.includes(',') || s.includes('"') || s.includes('\n')) {
+    return `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
+}

--- a/src/server/scratchpad/adapters/index.ts
+++ b/src/server/scratchpad/adapters/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Adapter registry for scratchpad send and import operations.
+ */
+
+// Send adapters
+export { sendEmail } from './send-email.js';
+export { sendEmailDraft } from './send-email-draft.js';
+export { sendDocCreate, sendDocWrite } from './send-doc.js';
+export { sendWorkspace } from './send-workspace.js';
+
+// Import adapters
+export { importEmail } from './import-email.js';
+export { importDoc } from './import-doc.js';

--- a/src/server/scratchpad/adapters/index.ts
+++ b/src/server/scratchpad/adapters/index.ts
@@ -7,9 +7,13 @@ export { sendEmail } from './send-email.js';
 export { sendEmailDraft } from './send-email-draft.js';
 export { sendDocCreate, sendDocWrite } from './send-doc.js';
 export { sendWorkspace } from './send-workspace.js';
+export { sendSheetWrite } from './send-sheet.js';
+export { sendCalendarEvent } from './send-calendar.js';
+export { sendTaskCreate } from './send-task.js';
 
 // Import adapters
 export { importEmail } from './import-email.js';
 export { importDoc } from './import-doc.js';
 export { importSheet } from './import-sheet.js';
 export { importDriveFile } from './import-drive.js';
+export { importMeet } from './import-meet.js';

--- a/src/server/scratchpad/adapters/index.ts
+++ b/src/server/scratchpad/adapters/index.ts
@@ -11,3 +11,5 @@ export { sendWorkspace } from './send-workspace.js';
 // Import adapters
 export { importEmail } from './import-email.js';
 export { importDoc } from './import-doc.js';
+export { importSheet } from './import-sheet.js';
+export { importDriveFile } from './import-drive.js';

--- a/src/server/scratchpad/adapters/send-calendar.ts
+++ b/src/server/scratchpad/adapters/send-calendar.ts
@@ -1,0 +1,67 @@
+/**
+ * Send adapter: calendar_event — creates a calendar event with scratchpad content as description.
+ */
+
+import { execute } from '../../../executor/gws.js';
+import type { HandlerResponse } from '../../handler.js';
+import type { ScratchpadManager } from '../manager.js';
+import { nextSteps } from '../../formatting/next-steps.js';
+
+interface CalendarEventParams {
+  email: string;
+  summary: string;
+  start: string;
+  end: string;
+  location?: string;
+  attendees?: string;
+}
+
+export async function sendCalendarEvent(
+  scratchpads: ScratchpadManager,
+  scratchpadId: string,
+  targetParams: CalendarEventParams,
+): Promise<HandlerResponse> {
+  const content = scratchpads.getContent(scratchpadId);
+  if (content === null) {
+    return { text: `Scratchpad ${scratchpadId} not found.`, refs: { error: true } };
+  }
+
+  const { email, summary, start, end, location, attendees } = targetParams;
+  if (!email || !summary || !start || !end) {
+    return {
+      text: `Send failed: email, summary, start, and end are required for calendar_event.\nScratchpad ${scratchpadId} is still active.`,
+      refs: { error: true, scratchpadId },
+    };
+  }
+
+  const args = [
+    'calendar', '+insert',
+    '--summary', summary,
+    '--start', start,
+    '--end', end,
+    '--description', content,
+  ];
+  if (location) args.push('--location', location);
+  if (attendees) args.push('--attendees', attendees);
+
+  try {
+    const result = await execute(args, { account: email });
+    const data = result.data as Record<string, unknown>;
+
+    return {
+      text: `Event created: **${summary}**\n\n` +
+        `**When:** ${start} – ${end}\n` +
+        (location ? `**Where:** ${location}\n` : '') +
+        `**Description:** scratchpad content (${content.split('\n').length} lines)\n` +
+        `**Event ID:** ${data.id ?? 'unknown'}` +
+        nextSteps('calendar', 'create', { email }),
+      refs: { scratchpadId, eventId: data.id, summary, start, end },
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      text: `Send failed: ${message}\nScratchpad ${scratchpadId} is still active.`,
+      refs: { error: true, scratchpadId },
+    };
+  }
+}

--- a/src/server/scratchpad/adapters/send-doc.ts
+++ b/src/server/scratchpad/adapters/send-doc.ts
@@ -37,10 +37,10 @@ export async function sendDocCreate(
   }
 
   try {
-    // Step 1: Create empty doc
+    // Step 1: Create empty doc (title goes in --json request body)
     const createResult = await execute([
       'docs', 'documents', 'create',
-      '--params', JSON.stringify({ requestBody: { title } }),
+      '--json', JSON.stringify({ title }),
     ], { account: email });
 
     const doc = createResult.data as Record<string, unknown>;

--- a/src/server/scratchpad/adapters/send-doc.ts
+++ b/src/server/scratchpad/adapters/send-doc.ts
@@ -1,0 +1,105 @@
+/**
+ * Send adapters: doc_create and doc_write.
+ * doc_create: creates a new Google Doc and writes scratchpad content.
+ * doc_write: appends scratchpad content to an existing Google Doc.
+ */
+
+import { execute } from '../../../executor/gws.js';
+import type { HandlerResponse } from '../../handler.js';
+import type { ScratchpadManager } from '../manager.js';
+
+interface DocCreateParams {
+  email: string;
+  title: string;
+}
+
+interface DocWriteParams {
+  email: string;
+  documentId: string;
+}
+
+export async function sendDocCreate(
+  scratchpads: ScratchpadManager,
+  scratchpadId: string,
+  targetParams: DocCreateParams,
+): Promise<HandlerResponse> {
+  const content = scratchpads.getContent(scratchpadId);
+  if (content === null) {
+    return { text: `Scratchpad ${scratchpadId} not found.`, refs: { error: true } };
+  }
+
+  const { email, title } = targetParams;
+  if (!email || !title) {
+    return {
+      text: `Send failed: email and title are required for doc_create.\nScratchpad ${scratchpadId} is still active.`,
+      refs: { error: true, scratchpadId },
+    };
+  }
+
+  try {
+    // Step 1: Create empty doc
+    const createResult = await execute([
+      'docs', 'documents', 'create',
+      '--params', JSON.stringify({ requestBody: { title } }),
+    ], { account: email });
+
+    const doc = createResult.data as Record<string, unknown>;
+    const documentId = doc.documentId as string;
+
+    // Step 2: Write content
+    await execute([
+      'docs', '+write',
+      '--document', documentId,
+      '--text', content,
+    ], { account: email });
+
+    return {
+      text: `Document created from scratchpad.\n\n**Title:** ${title}\n**Document ID:** ${documentId}`,
+      refs: { scratchpadId, documentId, title },
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      text: `Send failed: ${message}\nScratchpad ${scratchpadId} is still active.`,
+      refs: { error: true, scratchpadId },
+    };
+  }
+}
+
+export async function sendDocWrite(
+  scratchpads: ScratchpadManager,
+  scratchpadId: string,
+  targetParams: DocWriteParams,
+): Promise<HandlerResponse> {
+  const content = scratchpads.getContent(scratchpadId);
+  if (content === null) {
+    return { text: `Scratchpad ${scratchpadId} not found.`, refs: { error: true } };
+  }
+
+  const { email, documentId } = targetParams;
+  if (!email || !documentId) {
+    return {
+      text: `Send failed: email and documentId are required for doc_write.\nScratchpad ${scratchpadId} is still active.`,
+      refs: { error: true, scratchpadId },
+    };
+  }
+
+  try {
+    await execute([
+      'docs', '+write',
+      '--document', documentId,
+      '--text', content,
+    ], { account: email });
+
+    return {
+      text: `Content appended to document ${documentId}.`,
+      refs: { scratchpadId, documentId },
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      text: `Send failed: ${message}\nScratchpad ${scratchpadId} is still active.`,
+      refs: { error: true, scratchpadId },
+    };
+  }
+}

--- a/src/server/scratchpad/adapters/send-email-draft.ts
+++ b/src/server/scratchpad/adapters/send-email-draft.ts
@@ -1,0 +1,64 @@
+/**
+ * Send adapter: email_draft — creates a Gmail draft from scratchpad content.
+ */
+
+import { execute } from '../../../executor/gws.js';
+import type { HandlerResponse } from '../../handler.js';
+import type { ScratchpadManager } from '../manager.js';
+
+interface EmailDraftTargetParams {
+  email: string;
+  to?: string;
+  subject?: string;
+}
+
+export async function sendEmailDraft(
+  scratchpads: ScratchpadManager,
+  scratchpadId: string,
+  targetParams: EmailDraftTargetParams,
+): Promise<HandlerResponse> {
+  const content = scratchpads.getContent(scratchpadId);
+  if (content === null) {
+    return { text: `Scratchpad ${scratchpadId} not found.`, refs: { error: true } };
+  }
+
+  const { email, to, subject } = targetParams;
+  if (!email) {
+    return {
+      text: `Send failed: email (account) is required.\nScratchpad ${scratchpadId} is still active.`,
+      refs: { error: true, scratchpadId },
+    };
+  }
+
+  // Build raw RFC 2822 message for drafts.create
+  const headers: string[] = [];
+  if (to) headers.push(`To: ${to}`);
+  if (subject) headers.push(`Subject: ${subject}`);
+  headers.push('Content-Type: text/plain; charset=utf-8');
+  headers.push('');
+  headers.push(content);
+  const raw = Buffer.from(headers.join('\r\n')).toString('base64url');
+
+  try {
+    const result = await execute([
+      'gmail', 'users', 'drafts', 'create',
+      '--params', JSON.stringify({
+        userId: 'me',
+        requestBody: { message: { raw } },
+      }),
+    ], { account: email });
+
+    const data = result.data as Record<string, unknown>;
+    const draftId = data.id ?? 'unknown';
+    return {
+      text: `Draft created.\n\n**Draft ID:** ${draftId}${to ? `\n**To:** ${to}` : ''}${subject ? `\n**Subject:** ${subject}` : ''}`,
+      refs: { scratchpadId, draftId },
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      text: `Send failed: ${message}\nScratchpad ${scratchpadId} is still active.`,
+      refs: { error: true, scratchpadId },
+    };
+  }
+}

--- a/src/server/scratchpad/adapters/send-email-draft.ts
+++ b/src/server/scratchpad/adapters/send-email-draft.ts
@@ -31,9 +31,11 @@ export async function sendEmailDraft(
   }
 
   // Build raw RFC 2822 message for drafts.create
+  // Strip CRLF to prevent header injection
+  const sanitize = (s: string) => s.replace(/[\r\n]/g, '');
   const headers: string[] = [];
-  if (to) headers.push(`To: ${to}`);
-  if (subject) headers.push(`Subject: ${subject}`);
+  if (to) headers.push(`To: ${sanitize(to)}`);
+  if (subject) headers.push(`Subject: ${sanitize(subject)}`);
   headers.push('Content-Type: text/plain; charset=utf-8');
   headers.push('');
   headers.push(content);

--- a/src/server/scratchpad/adapters/send-email.ts
+++ b/src/server/scratchpad/adapters/send-email.ts
@@ -1,9 +1,11 @@
 /**
  * Send adapter: email — delivers scratchpad content as an email.
- * Attachments from the side-table are included as file attachments.
+ * When attachments are present, uses MIME builder for multipart message.
  */
 
+import * as fs from 'node:fs/promises';
 import { execute } from '../../../executor/gws.js';
+import { buildMimeMessage } from '../../../services/gmail/mime.js';
 import type { HandlerResponse } from '../../handler.js';
 import type { ScratchpadManager } from '../manager.js';
 import { nextSteps } from '../../formatting/next-steps.js';
@@ -34,17 +36,50 @@ export async function sendEmail(
     };
   }
 
-  const args = ['gmail', '+send', '--to', to, '--subject', subject, '--body', content];
-  if (cc) args.push('--cc', cc);
-  if (bcc) args.push('--bcc', bcc);
-
-  // TODO: Resolve attachments from side-table and include as --attachment flags
+  const attachments = scratchpads.getAttachments(scratchpadId);
+  const attachmentRefs = attachments ? [...attachments.values()] : [];
+  const hasAttachments = attachmentRefs.some(a => a.location);
 
   try {
-    const result = await execute(args, { account: email });
-    const data = result.data as Record<string, unknown>;
+    let data: Record<string, unknown>;
+
+    if (hasAttachments) {
+      // Build MIME multipart message with attachments
+      const mimeAttachments = await Promise.all(
+        attachmentRefs
+          .filter(a => a.location)
+          .map(async (a) => ({
+            filename: a.filename,
+            mimeType: a.mimeType,
+            content: await fs.readFile(a.location),
+          })),
+      );
+
+      const raw = buildMimeMessage({
+        to, subject, body: content, cc, bcc,
+        attachments: mimeAttachments,
+      });
+
+      const result = await execute([
+        'gmail', 'users', 'messages', 'send',
+        '--params', JSON.stringify({
+          userId: 'me',
+          requestBody: { raw },
+        }),
+      ], { account: email });
+      data = result.data as Record<string, unknown>;
+    } else {
+      // Simple send without attachments
+      const args = ['gmail', '+send', '--to', to, '--subject', subject, '--body', content];
+      if (cc) args.push('--cc', cc);
+      if (bcc) args.push('--bcc', bcc);
+      const result = await execute(args, { account: email });
+      data = result.data as Record<string, unknown>;
+    }
+
+    const attNote = hasAttachments ? ` (${attachmentRefs.filter(a => a.location).length} attachment(s))` : '';
     return {
-      text: `Email sent to ${to}.\n\n**Subject:** ${subject}\n**Message ID:** ${data.id ?? 'unknown'}` +
+      text: `Email sent to ${to}${attNote}.\n\n**Subject:** ${subject}\n**Message ID:** ${data.id ?? 'unknown'}` +
         nextSteps('email', 'send', { email }),
       refs: { scratchpadId, id: data.id, threadId: data.threadId, to, subject },
     };

--- a/src/server/scratchpad/adapters/send-email.ts
+++ b/src/server/scratchpad/adapters/send-email.ts
@@ -1,0 +1,58 @@
+/**
+ * Send adapter: email — delivers scratchpad content as an email.
+ * Attachments from the side-table are included as file attachments.
+ */
+
+import { execute } from '../../../executor/gws.js';
+import type { HandlerResponse } from '../../handler.js';
+import type { ScratchpadManager } from '../manager.js';
+import { nextSteps } from '../../formatting/next-steps.js';
+
+interface EmailTargetParams {
+  email: string;
+  to: string;
+  subject: string;
+  cc?: string;
+  bcc?: string;
+}
+
+export async function sendEmail(
+  scratchpads: ScratchpadManager,
+  scratchpadId: string,
+  targetParams: EmailTargetParams,
+): Promise<HandlerResponse> {
+  const content = scratchpads.getContent(scratchpadId);
+  if (content === null) {
+    return { text: `Scratchpad ${scratchpadId} not found.`, refs: { error: true } };
+  }
+
+  const { email, to, subject, cc, bcc } = targetParams;
+  if (!email || !to || !subject) {
+    return {
+      text: `Send failed: email, to, and subject are required.\nScratchpad ${scratchpadId} is still active.`,
+      refs: { error: true, scratchpadId },
+    };
+  }
+
+  const args = ['gmail', '+send', '--to', to, '--subject', subject, '--body', content];
+  if (cc) args.push('--cc', cc);
+  if (bcc) args.push('--bcc', bcc);
+
+  // TODO: Resolve attachments from side-table and include as --attachment flags
+
+  try {
+    const result = await execute(args, { account: email });
+    const data = result.data as Record<string, unknown>;
+    return {
+      text: `Email sent to ${to}.\n\n**Subject:** ${subject}\n**Message ID:** ${data.id ?? 'unknown'}` +
+        nextSteps('email', 'send', { email }),
+      refs: { scratchpadId, id: data.id, threadId: data.threadId, to, subject },
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      text: `Send failed: ${message}\nScratchpad ${scratchpadId} is still active.`,
+      refs: { error: true, scratchpadId },
+    };
+  }
+}

--- a/src/server/scratchpad/adapters/send-sheet.ts
+++ b/src/server/scratchpad/adapters/send-sheet.ts
@@ -1,0 +1,86 @@
+/**
+ * Send adapter: sheet_write — writes scratchpad CSV content to a Google Sheet.
+ * Parses CSV lines back into a values array for spreadsheets.values.update.
+ */
+
+import { execute } from '../../../executor/gws.js';
+import type { HandlerResponse } from '../../handler.js';
+import type { ScratchpadManager } from '../manager.js';
+
+interface SheetWriteParams {
+  email: string;
+  spreadsheetId: string;
+  range?: string;
+}
+
+export async function sendSheetWrite(
+  scratchpads: ScratchpadManager,
+  scratchpadId: string,
+  targetParams: SheetWriteParams,
+): Promise<HandlerResponse> {
+  const content = scratchpads.getContent(scratchpadId);
+  if (content === null) {
+    return { text: `Scratchpad ${scratchpadId} not found.`, refs: { error: true } };
+  }
+
+  const { email, spreadsheetId, range = 'Sheet1' } = targetParams;
+  if (!email || !spreadsheetId) {
+    return {
+      text: `Send failed: email and spreadsheetId are required for sheet_write.\nScratchpad ${scratchpadId} is still active.`,
+      refs: { error: true, scratchpadId },
+    };
+  }
+
+  // Parse CSV lines into values array
+  const lines = content.split('\n').filter(l => l.trim());
+  const values = lines.map(parseCsvLine);
+
+  try {
+    await execute([
+      'sheets', 'spreadsheets', 'values', 'update',
+      '--params', JSON.stringify({
+        spreadsheetId,
+        range,
+        valueInputOption: 'USER_ENTERED',
+        requestBody: { values },
+      }),
+    ], { account: email });
+
+    return {
+      text: `Written ${values.length} rows to sheet ${spreadsheetId} (${range}).`,
+      refs: { scratchpadId, spreadsheetId, range, rows: values.length },
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      text: `Send failed: ${message}\nScratchpad ${scratchpadId} is still active.`,
+      refs: { error: true, scratchpadId },
+    };
+  }
+}
+
+/** Parse a CSV line respecting quoted fields. */
+function parseCsvLine(line: string): string[] {
+  const fields: string[] = [];
+  let current = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (ch === '"') {
+      if (inQuotes && line[i + 1] === '"') {
+        current += '"';
+        i++;
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if (ch === ',' && !inQuotes) {
+      fields.push(current);
+      current = '';
+    } else {
+      current += ch;
+    }
+  }
+  fields.push(current);
+  return fields;
+}

--- a/src/server/scratchpad/adapters/send-task.ts
+++ b/src/server/scratchpad/adapters/send-task.ts
@@ -1,0 +1,70 @@
+/**
+ * Send adapter: task_create — creates a Google Task from scratchpad content.
+ * First line becomes the task title, remaining lines become the notes.
+ */
+
+import { execute } from '../../../executor/gws.js';
+import type { HandlerResponse } from '../../handler.js';
+import type { ScratchpadManager } from '../manager.js';
+
+interface TaskCreateParams {
+  email: string;
+  taskListId?: string;
+}
+
+export async function sendTaskCreate(
+  scratchpads: ScratchpadManager,
+  scratchpadId: string,
+  targetParams: TaskCreateParams,
+): Promise<HandlerResponse> {
+  const content = scratchpads.getContent(scratchpadId);
+  if (content === null) {
+    return { text: `Scratchpad ${scratchpadId} not found.`, refs: { error: true } };
+  }
+
+  const { email, taskListId = '@default' } = targetParams;
+  if (!email) {
+    return {
+      text: `Send failed: email is required for task_create.\nScratchpad ${scratchpadId} is still active.`,
+      refs: { error: true, scratchpadId },
+    };
+  }
+
+  // First non-empty line → title, rest → notes
+  const lines = content.split('\n');
+  const titleLine = lines.findIndex(l => l.trim().length > 0);
+  if (titleLine === -1) {
+    return {
+      text: `Send failed: scratchpad is empty, no task title.\nScratchpad ${scratchpadId} is still active.`,
+      refs: { error: true, scratchpadId },
+    };
+  }
+
+  const title = lines[titleLine].replace(/^#+\s*/, '').trim(); // strip markdown heading prefix
+  const notes = lines.slice(titleLine + 1).join('\n').trim();
+
+  const requestBody: Record<string, string> = { title };
+  if (notes) requestBody.notes = notes;
+
+  try {
+    const result = await execute([
+      'tasks', 'tasks', 'insert',
+      '--params', JSON.stringify({ tasklist: taskListId, requestBody }),
+    ], { account: email });
+
+    const data = result.data as Record<string, unknown>;
+
+    return {
+      text: `Task created: **${title}**\n\n` +
+        (notes ? `**Notes:** ${notes.split('\n').length} lines\n` : '') +
+        `**Task ID:** ${data.id ?? 'unknown'}`,
+      refs: { scratchpadId, taskId: data.id, title },
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      text: `Send failed: ${message}\nScratchpad ${scratchpadId} is still active.`,
+      refs: { error: true, scratchpadId },
+    };
+  }
+}

--- a/src/server/scratchpad/adapters/send-workspace.ts
+++ b/src/server/scratchpad/adapters/send-workspace.ts
@@ -1,0 +1,67 @@
+/**
+ * Send adapter: workspace — writes scratchpad content to a file in the workspace directory.
+ * Attachments are copied alongside the content file.
+ */
+
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { resolveWorkspacePath, verifyPathSafety } from '../../../executor/workspace.js';
+import { ensureWorkspaceDir } from '../../../executor/workspace.js';
+import type { HandlerResponse } from '../../handler.js';
+import type { ScratchpadManager } from '../manager.js';
+
+interface WorkspaceTargetParams {
+  filename: string;
+}
+
+export async function sendWorkspace(
+  scratchpads: ScratchpadManager,
+  scratchpadId: string,
+  targetParams: WorkspaceTargetParams,
+): Promise<HandlerResponse> {
+  const content = scratchpads.getContent(scratchpadId);
+  if (content === null) {
+    return { text: `Scratchpad ${scratchpadId} not found.`, refs: { error: true } };
+  }
+
+  const { filename } = targetParams;
+  if (!filename) {
+    return {
+      text: `Send failed: filename is required for workspace target.\nScratchpad ${scratchpadId} is still active.`,
+      refs: { error: true, scratchpadId },
+    };
+  }
+
+  const wsStatus = await ensureWorkspaceDir();
+  if (!wsStatus.valid) {
+    return {
+      text: `Send failed: workspace invalid — ${wsStatus.warning}\nScratchpad ${scratchpadId} is still active.`,
+      refs: { error: true, scratchpadId },
+    };
+  }
+
+  try {
+    const filePath = resolveWorkspacePath(filename);
+    await verifyPathSafety(filePath);
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, content, 'utf-8');
+
+    const size = Buffer.byteLength(content);
+
+    // TODO: Copy attachments alongside the file
+    const attachments = scratchpads.getAttachments(scratchpadId);
+    const attCount = attachments?.size ?? 0;
+    const attNote = attCount > 0 ? `\n${attCount} attachment(s) — copy not yet implemented.` : '';
+
+    return {
+      text: `Written to workspace: **${filename}** (${size} bytes)${attNote}\n\n**Path:** ${filePath}`,
+      refs: { scratchpadId, filename, path: filePath, size },
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      text: `Send failed: ${message}\nScratchpad ${scratchpadId} is still active.`,
+      refs: { error: true, scratchpadId },
+    };
+  }
+}

--- a/src/server/scratchpad/adapters/send-workspace.ts
+++ b/src/server/scratchpad/adapters/send-workspace.ts
@@ -48,14 +48,31 @@ export async function sendWorkspace(
 
     const size = Buffer.byteLength(content);
 
-    // TODO: Copy attachments alongside the file
+    // Copy attachments alongside the content file
     const attachments = scratchpads.getAttachments(scratchpadId);
-    const attCount = attachments?.size ?? 0;
-    const attNote = attCount > 0 ? `\n${attCount} attachment(s) — copy not yet implemented.` : '';
+    let copiedCount = 0;
+    if (attachments && attachments.size > 0) {
+      const targetDir = path.dirname(filePath);
+      for (const att of attachments.values()) {
+        if (!att.location) continue;
+        try {
+          const destPath = path.join(targetDir, att.filename);
+          // Only copy if source and dest differ (workspace files may already be in place)
+          if (path.resolve(att.location) !== path.resolve(destPath)) {
+            await fs.copyFile(att.location, destPath);
+          }
+          copiedCount++;
+        } catch {
+          // Non-fatal: log but continue
+        }
+      }
+    }
+
+    const attNote = copiedCount > 0 ? `\n${copiedCount} attachment(s) copied alongside.` : '';
 
     return {
       text: `Written to workspace: **${filename}** (${size} bytes)${attNote}\n\n**Path:** ${filePath}`,
-      refs: { scratchpadId, filename, path: filePath, size },
+      refs: { scratchpadId, filename, path: filePath, size, attachmentsCopied: copiedCount },
     };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/src/server/scratchpad/handler.ts
+++ b/src/server/scratchpad/handler.ts
@@ -4,10 +4,14 @@
  */
 
 import { ScratchpadManager } from './manager.js';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
 import {
   sendEmail, sendEmailDraft, sendDocCreate, sendDocWrite, sendWorkspace,
-  importEmail, importDoc,
+  importEmail, importDoc, importSheet, importDriveFile,
 } from './adapters/index.js';
+import { resolveWorkspacePath, verifyPathSafety } from '../../executor/workspace.js';
+import { lookupMimeType } from '../../services/gmail/mime.js';
 import type { HandlerResponse } from '../handler.js';
 
 const scratchpads = new ScratchpadManager();
@@ -283,7 +287,7 @@ function handleJsonInsert(params: Record<string, unknown>): HandlerResponse {
 
 // ── Attachments ───────────────────────────────────────────
 
-function handleAttach(params: Record<string, unknown>): HandlerResponse {
+async function handleAttach(params: Record<string, unknown>): Promise<HandlerResponse> {
   const id = requireScratchpadId(params);
   if (!id) return scratchpadNotFound(params.scratchpadId as string);
 
@@ -293,13 +297,39 @@ function handleAttach(params: Record<string, unknown>): HandlerResponse {
   const fileId = params.fileId as string | undefined;
   if (!filename && !fileId) return error('filename (for workspace) or fileId (for drive) is required.');
 
-  // TODO: Resolve file metadata (size, mimeType) from workspace or Drive
+  let resolvedFilename: string;
+  let mimeType: string;
+  let size: number;
+  let location: string;
+
+  if (source === 'workspace') {
+    if (!filename) return error('filename is required for workspace attachments.');
+    try {
+      const filePath = resolveWorkspacePath(filename);
+      await verifyPathSafety(filePath);
+      const stat = await fs.stat(filePath);
+      resolvedFilename = filename;
+      mimeType = lookupMimeType(filename);
+      size = stat.size;
+      location = filePath;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return error(`Cannot attach workspace file: ${msg}`);
+    }
+  } else {
+    // Drive attachments — use fileId as identifier, metadata resolved later on send
+    resolvedFilename = fileId ?? 'unknown';
+    mimeType = 'application/octet-stream';
+    size = 0;
+    location = fileId ?? '';
+  }
+
   const result = scratchpads.attach(id, {
     source,
-    filename: filename ?? fileId ?? 'unknown',
-    mimeType: 'application/octet-stream',
-    size: 0,
-    location: filename ?? fileId ?? '',
+    filename: resolvedFilename,
+    mimeType,
+    size,
+    location,
   }, params.afterLine as number | undefined);
 
   if (!result) return scratchpadNotFound(id);
@@ -335,9 +365,9 @@ async function handleImport(params: Record<string, unknown>): Promise<HandlerRes
     case 'doc':
       return importDoc(scratchpads, id, sourceParams as unknown as Parameters<typeof importDoc>[2]);
     case 'sheet':
-      return error('Import from sheet not yet implemented.');
+      return importSheet(scratchpads, id, sourceParams as unknown as Parameters<typeof importSheet>[2]);
     case 'drive_file':
-      return error('Import from drive_file not yet implemented.');
+      return importDriveFile(scratchpads, id, sourceParams as unknown as Parameters<typeof importDriveFile>[2]);
     default:
       return error(`Unknown import source: ${source}. Valid sources: doc, email, sheet, drive_file.`);
   }

--- a/src/server/scratchpad/handler.ts
+++ b/src/server/scratchpad/handler.ts
@@ -8,7 +8,8 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import {
   sendEmail, sendEmailDraft, sendDocCreate, sendDocWrite, sendWorkspace,
-  importEmail, importDoc, importSheet, importDriveFile,
+  sendSheetWrite, sendCalendarEvent, sendTaskCreate,
+  importEmail, importDoc, importSheet, importDriveFile, importMeet,
 } from './adapters/index.js';
 import { execute } from '../../executor/gws.js';
 import { resolveWorkspacePath, verifyPathSafety } from '../../executor/workspace.js';
@@ -469,8 +470,10 @@ async function handleImport(params: Record<string, unknown>): Promise<HandlerRes
       return importSheet(scratchpads, id, sourceParams as unknown as Parameters<typeof importSheet>[2]);
     case 'drive_file':
       return importDriveFile(scratchpads, id, sourceParams as unknown as Parameters<typeof importDriveFile>[2]);
+    case 'meet':
+      return importMeet(scratchpads, id, sourceParams as unknown as Parameters<typeof importMeet>[2]);
     default:
-      return error(`Unknown import source: ${source}. Valid sources: doc, email, sheet, drive_file.`);
+      return error(`Unknown import source: ${source}. Valid sources: doc, email, sheet, drive_file, meet.`);
   }
 }
 
@@ -502,8 +505,17 @@ async function handleSend(params: Record<string, unknown>): Promise<HandlerRespo
     case 'workspace':
       result = await sendWorkspace(scratchpads, id, targetParams as unknown as Parameters<typeof sendWorkspace>[2]);
       break;
+    case 'sheet_write':
+      result = await sendSheetWrite(scratchpads, id, targetParams as unknown as Parameters<typeof sendSheetWrite>[2]);
+      break;
+    case 'calendar_event':
+      result = await sendCalendarEvent(scratchpads, id, targetParams as unknown as Parameters<typeof sendCalendarEvent>[2]);
+      break;
+    case 'task_create':
+      result = await sendTaskCreate(scratchpads, id, targetParams as unknown as Parameters<typeof sendTaskCreate>[2]);
+      break;
     default:
-      return error(`Unknown send target: ${target}. Valid targets: email, email_draft, doc_create, doc_write, workspace.`);
+      return error(`Unknown send target: ${target}. Valid targets: email, email_draft, doc_create, doc_write, workspace, sheet_write, calendar_event, task_create.`);
   }
 
   // Discard scratchpad on success if keep=false

--- a/src/server/scratchpad/handler.ts
+++ b/src/server/scratchpad/handler.ts
@@ -312,36 +312,18 @@ async function syncIfBound(id: string): Promise<HandlerResponse | null> {
 
   try {
     if (binding.service === 'docs') {
-      // For Docs: the buffer IS the full document JSON.
-      // Push the modified body back via documents.batchUpdate.
-      // Strategy: replace the entire body content from the modified JSON.
-      const doc = JSON.parse(content) as Record<string, unknown>;
-      const body = doc.body as Record<string, unknown> | undefined;
-
-      if (!body?.content) {
-        return error('Cannot sync: document JSON has no body.content');
-      }
-
-      // The Docs API doesn't accept a full JSON replace — it requires batchUpdate requests.
-      // For now: re-fetch to validate our changes took effect locally,
-      // then use the local buffer as source of truth.
-      // Full batchUpdate translation is a future enhancement.
-      // The local mutation is already applied to the buffer.
-
-      // Reload from API to verify consistency
-      const result = await execute([
-        'docs', 'documents', 'get',
-        '--params', JSON.stringify({ documentId: binding.resourceId }),
-      ], { account: binding.account });
-
-      const freshJson = JSON.stringify(result.data, null, 2);
-      const freshLines = freshJson.split('\n');
-
-      // Replace buffer with fresh data
-      const sp = scratchpads.get(id);
-      if (sp) {
-        sp.lines = freshLines;
-      }
+      // Docs API requires batchUpdate with discrete operations (insertText,
+      // deleteContentRange, etc.) — no full JSON replace endpoint.
+      //
+      // Future (#79): translate text content changes (textRun.content) to
+      // deleteContentRange + insertText using startIndex/endIndex from
+      // the JSON structure. Structural changes (add/remove paragraphs)
+      // that batchUpdate rejects should return guidance to use markdown
+      // mode + doc_create instead. One edit per sync cycle with reload.
+      //
+      // For now: local mutations are source of truth. The buffer diverges
+      // from the live doc. Agent can send modified JSON to workspace.
+      return null; // Local mutation already applied
     } else if (binding.service === 'sheets') {
       // For Sheets: the buffer is the values JSON.
       // Push back via spreadsheets.values.update.

--- a/src/server/scratchpad/handler.ts
+++ b/src/server/scratchpad/handler.ts
@@ -10,6 +10,7 @@ import {
   sendEmail, sendEmailDraft, sendDocCreate, sendDocWrite, sendWorkspace,
   importEmail, importDoc, importSheet, importDriveFile,
 } from './adapters/index.js';
+import { execute } from '../../executor/gws.js';
 import { resolveWorkspacePath, verifyPathSafety } from '../../executor/workspace.js';
 import { lookupMimeType } from '../../services/gmail/mime.js';
 import type { HandlerResponse } from '../handler.js';
@@ -244,45 +245,145 @@ function handleJsonGet(params: Record<string, unknown>): HandlerResponse {
   };
 }
 
-function handleJsonSet(params: Record<string, unknown>): HandlerResponse {
+async function handleJsonSet(params: Record<string, unknown>): Promise<HandlerResponse> {
   const id = requireScratchpadId(params);
   if (!id) return scratchpadNotFound(params.scratchpadId as string);
 
-  const path = params.path as string | undefined;
-  if (!path) return error('path is required for json_set.');
+  const jsonPath = params.path as string | undefined;
+  if (!jsonPath) return error('path is required for json_set.');
   if (!('value' in params)) return error('value is required for json_set.');
 
-  // TODO: If live-bound, translate to API mutation + reload
-  const result = scratchpads.jsonSet(id, path, params.value);
+  // Local mutation first
+  const result = scratchpads.jsonSet(id, jsonPath, params.value);
   if (!result) return scratchpadNotFound(id);
+
+  // If live-bound, push to API and reload
+  const syncResult = await syncIfBound(id);
+  if (syncResult) return syncResult;
+
   return { text: formatMutation(result), refs: { scratchpadId: id } };
 }
 
-function handleJsonDelete(params: Record<string, unknown>): HandlerResponse {
+async function handleJsonDelete(params: Record<string, unknown>): Promise<HandlerResponse> {
   const id = requireScratchpadId(params);
   if (!id) return scratchpadNotFound(params.scratchpadId as string);
 
-  const path = params.path as string | undefined;
-  if (!path) return error('path is required for json_delete.');
+  const jsonPath = params.path as string | undefined;
+  if (!jsonPath) return error('path is required for json_delete.');
 
-  // TODO: If live-bound, translate to API mutation + reload
-  const result = scratchpads.jsonDelete(id, path);
+  const result = scratchpads.jsonDelete(id, jsonPath);
   if (!result) return scratchpadNotFound(id);
+
+  const syncResult = await syncIfBound(id);
+  if (syncResult) return syncResult;
+
   return { text: formatMutation(result), refs: { scratchpadId: id } };
 }
 
-function handleJsonInsert(params: Record<string, unknown>): HandlerResponse {
+async function handleJsonInsert(params: Record<string, unknown>): Promise<HandlerResponse> {
   const id = requireScratchpadId(params);
   if (!id) return scratchpadNotFound(params.scratchpadId as string);
 
-  const path = params.path as string | undefined;
-  if (!path) return error('path is required for json_insert.');
+  const jsonPath = params.path as string | undefined;
+  if (!jsonPath) return error('path is required for json_insert.');
   if (!('value' in params)) return error('value is required for json_insert.');
 
-  // TODO: If live-bound, translate to API mutation + reload
-  const result = scratchpads.jsonInsert(id, path, params.value);
+  const result = scratchpads.jsonInsert(id, jsonPath, params.value);
   if (!result) return scratchpadNotFound(id);
+
+  const syncResult = await syncIfBound(id);
+  if (syncResult) return syncResult;
+
   return { text: formatMutation(result), refs: { scratchpadId: id } };
+}
+
+/**
+ * If the scratchpad is live-bound, push the current buffer to the API
+ * and reload from the live resource. Returns an error HandlerResponse
+ * on failure, or null on success (caller uses its own mutation result).
+ */
+async function syncIfBound(id: string): Promise<HandlerResponse | null> {
+  const binding = scratchpads.getBinding(id);
+  if (!binding) return null;
+
+  const content = scratchpads.getContent(id);
+  if (content === null) return null;
+
+  try {
+    if (binding.service === 'docs') {
+      // For Docs: the buffer IS the full document JSON.
+      // Push the modified body back via documents.batchUpdate.
+      // Strategy: replace the entire body content from the modified JSON.
+      const doc = JSON.parse(content) as Record<string, unknown>;
+      const body = doc.body as Record<string, unknown> | undefined;
+
+      if (!body?.content) {
+        return error('Cannot sync: document JSON has no body.content');
+      }
+
+      // The Docs API doesn't accept a full JSON replace — it requires batchUpdate requests.
+      // For now: re-fetch to validate our changes took effect locally,
+      // then use the local buffer as source of truth.
+      // Full batchUpdate translation is a future enhancement.
+      // The local mutation is already applied to the buffer.
+
+      // Reload from API to verify consistency
+      const result = await execute([
+        'docs', 'documents', 'get',
+        '--params', JSON.stringify({ documentId: binding.resourceId }),
+      ], { account: binding.account });
+
+      const freshJson = JSON.stringify(result.data, null, 2);
+      const freshLines = freshJson.split('\n');
+
+      // Replace buffer with fresh data
+      const sp = scratchpads.get(id);
+      if (sp) {
+        sp.lines = freshLines;
+      }
+    } else if (binding.service === 'sheets') {
+      // For Sheets: the buffer is the values JSON.
+      // Push back via spreadsheets.values.update.
+      const data = JSON.parse(content) as Record<string, unknown>;
+      const values = data.values as unknown[][] | undefined;
+      const range = data.range as string | undefined;
+
+      if (values && range) {
+        await execute([
+          'sheets', 'spreadsheets', 'values', 'update',
+          '--params', JSON.stringify({
+            spreadsheetId: binding.resourceId,
+            range,
+            valueInputOption: 'USER_ENTERED',
+            requestBody: { values },
+          }),
+        ], { account: binding.account });
+      }
+
+      // Reload from API
+      const result = await execute([
+        'sheets', 'spreadsheets', 'values', 'get',
+        '--params', JSON.stringify({
+          spreadsheetId: binding.resourceId,
+          range: range ?? 'Sheet1',
+        }),
+      ], { account: binding.account });
+
+      const freshJson = JSON.stringify(result.data, null, 2);
+      const sp = scratchpads.get(id);
+      if (sp) {
+        sp.lines = freshJson.split('\n');
+      }
+    }
+
+    return null; // Success — caller uses its own result
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      text: `Sync failed: ${message}\nLocal buffer still has your changes. Retry or discard.`,
+      refs: { error: true, scratchpadId: id },
+    };
+  }
 }
 
 // ── Attachments ───────────────────────────────────────────

--- a/src/server/scratchpad/handler.ts
+++ b/src/server/scratchpad/handler.ts
@@ -1,0 +1,385 @@
+/**
+ * Handler for manage_scratchpad tool.
+ * See ADR-301: Scratchpad Buffer — Service-Agnostic Content Authoring.
+ */
+
+import { ScratchpadManager } from './manager.js';
+import {
+  sendEmail, sendEmailDraft, sendDocCreate, sendDocWrite, sendWorkspace,
+  importEmail, importDoc,
+} from './adapters/index.js';
+import type { HandlerResponse } from '../handler.js';
+
+const scratchpads = new ScratchpadManager();
+
+/** Expose the singleton for import/send adapters. */
+export function getScratchpadManager(): ScratchpadManager {
+  return scratchpads;
+}
+
+export async function handleScratchpad(params: Record<string, unknown>): Promise<HandlerResponse> {
+  const operation = params.operation as string;
+
+  switch (operation) {
+    // ── Buffer lifecycle ────────────────────────────────
+    case 'create':
+      return handleCreate(params);
+    case 'view':
+      return handleView(params);
+    case 'discard':
+      return handleDiscard(params);
+    case 'list':
+      return handleList();
+
+    // ── Line operations ─────────────────────────────────
+    case 'insert_lines':
+      return handleInsertLines(params);
+    case 'append_lines':
+      return handleAppendLines(params);
+    case 'replace_lines':
+      return handleReplaceLines(params);
+    case 'remove_lines':
+      return handleRemoveLines(params);
+    case 'copy_lines':
+      return handleCopyLines(params);
+
+    // ── JSON path operations ────────────────────────────
+    case 'json_get':
+      return handleJsonGet(params);
+    case 'json_set':
+      return handleJsonSet(params);
+    case 'json_delete':
+      return handleJsonDelete(params);
+    case 'json_insert':
+      return handleJsonInsert(params);
+
+    // ── Attachments ─────────────────────────────────────
+    case 'attach':
+      return handleAttach(params);
+    case 'detach':
+      return handleDetach(params);
+
+    // ── Import / Send ───────────────────────────────────
+    case 'import':
+      return handleImport(params);
+    case 'send':
+      return handleSend(params);
+
+    default:
+      return error(`Unknown operation: ${operation}`);
+  }
+}
+
+// ── Helpers ────────────────────────────────────────────────
+
+function error(text: string): HandlerResponse {
+  return { text, refs: { error: true } };
+}
+
+function requireScratchpadId(params: Record<string, unknown>): string | null {
+  const id = params.scratchpadId as string | undefined;
+  if (!id) return null;
+  if (!scratchpads.get(id)) return null;
+  return id;
+}
+
+function scratchpadNotFound(id?: string): HandlerResponse {
+  if (!id) return error('scratchpadId is required. Use create to start a new scratchpad.');
+  return error(`Scratchpad ${id} not found or expired. Use create to start a new one.`);
+}
+
+function formatMutation(result: { message: string; context: string; validation: string }): string {
+  const parts = [result.message];
+  if (result.context) parts.push(result.context);
+  parts.push(result.validation);
+  return parts.join('\n');
+}
+
+// ── Buffer lifecycle ──────────────────────────────────────
+
+function handleCreate(params: Record<string, unknown>): HandlerResponse {
+  const id = scratchpads.create({
+    label: params.label as string | undefined,
+    content: params.content as string | undefined,
+    format: params.format as 'text' | 'markdown' | 'json' | 'csv' | undefined,
+  });
+
+  const sp = scratchpads.get(id)!;
+  const lineInfo = sp.lines.length > 0 ? ` (${sp.lines.length} lines)` : '';
+  return {
+    text: `Scratchpad created: ${id}${lineInfo}\nFormat: ${sp.format}`,
+    refs: { scratchpadId: id, format: sp.format, lineCount: sp.lines.length },
+  };
+}
+
+function handleView(params: Record<string, unknown>): HandlerResponse {
+  const id = requireScratchpadId(params);
+  if (!id) return scratchpadNotFound(params.scratchpadId as string);
+
+  const result = scratchpads.view(id, params.startLine as number, params.endLine as number);
+  if (!result) return scratchpadNotFound(id);
+  return { text: result, refs: { scratchpadId: id } };
+}
+
+function handleDiscard(params: Record<string, unknown>): HandlerResponse {
+  const id = params.scratchpadId as string;
+  if (!id) return error('scratchpadId is required.');
+  scratchpads.discard(id);
+  return { text: `Scratchpad ${id} discarded.`, refs: { scratchpadId: id, status: 'discarded' } };
+}
+
+function handleList(): HandlerResponse {
+  const list = scratchpads.list();
+  if (list.length === 0) {
+    return { text: 'No active scratchpads.', refs: { count: 0 } };
+  }
+
+  const lines = list.map(sp => {
+    const label = sp.label ? ` "${sp.label}"` : '';
+    const att = sp.attachmentCount > 0 ? ` | ${sp.attachmentCount} att` : '';
+    const bound = sp.bound ? ' | live' : '';
+    return `- ${sp.id}${label} | ${sp.format} | ${sp.lineCount} lines${att}${bound} | ${sp.validation}`;
+  });
+
+  return {
+    text: `Active scratchpads (${list.length}):\n${lines.join('\n')}`,
+    refs: { count: list.length, scratchpads: list.map(s => s.id) },
+  };
+}
+
+// ── Line operations ───────────────────────────────────────
+
+function handleInsertLines(params: Record<string, unknown>): HandlerResponse {
+  const id = requireScratchpadId(params);
+  if (!id) return scratchpadNotFound(params.scratchpadId as string);
+
+  const afterLine = params.afterLine as number | undefined;
+  if (afterLine === undefined) return error('afterLine is required for insert_lines.');
+  const content = params.content as string | undefined;
+  if (content === undefined) return error('content is required for insert_lines.');
+
+  const result = scratchpads.insertLines(id, afterLine, content);
+  if (!result) return scratchpadNotFound(id);
+  return { text: formatMutation(result), refs: { scratchpadId: id, lineCount: scratchpads.get(id)!.lines.length } };
+}
+
+function handleAppendLines(params: Record<string, unknown>): HandlerResponse {
+  const id = requireScratchpadId(params);
+  if (!id) return scratchpadNotFound(params.scratchpadId as string);
+
+  const content = params.content as string | undefined;
+  if (content === undefined) return error('content is required for append_lines.');
+
+  const result = scratchpads.appendLines(id, content);
+  if (!result) return scratchpadNotFound(id);
+  return { text: formatMutation(result), refs: { scratchpadId: id, lineCount: scratchpads.get(id)!.lines.length } };
+}
+
+function handleReplaceLines(params: Record<string, unknown>): HandlerResponse {
+  const id = requireScratchpadId(params);
+  if (!id) return scratchpadNotFound(params.scratchpadId as string);
+
+  const startLine = params.startLine as number | undefined;
+  const endLine = params.endLine as number | undefined;
+  if (startLine === undefined || endLine === undefined) return error('startLine and endLine are required.');
+  const content = params.content as string | undefined;
+  if (content === undefined) return error('content is required for replace_lines.');
+
+  const result = scratchpads.replaceLines(id, startLine, endLine, content);
+  if (!result) return scratchpadNotFound(id);
+  return { text: formatMutation(result), refs: { scratchpadId: id, lineCount: scratchpads.get(id)!.lines.length } };
+}
+
+function handleRemoveLines(params: Record<string, unknown>): HandlerResponse {
+  const id = requireScratchpadId(params);
+  if (!id) return scratchpadNotFound(params.scratchpadId as string);
+
+  const startLine = params.startLine as number | undefined;
+  if (startLine === undefined) return error('startLine is required for remove_lines.');
+
+  const result = scratchpads.removeLines(id, startLine, params.endLine as number | undefined);
+  if (!result) return scratchpadNotFound(id);
+  return { text: formatMutation(result), refs: { scratchpadId: id, lineCount: scratchpads.get(id)!.lines.length } };
+}
+
+function handleCopyLines(params: Record<string, unknown>): HandlerResponse {
+  const id = requireScratchpadId(params);
+  if (!id) return scratchpadNotFound(params.scratchpadId as string);
+
+  const fromId = params.fromScratchpadId as string | undefined;
+  if (!fromId) return error('fromScratchpadId is required for copy_lines.');
+  const startLine = params.startLine as number | undefined;
+  const endLine = params.endLine as number | undefined;
+  const afterLine = params.afterLine as number | undefined;
+  if (startLine === undefined || endLine === undefined || afterLine === undefined) {
+    return error('startLine, endLine, and afterLine are required for copy_lines.');
+  }
+
+  const result = scratchpads.copyLines(id, fromId, startLine, endLine, afterLine);
+  if (!result) return scratchpadNotFound(id);
+  return { text: formatMutation(result), refs: { scratchpadId: id, lineCount: scratchpads.get(id)!.lines.length } };
+}
+
+// ── JSON path operations ──────────────────────────────────
+
+function handleJsonGet(params: Record<string, unknown>): HandlerResponse {
+  const id = requireScratchpadId(params);
+  if (!id) return scratchpadNotFound(params.scratchpadId as string);
+
+  const path = params.path as string | undefined;
+  if (!path) return error('path is required for json_get.');
+
+  const result = scratchpads.jsonGet(id, path);
+  if (!result) return scratchpadNotFound(id);
+  if ('error' in result) return error(result.error);
+
+  const display = JSON.stringify(result.value, null, 2);
+  return {
+    text: `${path} (${result.lineSpan}):\n${display}`,
+    refs: { scratchpadId: id, path, value: result.value },
+  };
+}
+
+function handleJsonSet(params: Record<string, unknown>): HandlerResponse {
+  const id = requireScratchpadId(params);
+  if (!id) return scratchpadNotFound(params.scratchpadId as string);
+
+  const path = params.path as string | undefined;
+  if (!path) return error('path is required for json_set.');
+  if (!('value' in params)) return error('value is required for json_set.');
+
+  // TODO: If live-bound, translate to API mutation + reload
+  const result = scratchpads.jsonSet(id, path, params.value);
+  if (!result) return scratchpadNotFound(id);
+  return { text: formatMutation(result), refs: { scratchpadId: id } };
+}
+
+function handleJsonDelete(params: Record<string, unknown>): HandlerResponse {
+  const id = requireScratchpadId(params);
+  if (!id) return scratchpadNotFound(params.scratchpadId as string);
+
+  const path = params.path as string | undefined;
+  if (!path) return error('path is required for json_delete.');
+
+  // TODO: If live-bound, translate to API mutation + reload
+  const result = scratchpads.jsonDelete(id, path);
+  if (!result) return scratchpadNotFound(id);
+  return { text: formatMutation(result), refs: { scratchpadId: id } };
+}
+
+function handleJsonInsert(params: Record<string, unknown>): HandlerResponse {
+  const id = requireScratchpadId(params);
+  if (!id) return scratchpadNotFound(params.scratchpadId as string);
+
+  const path = params.path as string | undefined;
+  if (!path) return error('path is required for json_insert.');
+  if (!('value' in params)) return error('value is required for json_insert.');
+
+  // TODO: If live-bound, translate to API mutation + reload
+  const result = scratchpads.jsonInsert(id, path, params.value);
+  if (!result) return scratchpadNotFound(id);
+  return { text: formatMutation(result), refs: { scratchpadId: id } };
+}
+
+// ── Attachments ───────────────────────────────────────────
+
+function handleAttach(params: Record<string, unknown>): HandlerResponse {
+  const id = requireScratchpadId(params);
+  if (!id) return scratchpadNotFound(params.scratchpadId as string);
+
+  const source = params.source as 'workspace' | 'drive' | undefined;
+  if (!source) return error('source is required for attach (workspace or drive).');
+  const filename = params.filename as string | undefined;
+  const fileId = params.fileId as string | undefined;
+  if (!filename && !fileId) return error('filename (for workspace) or fileId (for drive) is required.');
+
+  // TODO: Resolve file metadata (size, mimeType) from workspace or Drive
+  const result = scratchpads.attach(id, {
+    source,
+    filename: filename ?? fileId ?? 'unknown',
+    mimeType: 'application/octet-stream',
+    size: 0,
+    location: filename ?? fileId ?? '',
+  }, params.afterLine as number | undefined);
+
+  if (!result) return scratchpadNotFound(id);
+  return { text: result.message, refs: { scratchpadId: id, refId: result.refId } };
+}
+
+function handleDetach(params: Record<string, unknown>): HandlerResponse {
+  const id = requireScratchpadId(params);
+  if (!id) return scratchpadNotFound(params.scratchpadId as string);
+
+  const refId = params.refId as string | undefined;
+  if (!refId) return error('refId is required for detach.');
+
+  const result = scratchpads.detach(id, refId);
+  if (!result) return scratchpadNotFound(id);
+  return { text: result, refs: { scratchpadId: id, refId } };
+}
+
+// ── Import / Send (stubs — adapters in separate files) ────
+
+async function handleImport(params: Record<string, unknown>): Promise<HandlerResponse> {
+  const id = requireScratchpadId(params);
+  if (!id) return scratchpadNotFound(params.scratchpadId as string);
+
+  const source = params.source as string | undefined;
+  if (!source) return error('source is required for import (doc, email, sheet, drive_file).');
+
+  const sourceParams = (params.sourceParams ?? {}) as Record<string, unknown>;
+
+  switch (source) {
+    case 'email':
+      return importEmail(scratchpads, id, sourceParams as unknown as Parameters<typeof importEmail>[2]);
+    case 'doc':
+      return importDoc(scratchpads, id, sourceParams as unknown as Parameters<typeof importDoc>[2]);
+    case 'sheet':
+      return error('Import from sheet not yet implemented.');
+    case 'drive_file':
+      return error('Import from drive_file not yet implemented.');
+    default:
+      return error(`Unknown import source: ${source}. Valid sources: doc, email, sheet, drive_file.`);
+  }
+}
+
+async function handleSend(params: Record<string, unknown>): Promise<HandlerResponse> {
+  const id = requireScratchpadId(params);
+  if (!id) return scratchpadNotFound(params.scratchpadId as string);
+
+  const target = params.target as string | undefined;
+  if (!target) return error('target is required for send (email, email_draft, doc_create, doc_write, workspace).');
+
+  const targetParams = (params.targetParams ?? {}) as Record<string, string>;
+  const keep = params.keep !== false; // default true
+
+  let result: HandlerResponse;
+
+  switch (target) {
+    case 'email':
+      result = await sendEmail(scratchpads, id, targetParams as unknown as Parameters<typeof sendEmail>[2]);
+      break;
+    case 'email_draft':
+      result = await sendEmailDraft(scratchpads, id, targetParams as unknown as Parameters<typeof sendEmailDraft>[2]);
+      break;
+    case 'doc_create':
+      result = await sendDocCreate(scratchpads, id, targetParams as unknown as Parameters<typeof sendDocCreate>[2]);
+      break;
+    case 'doc_write':
+      result = await sendDocWrite(scratchpads, id, targetParams as unknown as Parameters<typeof sendDocWrite>[2]);
+      break;
+    case 'workspace':
+      result = await sendWorkspace(scratchpads, id, targetParams as unknown as Parameters<typeof sendWorkspace>[2]);
+      break;
+    default:
+      return error(`Unknown send target: ${target}. Valid targets: email, email_draft, doc_create, doc_write, workspace.`);
+  }
+
+  // Discard scratchpad on success if keep=false
+  if (!keep && !result.refs?.error) {
+    scratchpads.discard(id);
+    result.text += `\nScratchpad ${id} discarded.`;
+  }
+
+  return result;
+}

--- a/src/server/scratchpad/json-path.ts
+++ b/src/server/scratchpad/json-path.ts
@@ -1,0 +1,80 @@
+/**
+ * JSON path helpers for path-addressed editing.
+ * Supports dot/bracket notation: $.foo.bar[0].baz
+ */
+
+/** Parse a JSON path into segments. */
+export function parsePath(path: string): (string | number)[] {
+  const segments: (string | number)[] = [];
+  const normalized = path.startsWith('$.') ? path.slice(2) : path.startsWith('$') ? path.slice(1) : path;
+  if (!normalized) return segments;
+
+  const parts = normalized.split(/\.|\[|\]/).filter(Boolean);
+  for (const part of parts) {
+    const num = parseInt(part, 10);
+    if (!isNaN(num) && String(num) === part) {
+      segments.push(num);
+    } else {
+      segments.push(part);
+    }
+  }
+  return segments;
+}
+
+/** Get a value at a JSON path. */
+export function getByPath(obj: unknown, path: string): unknown {
+  const segments = parsePath(path);
+  let current: unknown = obj;
+  for (const seg of segments) {
+    if (current === null || current === undefined || typeof current !== 'object') {
+      throw new Error(`Path ${path}: cannot traverse into ${typeof current}`);
+    }
+    current = (current as Record<string, unknown>)[String(seg)];
+  }
+  return current;
+}
+
+/** Set a value at a JSON path. */
+export function setByPath(obj: unknown, path: string, value: unknown): void {
+  const segments = parsePath(path);
+  if (segments.length === 0) throw new Error('Cannot set at root path');
+
+  let current: unknown = obj;
+  for (let i = 0; i < segments.length - 1; i++) {
+    if (current === null || current === undefined || typeof current !== 'object') {
+      throw new Error(`Path ${path}: cannot traverse into ${typeof current} at segment ${segments[i]}`);
+    }
+    current = (current as Record<string, unknown>)[String(segments[i])];
+  }
+
+  if (current === null || current === undefined || typeof current !== 'object') {
+    throw new Error(`Path ${path}: parent is not an object`);
+  }
+
+  (current as Record<string, unknown>)[String(segments[segments.length - 1])] = value;
+}
+
+/** Delete a key or array element at a JSON path. */
+export function deleteByPath(obj: unknown, path: string): void {
+  const segments = parsePath(path);
+  if (segments.length === 0) throw new Error('Cannot delete root');
+
+  let current: unknown = obj;
+  for (let i = 0; i < segments.length - 1; i++) {
+    if (current === null || current === undefined || typeof current !== 'object') {
+      throw new Error(`Path ${path}: cannot traverse into ${typeof current} at segment ${segments[i]}`);
+    }
+    current = (current as Record<string, unknown>)[String(segments[i])];
+  }
+
+  if (current === null || current === undefined || typeof current !== 'object') {
+    throw new Error(`Path ${path}: parent is not an object`);
+  }
+
+  const lastSeg = segments[segments.length - 1];
+  if (Array.isArray(current) && typeof lastSeg === 'number') {
+    current.splice(lastSeg, 1);
+  } else {
+    delete (current as Record<string, unknown>)[String(lastSeg)];
+  }
+}

--- a/src/server/scratchpad/manager.ts
+++ b/src/server/scratchpad/manager.ts
@@ -1,0 +1,857 @@
+/**
+ * ScratchpadManager — line-addressed content authoring buffer.
+ * See ADR-301: Scratchpad Buffer — Service-Agnostic Content Authoring.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { getEpoch } from '../handler.js';
+
+// ── Types ──────────────────────────────────────────────────
+
+export type ScratchpadFormat = 'text' | 'markdown' | 'json' | 'csv';
+
+/** Present when scratchpad is a live view of a GWS resource (JSON mode). */
+export interface LiveBinding {
+  service: 'docs' | 'sheets';
+  resourceId: string;
+  account: string;
+}
+
+/** File reference tracked in the attachment side-table. */
+export interface AttachmentRef {
+  refId: string;
+  source: 'workspace' | 'drive' | 'import';
+  filename: string;
+  mimeType: string;
+  size: number;
+  location: string;
+}
+
+export interface Scratchpad {
+  id: string;
+  lines: string[];
+  format: ScratchpadFormat;
+  attachments: Map<string, AttachmentRef>;
+  binding?: LiveBinding;
+  label?: string;
+  lastTouchedEpoch: number;
+  createdAt: Date;
+}
+
+export interface MutationResult {
+  message: string;
+  context: string;
+  validation: string;
+}
+
+export interface ScratchpadSummary {
+  id: string;
+  format: ScratchpadFormat;
+  label?: string;
+  lineCount: number;
+  attachmentCount: number;
+  bound: boolean;
+  validation: string;
+  lastTouchedEpoch: number;
+}
+
+// ── ScratchpadManager ──────────────────────────────────────
+
+const SCRATCHPAD_MAX_AGE_EPOCHS = 100;
+
+export class ScratchpadManager {
+  private scratchpads: Map<string, Scratchpad> = new Map();
+
+  /**
+   * Create a new scratchpad, optionally pre-filled with content.
+   */
+  create(opts?: { label?: string; content?: string; format?: ScratchpadFormat }): string {
+    this.gc();
+    const id = `sp-${randomUUID().slice(0, 12)}`;
+    const lines = opts?.content ? normalizeAndSplit(opts.content) : [];
+    this.scratchpads.set(id, {
+      id,
+      lines,
+      format: opts?.format ?? 'text',
+      attachments: new Map(),
+      label: opts?.label,
+      lastTouchedEpoch: getEpoch(),
+      createdAt: new Date(),
+    });
+    return id;
+  }
+
+  /**
+   * Get a scratchpad by ID. Returns null if not found or GC'd.
+   */
+  get(id: string): Scratchpad | null {
+    const sp = this.scratchpads.get(id);
+    if (!sp) return null;
+    if (this.isExpired(sp)) {
+      this.scratchpads.delete(id);
+      return null;
+    }
+    return sp;
+  }
+
+  /**
+   * Touch a scratchpad — resets its epoch to keep it alive.
+   */
+  private touch(sp: Scratchpad): void {
+    sp.lastTouchedEpoch = getEpoch();
+  }
+
+  /**
+   * View buffer content with line numbers and validation status.
+   */
+  view(id: string, startLine?: number, endLine?: number): string | null {
+    const sp = this.get(id);
+    if (!sp) return null;
+    this.touch(sp);
+
+    const start = startLine ? Math.max(1, startLine) : 1;
+    const end = endLine ? Math.min(endLine, sp.lines.length) : sp.lines.length;
+
+    const numbered = formatNumberedLines(sp.lines, start, end);
+    const validation = validate(sp.lines, sp.format);
+
+    const label = sp.label ? ` "${sp.label}"` : '';
+    const attInfo = sp.attachments.size > 0 ? ` | ${sp.attachments.size} attachment(s)` : '';
+    const bindInfo = sp.binding ? ` | bound: ${sp.binding.service}/${sp.binding.resourceId}` : '';
+    const header = `Scratchpad: ${sp.id}${label} | ${sp.format} | ${sp.lines.length} lines${attInfo}${bindInfo}`;
+    return `${header}\n${numbered}\n${validation}`;
+  }
+
+  /**
+   * Insert lines after a given line number. afterLine=0 prepends.
+   */
+  insertLines(id: string, afterLine: number, content: string): MutationResult | null {
+    const sp = this.get(id);
+    if (!sp) return null;
+    this.touch(sp);
+
+    if (afterLine < 0 || afterLine > sp.lines.length) {
+      return {
+        message: `Error: afterLine ${afterLine} out of range (0-${sp.lines.length}).`,
+        context: '',
+        validation: validate(sp.lines, sp.format),
+      };
+    }
+
+    const newLines = normalizeAndSplit(content);
+    sp.lines.splice(afterLine, 0, ...newLines);
+
+    const affectedStart = afterLine + 1;
+    const affectedEnd = afterLine + newLines.length;
+
+    return {
+      message: `Inserted ${newLines.length} line(s) after line ${afterLine}. Buffer: ${sp.lines.length} lines.`,
+      context: formatContext(sp.lines, affectedStart, affectedEnd),
+      validation: validate(sp.lines, sp.format),
+    };
+  }
+
+  /**
+   * Append lines at the end of the buffer.
+   */
+  appendLines(id: string, content: string): MutationResult | null {
+    const sp = this.get(id);
+    if (!sp) return null;
+    this.touch(sp);
+
+    const newLines = normalizeAndSplit(content);
+    const affectedStart = sp.lines.length + 1;
+    sp.lines.push(...newLines);
+    const affectedEnd = sp.lines.length;
+
+    return {
+      message: `Appended ${newLines.length} line(s). Buffer: ${sp.lines.length} lines.`,
+      context: formatContext(sp.lines, affectedStart, affectedEnd),
+      validation: validate(sp.lines, sp.format),
+    };
+  }
+
+  /**
+   * Replace a range of lines with new content.
+   */
+  replaceLines(id: string, startLine: number, endLine: number, content: string): MutationResult | null {
+    const sp = this.get(id);
+    if (!sp) return null;
+    this.touch(sp);
+
+    if (startLine < 1 || startLine > sp.lines.length) {
+      return {
+        message: `Error: startLine ${startLine} out of range (1-${sp.lines.length}).`,
+        context: '',
+        validation: validate(sp.lines, sp.format),
+      };
+    }
+    if (endLine < startLine || endLine > sp.lines.length) {
+      return {
+        message: `Error: endLine ${endLine} out of range (${startLine}-${sp.lines.length}).`,
+        context: '',
+        validation: validate(sp.lines, sp.format),
+      };
+    }
+
+    const newLines = normalizeAndSplit(content);
+    sp.lines.splice(startLine - 1, endLine - startLine + 1, ...newLines);
+
+    const affectedEnd = startLine + newLines.length - 1;
+
+    return {
+      message: `Replaced lines ${startLine}-${endLine}. Buffer: ${sp.lines.length} lines.`,
+      context: formatContext(sp.lines, startLine, affectedEnd),
+      validation: validate(sp.lines, sp.format),
+    };
+  }
+
+  /**
+   * Remove line(s) from the buffer.
+   */
+  removeLines(id: string, startLine: number, endLine?: number): MutationResult | null {
+    const sp = this.get(id);
+    if (!sp) return null;
+    this.touch(sp);
+
+    const end = endLine ?? startLine;
+
+    if (startLine < 1 || startLine > sp.lines.length) {
+      return {
+        message: `Error: startLine ${startLine} out of range (1-${sp.lines.length}).`,
+        context: '',
+        validation: validate(sp.lines, sp.format),
+      };
+    }
+    if (end < startLine || end > sp.lines.length) {
+      return {
+        message: `Error: endLine ${end} out of range (${startLine}-${sp.lines.length}).`,
+        context: '',
+        validation: validate(sp.lines, sp.format),
+      };
+    }
+
+    sp.lines.splice(startLine - 1, end - startLine + 1);
+
+    const joinLine = Math.min(startLine, sp.lines.length);
+
+    return {
+      message: `Removed ${end - startLine + 1} line(s). Buffer: ${sp.lines.length} lines.`,
+      context: formatRemoveContext(sp.lines, startLine, joinLine),
+      validation: validate(sp.lines, sp.format),
+    };
+  }
+
+  /**
+   * Copy lines from another scratchpad into this one.
+   * Source is not modified.
+   */
+  copyLines(
+    targetId: string,
+    sourceId: string,
+    startLine: number,
+    endLine: number,
+    afterLine: number,
+  ): MutationResult | null {
+    const target = this.get(targetId);
+    const source = this.get(sourceId);
+    if (!target) return null;
+    if (!source) {
+      return {
+        message: `Error: source scratchpad ${sourceId} not found.`,
+        context: '',
+        validation: validate(target.lines, target.format),
+      };
+    }
+
+    if (startLine < 1 || startLine > source.lines.length) {
+      return {
+        message: `Error: source startLine ${startLine} out of range (1-${source.lines.length}).`,
+        context: '',
+        validation: validate(target.lines, target.format),
+      };
+    }
+    if (endLine < startLine || endLine > source.lines.length) {
+      return {
+        message: `Error: source endLine ${endLine} out of range (${startLine}-${source.lines.length}).`,
+        context: '',
+        validation: validate(target.lines, target.format),
+      };
+    }
+    if (afterLine < 0 || afterLine > target.lines.length) {
+      return {
+        message: `Error: afterLine ${afterLine} out of range (0-${target.lines.length}).`,
+        context: '',
+        validation: validate(target.lines, target.format),
+      };
+    }
+
+    this.touch(target);
+    this.touch(source);
+
+    const copied = source.lines.slice(startLine - 1, endLine);
+    target.lines.splice(afterLine, 0, ...copied);
+
+    const affectedStart = afterLine + 1;
+    const affectedEnd = afterLine + copied.length;
+
+    return {
+      message: `Copied ${copied.length} line(s) from ${sourceId}. Buffer: ${target.lines.length} lines.`,
+      context: formatContext(target.lines, affectedStart, affectedEnd),
+      validation: validate(target.lines, target.format),
+    };
+  }
+
+  // ── Attachments ─────────────────────────────────────────
+
+  /**
+   * Attach a file reference and insert a marker line.
+   * Returns the assigned refId (e.g., "att-1").
+   */
+  attach(
+    id: string,
+    ref: Omit<AttachmentRef, 'refId'>,
+    afterLine?: number,
+  ): { refId: string; message: string } | null {
+    const sp = this.get(id);
+    if (!sp) return null;
+    this.touch(sp);
+
+    const refId = `att-${sp.attachments.size + 1}`;
+    sp.attachments.set(refId, { ...ref, refId });
+
+    const marker = `![${ref.filename}](att:${refId} "${ref.filename}, ${formatSize(ref.size)}, from ${ref.source}")`;
+    const insertAt = afterLine ?? sp.lines.length;
+    sp.lines.splice(insertAt, 0, marker);
+
+    return { refId, message: `Attached ${ref.filename} as ${refId}. Buffer: ${sp.lines.length} lines.` };
+  }
+
+  /**
+   * Remove an attachment from the side-table. Marker line is left for the agent.
+   */
+  detach(id: string, refId: string): string | null {
+    const sp = this.get(id);
+    if (!sp) return null;
+    this.touch(sp);
+
+    if (!sp.attachments.has(refId)) {
+      return `Error: attachment ${refId} not found.`;
+    }
+
+    const ref = sp.attachments.get(refId)!;
+    sp.attachments.delete(refId);
+    return `Detached ${ref.filename} (${refId}). Marker line remains in buffer — remove it with remove_lines if needed.`;
+  }
+
+  /** Get all attachments for a scratchpad. */
+  getAttachments(id: string): Map<string, AttachmentRef> | null {
+    const sp = this.get(id);
+    if (!sp) return null;
+    return sp.attachments;
+  }
+
+  // ── Live binding ───────────────────────────────────────
+
+  /** Set a live binding on a scratchpad (used by import adapters). */
+  setBinding(id: string, binding: LiveBinding): boolean {
+    const sp = this.get(id);
+    if (!sp) return false;
+    sp.binding = binding;
+    return true;
+  }
+
+  /** Get the live binding, if any. */
+  getBinding(id: string): LiveBinding | undefined {
+    const sp = this.get(id);
+    return sp?.binding;
+  }
+
+  // ── JSON path operations ───────────────────────────────
+
+  /**
+   * Get a value at a JSON path. Only valid for json-format scratchpads.
+   */
+  jsonGet(id: string, path: string): { value: unknown; lineSpan: string } | { error: string } | null {
+    const sp = this.get(id);
+    if (!sp) return null;
+    if (sp.format !== 'json') return { error: 'json_get requires format: json' };
+    this.touch(sp);
+
+    const text = sp.lines.join('\n');
+    let obj: unknown;
+    try {
+      obj = JSON.parse(text);
+    } catch {
+      return { error: 'Buffer is not valid JSON. Fix syntax errors first.' };
+    }
+
+    try {
+      const value = getByPath(obj, path);
+      const serialized = JSON.stringify(value, null, 2);
+      const lineCount = serialized.split('\n').length;
+      return { value, lineSpan: `${lineCount} line(s)` };
+    } catch (err) {
+      return { error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+
+  /**
+   * Set a value at a JSON path. Re-serializes the buffer.
+   */
+  jsonSet(id: string, path: string, value: unknown): MutationResult | null {
+    const sp = this.get(id);
+    if (!sp) return null;
+    if (sp.format !== 'json') {
+      return { message: 'Error: json_set requires format: json', context: '', validation: '' };
+    }
+    this.touch(sp);
+
+    const text = sp.lines.join('\n');
+    let obj: unknown;
+    try {
+      obj = JSON.parse(text);
+    } catch {
+      return {
+        message: 'Error: buffer is not valid JSON. Fix syntax errors first.',
+        context: '',
+        validation: validate(sp.lines, sp.format),
+      };
+    }
+
+    try {
+      setByPath(obj, path, value);
+    } catch (err) {
+      return {
+        message: `Error: ${err instanceof Error ? err.message : String(err)}`,
+        context: '',
+        validation: validate(sp.lines, sp.format),
+      };
+    }
+
+    sp.lines = JSON.stringify(obj, null, 2).split('\n');
+
+    return {
+      message: `Set ${path}. Buffer: ${sp.lines.length} lines.`,
+      context: '',
+      validation: validate(sp.lines, sp.format),
+    };
+  }
+
+  /**
+   * Delete a key or array element at a JSON path.
+   */
+  jsonDelete(id: string, path: string): MutationResult | null {
+    const sp = this.get(id);
+    if (!sp) return null;
+    if (sp.format !== 'json') {
+      return { message: 'Error: json_delete requires format: json', context: '', validation: '' };
+    }
+    this.touch(sp);
+
+    const text = sp.lines.join('\n');
+    let obj: unknown;
+    try {
+      obj = JSON.parse(text);
+    } catch {
+      return {
+        message: 'Error: buffer is not valid JSON. Fix syntax errors first.',
+        context: '',
+        validation: validate(sp.lines, sp.format),
+      };
+    }
+
+    try {
+      deleteByPath(obj, path);
+    } catch (err) {
+      return {
+        message: `Error: ${err instanceof Error ? err.message : String(err)}`,
+        context: '',
+        validation: validate(sp.lines, sp.format),
+      };
+    }
+
+    sp.lines = JSON.stringify(obj, null, 2).split('\n');
+
+    return {
+      message: `Deleted ${path}. Buffer: ${sp.lines.length} lines.`,
+      context: '',
+      validation: validate(sp.lines, sp.format),
+    };
+  }
+
+  /**
+   * Insert a value into an array at a JSON path.
+   */
+  jsonInsert(id: string, path: string, value: unknown): MutationResult | null {
+    const sp = this.get(id);
+    if (!sp) return null;
+    if (sp.format !== 'json') {
+      return { message: 'Error: json_insert requires format: json', context: '', validation: '' };
+    }
+    this.touch(sp);
+
+    const text = sp.lines.join('\n');
+    let obj: unknown;
+    try {
+      obj = JSON.parse(text);
+    } catch {
+      return {
+        message: 'Error: buffer is not valid JSON. Fix syntax errors first.',
+        context: '',
+        validation: validate(sp.lines, sp.format),
+      };
+    }
+
+    try {
+      const target = getByPath(obj, path);
+      if (!Array.isArray(target)) {
+        return {
+          message: `Error: ${path} is not an array.`,
+          context: '',
+          validation: validate(sp.lines, sp.format),
+        };
+      }
+      target.push(value);
+    } catch (err) {
+      return {
+        message: `Error: ${err instanceof Error ? err.message : String(err)}`,
+        context: '',
+        validation: validate(sp.lines, sp.format),
+      };
+    }
+
+    sp.lines = JSON.stringify(obj, null, 2).split('\n');
+
+    return {
+      message: `Inserted into ${path}. Buffer: ${sp.lines.length} lines.`,
+      context: '',
+      validation: validate(sp.lines, sp.format),
+    };
+  }
+
+  // ── Buffer access ──────────────────────────────────────
+
+  /** Get full buffer content as a single string. */
+  getContent(id: string): string | null {
+    const sp = this.get(id);
+    if (!sp) return null;
+    return sp.lines.join('\n');
+  }
+
+  /** Append raw lines to a scratchpad (used by import adapters). */
+  appendRawLines(id: string, lines: string[]): boolean {
+    const sp = this.get(id);
+    if (!sp) return false;
+    this.touch(sp);
+    sp.lines.push(...lines);
+    return true;
+  }
+
+  /** Set the format of a scratchpad (used by import adapters). */
+  setFormat(id: string, format: ScratchpadFormat): boolean {
+    const sp = this.get(id);
+    if (!sp) return false;
+    sp.format = format;
+    return true;
+  }
+
+  /** Discard and invalidate a scratchpad. */
+  discard(id: string): boolean {
+    return this.scratchpads.delete(id);
+  }
+
+  /** List all active scratchpads. */
+  list(): ScratchpadSummary[] {
+    this.gc();
+    const result: ScratchpadSummary[] = [];
+    for (const sp of this.scratchpads.values()) {
+      result.push({
+        id: sp.id,
+        format: sp.format,
+        label: sp.label,
+        lineCount: sp.lines.length,
+        attachmentCount: sp.attachments.size,
+        bound: !!sp.binding,
+        validation: validate(sp.lines, sp.format),
+        lastTouchedEpoch: sp.lastTouchedEpoch,
+      });
+    }
+    return result;
+  }
+
+  // ── Garbage collection ─────────────────────────────────
+
+  private isExpired(sp: Scratchpad): boolean {
+    return getEpoch() - sp.lastTouchedEpoch > SCRATCHPAD_MAX_AGE_EPOCHS;
+  }
+
+  private gc(): void {
+    for (const sp of this.scratchpads.values()) {
+      if (this.isExpired(sp)) {
+        this.scratchpads.delete(sp.id);
+      }
+    }
+  }
+}
+
+// ── Helpers ────────────────────────────────────────────────
+
+/** Format bytes as human-readable size. */
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/** Normalize CRLF/CR to LF and split into lines. */
+function normalizeAndSplit(content: string): string[] {
+  return content.replace(/\r\n/g, '\n').replace(/\r/g, '\n').split('\n');
+}
+
+/** Format lines with line numbers for display. */
+function formatNumberedLines(lines: string[], start: number, end: number): string {
+  if (lines.length === 0) return '  (empty buffer)';
+
+  const width = String(end).length;
+  const result: string[] = [];
+  for (let i = start; i <= end; i++) {
+    result.push(`${String(i).padStart(width)} | ${lines[i - 1]}`);
+  }
+  return result.join('\n');
+}
+
+/** Format a context marker showing the edit site with surrounding lines. */
+function formatContext(lines: string[], affectedStart: number, affectedEnd: number): string {
+  if (lines.length === 0) return '';
+
+  const width = String(Math.min(affectedEnd + 1, lines.length)).length;
+  const parts: string[] = [];
+
+  // One line before
+  if (affectedStart > 1) {
+    const ln = affectedStart - 1;
+    parts.push(`${String(ln).padStart(width)} | ${lines[ln - 1]}`);
+  }
+
+  // First affected line
+  parts.push(`${String(affectedStart).padStart(width)} | ${lines[affectedStart - 1]}`);
+
+  // Elide middle if > 2 affected lines
+  if (affectedEnd - affectedStart > 1) {
+    parts.push(`${' '.repeat(width)} | ...`);
+  }
+
+  // Last affected line (if different from first)
+  if (affectedEnd > affectedStart) {
+    parts.push(`${String(affectedEnd).padStart(width)} | ${lines[affectedEnd - 1]}`);
+  }
+
+  // One line after
+  if (affectedEnd < lines.length) {
+    const ln = affectedEnd + 1;
+    parts.push(`${String(ln).padStart(width)} | ${lines[ln - 1]}`);
+  }
+
+  return parts.join('\n');
+}
+
+/** Format context for a remove operation showing the join point. */
+function formatRemoveContext(lines: string[], removedAt: number, joinLine: number): string {
+  if (lines.length === 0) return '  (buffer now empty)';
+
+  const width = String(Math.min(joinLine + 1, lines.length)).length;
+  const parts: string[] = [];
+
+  if (removedAt > 1 && removedAt - 1 <= lines.length) {
+    const ln = removedAt - 1;
+    parts.push(`${String(ln).padStart(width)} | ${lines[ln - 1]}`);
+  }
+
+  if (joinLine >= 1 && joinLine <= lines.length) {
+    parts.push(`${String(joinLine).padStart(width)} | ${lines[joinLine - 1]}`);
+  }
+
+  return parts.join('\n');
+}
+
+// ── Validation ─────────────────────────────────────────────
+
+/** Run format-specific validation, returning a status string. */
+function validate(lines: string[], format: ScratchpadFormat): string {
+  if (lines.length === 0) return 'Status: empty';
+
+  switch (format) {
+    case 'text':
+      return `Status: valid (${lines.length} lines)`;
+
+    case 'markdown':
+      return validateMarkdown(lines);
+
+    case 'json':
+      return validateJson(lines);
+
+    case 'csv':
+      return validateCsv(lines);
+
+    default:
+      return `Status: valid (${lines.length} lines)`;
+  }
+}
+
+function validateMarkdown(lines: string[]): string {
+  let codeBlockOpen = -1;
+
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trimStart();
+
+    if (trimmed.startsWith('```')) {
+      if (codeBlockOpen === -1) {
+        codeBlockOpen = i + 1;
+      } else {
+        codeBlockOpen = -1;
+      }
+    }
+  }
+
+  if (codeBlockOpen !== -1) {
+    return `Status: invalid at line ${codeBlockOpen} — unclosed code fence`;
+  }
+
+  return `Status: valid (${lines.length} lines)`;
+}
+
+function validateJson(lines: string[]): string {
+  const text = lines.join('\n');
+  try {
+    JSON.parse(text);
+    return `Status: valid (${lines.length} lines)`;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    // V8 JSON.parse errors include position — try to extract line number
+    const posMatch = msg.match(/position (\d+)/);
+    if (posMatch) {
+      const pos = parseInt(posMatch[1], 10);
+      let line = 1;
+      let col = 1;
+      for (let i = 0; i < pos && i < text.length; i++) {
+        if (text[i] === '\n') { line++; col = 1; } else { col++; }
+      }
+      return `Status: invalid at line ${line}:${col} — ${msg.replace(/^.*?position \d+/, '').trim() || 'JSON syntax error'}`;
+    }
+    return `Status: invalid — ${msg}`;
+  }
+}
+
+function validateCsv(lines: string[]): string {
+  const nonEmpty = lines.filter(l => l.trim().length > 0);
+  if (nonEmpty.length === 0) return `Status: valid (${lines.length} lines)`;
+
+  // Count columns in first non-empty row (simple: split on comma outside quotes)
+  const expectedCols = countCsvColumns(nonEmpty[0]);
+
+  for (let i = 1; i < nonEmpty.length; i++) {
+    const cols = countCsvColumns(nonEmpty[i]);
+    if (cols !== expectedCols) {
+      // Find the actual line number in the full buffer
+      const lineNum = lines.indexOf(nonEmpty[i]) + 1;
+      return `Status: invalid at line ${lineNum} — expected ${expectedCols} columns, got ${cols}`;
+    }
+  }
+
+  return `Status: valid (${lines.length} lines, ${expectedCols} columns)`;
+}
+
+/** Count CSV columns handling quoted fields. */
+function countCsvColumns(line: string): number {
+  let cols = 1;
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (ch === '"') {
+      inQuotes = !inQuotes;
+    } else if (ch === ',' && !inQuotes) {
+      cols++;
+    }
+  }
+  return cols;
+}
+
+// ── JSON path helpers ──────────────────────────────────────
+
+/** Parse a simple JSON path like $.foo.bar[0].baz into segments. */
+function parsePath(path: string): (string | number)[] {
+  const segments: (string | number)[] = [];
+  // Strip leading $. if present
+  const normalized = path.startsWith('$.') ? path.slice(2) : path.startsWith('$') ? path.slice(1) : path;
+  if (!normalized) return segments;
+
+  const parts = normalized.split(/\.|\[|\]/).filter(Boolean);
+  for (const part of parts) {
+    const num = parseInt(part, 10);
+    if (!isNaN(num) && String(num) === part) {
+      segments.push(num);
+    } else {
+      segments.push(part);
+    }
+  }
+  return segments;
+}
+
+/** Get a value at a parsed path. */
+function getByPath(obj: unknown, path: string): unknown {
+  const segments = parsePath(path);
+  let current: unknown = obj;
+  for (const seg of segments) {
+    if (current === null || current === undefined || typeof current !== 'object') {
+      throw new Error(`Path ${path}: cannot traverse into ${typeof current}`);
+    }
+    current = (current as Record<string, unknown>)[String(seg)];
+  }
+  return current;
+}
+
+/** Set a value at a parsed path. */
+function setByPath(obj: unknown, path: string, value: unknown): void {
+  const segments = parsePath(path);
+  if (segments.length === 0) throw new Error('Cannot set at root path');
+
+  let current: unknown = obj;
+  for (let i = 0; i < segments.length - 1; i++) {
+    if (current === null || current === undefined || typeof current !== 'object') {
+      throw new Error(`Path ${path}: cannot traverse into ${typeof current} at segment ${segments[i]}`);
+    }
+    current = (current as Record<string, unknown>)[String(segments[i])];
+  }
+
+  if (current === null || current === undefined || typeof current !== 'object') {
+    throw new Error(`Path ${path}: parent is not an object`);
+  }
+
+  (current as Record<string, unknown>)[String(segments[segments.length - 1])] = value;
+}
+
+/** Delete a key or array element at a parsed path. */
+function deleteByPath(obj: unknown, path: string): void {
+  const segments = parsePath(path);
+  if (segments.length === 0) throw new Error('Cannot delete root');
+
+  let current: unknown = obj;
+  for (let i = 0; i < segments.length - 1; i++) {
+    if (current === null || current === undefined || typeof current !== 'object') {
+      throw new Error(`Path ${path}: cannot traverse into ${typeof current} at segment ${segments[i]}`);
+    }
+    current = (current as Record<string, unknown>)[String(segments[i])];
+  }
+
+  if (current === null || current === undefined || typeof current !== 'object') {
+    throw new Error(`Path ${path}: parent is not an object`);
+  }
+
+  const lastSeg = segments[segments.length - 1];
+  if (Array.isArray(current) && typeof lastSeg === 'number') {
+    current.splice(lastSeg, 1);
+  } else {
+    delete (current as Record<string, unknown>)[String(lastSeg)];
+  }
+}

--- a/src/server/scratchpad/manager.ts
+++ b/src/server/scratchpad/manager.ts
@@ -5,6 +5,8 @@
 
 import { randomUUID } from 'node:crypto';
 import { getEpoch } from '../handler.js';
+import { validate } from './validate.js';
+import { getByPath, setByPath, deleteByPath } from './json-path.js';
 
 // ── Types ──────────────────────────────────────────────────
 
@@ -587,11 +589,11 @@ export class ScratchpadManager {
   }
 
   private gc(): void {
+    const expired: string[] = [];
     for (const sp of this.scratchpads.values()) {
-      if (this.isExpired(sp)) {
-        this.scratchpads.delete(sp.id);
-      }
+      if (this.isExpired(sp)) expired.push(sp.id);
     }
+    for (const id of expired) this.scratchpads.delete(id);
   }
 }
 
@@ -675,183 +677,4 @@ function formatRemoveContext(lines: string[], removedAt: number, joinLine: numbe
   return parts.join('\n');
 }
 
-// ── Validation ─────────────────────────────────────────────
-
-/** Run format-specific validation, returning a status string. */
-function validate(lines: string[], format: ScratchpadFormat): string {
-  if (lines.length === 0) return 'Status: empty';
-
-  switch (format) {
-    case 'text':
-      return `Status: valid (${lines.length} lines)`;
-
-    case 'markdown':
-      return validateMarkdown(lines);
-
-    case 'json':
-      return validateJson(lines);
-
-    case 'csv':
-      return validateCsv(lines);
-
-    default:
-      return `Status: valid (${lines.length} lines)`;
-  }
-}
-
-function validateMarkdown(lines: string[]): string {
-  let codeBlockOpen = -1;
-
-  for (let i = 0; i < lines.length; i++) {
-    const trimmed = lines[i].trimStart();
-
-    if (trimmed.startsWith('```')) {
-      if (codeBlockOpen === -1) {
-        codeBlockOpen = i + 1;
-      } else {
-        codeBlockOpen = -1;
-      }
-    }
-  }
-
-  if (codeBlockOpen !== -1) {
-    return `Status: invalid at line ${codeBlockOpen} — unclosed code fence`;
-  }
-
-  return `Status: valid (${lines.length} lines)`;
-}
-
-function validateJson(lines: string[]): string {
-  const text = lines.join('\n');
-  try {
-    JSON.parse(text);
-    return `Status: valid (${lines.length} lines)`;
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    // V8 JSON.parse errors include position — try to extract line number
-    const posMatch = msg.match(/position (\d+)/);
-    if (posMatch) {
-      const pos = parseInt(posMatch[1], 10);
-      let line = 1;
-      let col = 1;
-      for (let i = 0; i < pos && i < text.length; i++) {
-        if (text[i] === '\n') { line++; col = 1; } else { col++; }
-      }
-      return `Status: invalid at line ${line}:${col} — ${msg.replace(/^.*?position \d+/, '').trim() || 'JSON syntax error'}`;
-    }
-    return `Status: invalid — ${msg}`;
-  }
-}
-
-function validateCsv(lines: string[]): string {
-  const nonEmpty = lines.filter(l => l.trim().length > 0);
-  if (nonEmpty.length === 0) return `Status: valid (${lines.length} lines)`;
-
-  // Count columns in first non-empty row (simple: split on comma outside quotes)
-  const expectedCols = countCsvColumns(nonEmpty[0]);
-
-  for (let i = 1; i < nonEmpty.length; i++) {
-    const cols = countCsvColumns(nonEmpty[i]);
-    if (cols !== expectedCols) {
-      // Find the actual line number in the full buffer
-      const lineNum = lines.indexOf(nonEmpty[i]) + 1;
-      return `Status: invalid at line ${lineNum} — expected ${expectedCols} columns, got ${cols}`;
-    }
-  }
-
-  return `Status: valid (${lines.length} lines, ${expectedCols} columns)`;
-}
-
-/** Count CSV columns handling quoted fields. */
-function countCsvColumns(line: string): number {
-  let cols = 1;
-  let inQuotes = false;
-  for (let i = 0; i < line.length; i++) {
-    const ch = line[i];
-    if (ch === '"') {
-      inQuotes = !inQuotes;
-    } else if (ch === ',' && !inQuotes) {
-      cols++;
-    }
-  }
-  return cols;
-}
-
-// ── JSON path helpers ──────────────────────────────────────
-
-/** Parse a simple JSON path like $.foo.bar[0].baz into segments. */
-function parsePath(path: string): (string | number)[] {
-  const segments: (string | number)[] = [];
-  // Strip leading $. if present
-  const normalized = path.startsWith('$.') ? path.slice(2) : path.startsWith('$') ? path.slice(1) : path;
-  if (!normalized) return segments;
-
-  const parts = normalized.split(/\.|\[|\]/).filter(Boolean);
-  for (const part of parts) {
-    const num = parseInt(part, 10);
-    if (!isNaN(num) && String(num) === part) {
-      segments.push(num);
-    } else {
-      segments.push(part);
-    }
-  }
-  return segments;
-}
-
-/** Get a value at a parsed path. */
-function getByPath(obj: unknown, path: string): unknown {
-  const segments = parsePath(path);
-  let current: unknown = obj;
-  for (const seg of segments) {
-    if (current === null || current === undefined || typeof current !== 'object') {
-      throw new Error(`Path ${path}: cannot traverse into ${typeof current}`);
-    }
-    current = (current as Record<string, unknown>)[String(seg)];
-  }
-  return current;
-}
-
-/** Set a value at a parsed path. */
-function setByPath(obj: unknown, path: string, value: unknown): void {
-  const segments = parsePath(path);
-  if (segments.length === 0) throw new Error('Cannot set at root path');
-
-  let current: unknown = obj;
-  for (let i = 0; i < segments.length - 1; i++) {
-    if (current === null || current === undefined || typeof current !== 'object') {
-      throw new Error(`Path ${path}: cannot traverse into ${typeof current} at segment ${segments[i]}`);
-    }
-    current = (current as Record<string, unknown>)[String(segments[i])];
-  }
-
-  if (current === null || current === undefined || typeof current !== 'object') {
-    throw new Error(`Path ${path}: parent is not an object`);
-  }
-
-  (current as Record<string, unknown>)[String(segments[segments.length - 1])] = value;
-}
-
-/** Delete a key or array element at a parsed path. */
-function deleteByPath(obj: unknown, path: string): void {
-  const segments = parsePath(path);
-  if (segments.length === 0) throw new Error('Cannot delete root');
-
-  let current: unknown = obj;
-  for (let i = 0; i < segments.length - 1; i++) {
-    if (current === null || current === undefined || typeof current !== 'object') {
-      throw new Error(`Path ${path}: cannot traverse into ${typeof current} at segment ${segments[i]}`);
-    }
-    current = (current as Record<string, unknown>)[String(segments[i])];
-  }
-
-  if (current === null || current === undefined || typeof current !== 'object') {
-    throw new Error(`Path ${path}: parent is not an object`);
-  }
-
-  const lastSeg = segments[segments.length - 1];
-  if (Array.isArray(current) && typeof lastSeg === 'number') {
-    current.splice(lastSeg, 1);
-  } else {
-    delete (current as Record<string, unknown>)[String(lastSeg)];
-  }
-}
+// Validation: ./validate.ts | JSON path: ./json-path.ts

--- a/src/server/scratchpad/validate.ts
+++ b/src/server/scratchpad/validate.ts
@@ -1,0 +1,103 @@
+/**
+ * Format-specific validators for scratchpad content.
+ * Each returns a status string appended to mutation responses.
+ */
+
+import type { ScratchpadFormat } from './manager.js';
+
+/** Run format-specific validation, returning a status string. */
+export function validate(lines: string[], format: ScratchpadFormat): string {
+  if (lines.length === 0) return 'Status: empty';
+
+  switch (format) {
+    case 'text':
+      return `Status: valid (${lines.length} lines)`;
+
+    case 'markdown':
+      return validateMarkdown(lines);
+
+    case 'json':
+      return validateJson(lines);
+
+    case 'csv':
+      return validateCsv(lines);
+
+    default:
+      return `Status: valid (${lines.length} lines)`;
+  }
+}
+
+function validateMarkdown(lines: string[]): string {
+  let codeBlockOpen = -1;
+
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trimStart();
+
+    if (trimmed.startsWith('```')) {
+      if (codeBlockOpen === -1) {
+        codeBlockOpen = i + 1;
+      } else {
+        codeBlockOpen = -1;
+      }
+    }
+  }
+
+  if (codeBlockOpen !== -1) {
+    return `Status: invalid at line ${codeBlockOpen} — unclosed code fence`;
+  }
+
+  return `Status: valid (${lines.length} lines)`;
+}
+
+function validateJson(lines: string[]): string {
+  const text = lines.join('\n');
+  try {
+    JSON.parse(text);
+    return `Status: valid (${lines.length} lines)`;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    const posMatch = msg.match(/position (\d+)/);
+    if (posMatch) {
+      const pos = parseInt(posMatch[1], 10);
+      let line = 1;
+      let col = 1;
+      for (let i = 0; i < pos && i < text.length; i++) {
+        if (text[i] === '\n') { line++; col = 1; } else { col++; }
+      }
+      return `Status: invalid at line ${line}:${col} — ${msg.replace(/^.*?position \d+/, '').trim() || 'JSON syntax error'}`;
+    }
+    return `Status: invalid — ${msg}`;
+  }
+}
+
+function validateCsv(lines: string[]): string {
+  const nonEmpty = lines.filter(l => l.trim().length > 0);
+  if (nonEmpty.length === 0) return `Status: valid (${lines.length} lines)`;
+
+  const expectedCols = countCsvColumns(nonEmpty[0]);
+
+  for (let i = 1; i < nonEmpty.length; i++) {
+    const cols = countCsvColumns(nonEmpty[i]);
+    if (cols !== expectedCols) {
+      const lineNum = lines.indexOf(nonEmpty[i]) + 1;
+      return `Status: invalid at line ${lineNum} — expected ${expectedCols} columns, got ${cols}`;
+    }
+  }
+
+  return `Status: valid (${lines.length} lines, ${expectedCols} columns)`;
+}
+
+/** Count CSV columns handling quoted fields. */
+function countCsvColumns(line: string): number {
+  let cols = 1;
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (ch === '"') {
+      inQuotes = !inQuotes;
+    } else if (ch === ',' && !inQuotes) {
+      cols++;
+    }
+  }
+  return cols;
+}

--- a/src/server/tools.ts
+++ b/src/server/tools.ts
@@ -92,7 +92,7 @@ const handCodedSchemas: ToolSchema[] = [
         // import
         sourceParams: { type: 'object', description: 'For import: source-specific parameters (e.g., { documentId, mode } for doc, { messageId } for email)' },
         // send
-        target: { type: 'string', enum: ['email', 'email_draft', 'doc_create', 'doc_write', 'workspace'], description: 'For send: delivery target' },
+        target: { type: 'string', enum: ['email', 'email_draft', 'doc_create', 'doc_write', 'workspace', 'sheet_write', 'calendar_event', 'task_create'], description: 'For send: delivery target' },
         targetParams: { type: 'object', description: 'For send: target-specific parameters (e.g., { email, to, subject } for email, { filename } for workspace)' },
         keep: { type: 'boolean', description: 'For send: keep scratchpad after successful send (default: true)' },
       },

--- a/src/server/tools.ts
+++ b/src/server/tools.ts
@@ -54,6 +54,53 @@ const handCodedSchemas: ToolSchema[] = [
     },
   },
   {
+    name: 'manage_scratchpad',
+    description: 'Compose, edit, and deliver text content. Use for any multi-line content: emails, documents, descriptions. Compose in the scratchpad, edit by line or JSON path, attach files, then send to any target. For short one-liners, use the service tool directly instead.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        operation: {
+          type: 'string',
+          enum: [
+            'create', 'view', 'discard', 'list',
+            'insert_lines', 'append_lines', 'replace_lines', 'remove_lines', 'copy_lines',
+            'json_get', 'json_set', 'json_delete', 'json_insert',
+            'attach', 'detach',
+            'import', 'send',
+          ],
+          description: 'create: new buffer | view: show content | discard: free buffer | list: show all | insert_lines/append_lines/replace_lines/remove_lines: line editing | copy_lines: copy from another scratchpad | json_get/json_set/json_delete/json_insert: path-addressed JSON editing | attach/detach: file references | import: load from GWS resource | send: deliver to target',
+        },
+        scratchpadId: { type: 'string', description: 'Scratchpad ID (sp-XXXX). Required for all operations except create and list.' },
+        // create
+        label: { type: 'string', description: 'For create: optional human-readable label' },
+        format: { type: 'string', enum: ['text', 'markdown', 'json', 'csv'], description: 'For create: content format (default: text). Controls validation and addressing mode.' },
+        // line ops
+        content: { type: 'string', description: 'Text content. For create (pre-fill), insert_lines, append_lines, replace_lines.' },
+        afterLine: { type: 'number', description: 'Insert after this line number (0 = prepend). For insert_lines, copy_lines, attach.' },
+        startLine: { type: 'number', description: 'Start of line range (1-based). For replace_lines, remove_lines, copy_lines, view.' },
+        endLine: { type: 'number', description: 'End of line range (inclusive). For replace_lines, remove_lines, copy_lines, view.' },
+        // copy_lines
+        fromScratchpadId: { type: 'string', description: 'For copy_lines: source scratchpad ID' },
+        // json path ops
+        path: { type: 'string', description: 'For json_* ops: JSON path (e.g., $.config.name, $.items[0].value)' },
+        value: { description: 'For json_set, json_insert: value to set or insert (any JSON type)' },
+        // attach
+        source: { type: 'string', description: 'For attach: file source (workspace or drive). For import: resource type (doc, email, sheet, drive_file).' },
+        filename: { type: 'string', description: 'For attach (workspace source): filename in workspace' },
+        fileId: { type: 'string', description: 'For attach (drive source): Drive file ID' },
+        refId: { type: 'string', description: 'For detach: attachment reference ID (att-1, att-2, etc.)' },
+        // import
+        sourceParams: { type: 'object', description: 'For import: source-specific parameters (e.g., { documentId, mode } for doc, { messageId } for email)' },
+        // send
+        target: { type: 'string', enum: ['email', 'email_draft', 'doc_create', 'doc_write', 'workspace'], description: 'For send: delivery target' },
+        targetParams: { type: 'object', description: 'For send: target-specific parameters (e.g., { email, to, subject } for email, { filename } for workspace)' },
+        keep: { type: 'boolean', description: 'For send: keep scratchpad after successful send (default: true)' },
+      },
+      required: ['operation'],
+      additionalProperties: false,
+    },
+  },
+  {
     name: 'queue_operations',
     description: 'Execute multiple operations in sequence. Operations run in order with result references ($0.field) to chain outputs. Use for multi-step workflows.',
     inputSchema: {
@@ -66,7 +113,7 @@ const handCodedSchemas: ToolSchema[] = [
             properties: {
               tool: {
                 type: 'string',
-                enum: ['manage_email', 'manage_calendar', 'manage_drive', 'manage_accounts'],
+                enum: ['manage_email', 'manage_calendar', 'manage_drive', 'manage_accounts', 'manage_scratchpad'],
                 description: 'Tool to call',
               },
               args: {


### PR DESCRIPTION
## Summary

- Adds `manage_scratchpad` MCP tool — an in-memory, line-addressed content buffer that decouples composition from delivery
- 17 operations: line editing, JSON path editing, attachments, import from 5 GWS sources, send to 8 GWS targets
- Epoch-based GC (100 tool calls), late-bound targets, cross-scratchpad assembly, format-driven validation
- ADR-301 documents the design: late-bound targets, live binding for JSON mode, attachment side-table

**Send targets:** email, email_draft, doc_create, doc_write, workspace, sheet_write, calendar_event, task_create
**Import sources:** doc (markdown/json), email, sheet, drive_file, meet transcript

## Why

Every content operation was previously a direct API call — no retry resilience, no incremental editing, no content reuse across targets. A 500-word email that fails on wrong account wastes ~700 tokens on recomposition. The scratchpad eliminates this: compose once, edit by line, send to any target, retry on failure without content loss.

## Test plan

- [x] 115 unit tests for ScratchpadManager (line ops, JSON path, attachments, GC, validation)
- [x] Live tested: compose → email, workspace, doc_create, task_create
- [x] Live tested: import email → edit → doc_create (cross-account: gmail → praecipio)
- [x] Live tested: import Meet transcript → workspace .md → Drive upload (praecipio)
- [x] Live tested: cross-scratchpad copy_lines → email
- [x] Live tested: CSV validation (column count error detection + inline fix)
- [x] Live tested: JSON path editing (json_get, json_set)
- [ ] Sheet write adapter (not live tested — no test spreadsheet)
- [ ] Calendar event adapter (not live tested)
- [ ] Live binding JSON sync (not live tested — needs doc import in JSON mode)