### PR TITLE
feat(workspace): nested directories, move, and mkdir

### DIFF
--- a/src/__tests__/executor/workspace.test.ts
+++ b/src/__tests__/executor/workspace.test.ts
@@ -1,4 +1,4 @@
-import { validateWorkspaceDir, resolveWorkspacePath, getWorkspaceDir, checkWorkspaceStatus } from '../../executor/workspace.js';
+import { validateWorkspaceDir, resolveWorkspacePath, getWorkspaceDir, checkWorkspaceStatus, sanitizePath } from '../../executor/workspace.js';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
@@ -44,6 +44,45 @@ describe('validateWorkspaceDir', () => {
   });
 });
 
+describe('sanitizePath', () => {
+  it('preserves directory separators', () => {
+    expect(sanitizePath('reports/q1/summary.csv')).toBe(path.join('reports', 'q1', 'summary.csv'));
+  });
+
+  it('sanitizes each segment individually', () => {
+    expect(sanitizePath('reports/<bad>/file.txt')).toBe(path.join('reports', '_bad_', 'file.txt'));
+  });
+
+  it('rejects .. traversal segments', () => {
+    expect(() => sanitizePath('../etc/passwd')).toThrow(/traversal/);
+    expect(() => sanitizePath('reports/../../etc/passwd')).toThrow(/traversal/);
+  });
+
+  it('rejects . segments', () => {
+    expect(() => sanitizePath('./file.txt')).toThrow(/traversal/);
+  });
+
+  it('handles empty input', () => {
+    expect(sanitizePath('')).toBe('unnamed');
+  });
+
+  it('collapses empty segments from double slashes', () => {
+    expect(sanitizePath('reports//q1///file.txt')).toBe(path.join('reports', 'q1', 'file.txt'));
+  });
+
+  it('normalizes backslashes', () => {
+    expect(sanitizePath('reports\\q1\\file.txt')).toBe(path.join('reports', 'q1', 'file.txt'));
+  });
+
+  it('strips leading dots from segments', () => {
+    expect(sanitizePath('.hidden/file.txt')).toBe(path.join('hidden', 'file.txt'));
+  });
+
+  it('handles single filename (no separators)', () => {
+    expect(sanitizePath('report.csv')).toBe('report.csv');
+  });
+});
+
 describe('resolveWorkspacePath', () => {
   const origEnv = process.env.WORKSPACE_DIR;
 
@@ -64,22 +103,18 @@ describe('resolveWorkspacePath', () => {
     expect(resolved).toBe('/tmp/test-workspace/report.csv');
   });
 
-  it('resolves filename within workspace (sanitized)', () => {
-    // Slashes in filenames get sanitized to underscores
-    const resolved = resolveWorkspacePath('report.csv');
-    expect(resolved).toBe('/tmp/test-workspace/report.csv');
+  it('resolves nested path within workspace', () => {
+    const resolved = resolveWorkspacePath('reports/q1/summary.csv');
+    expect(resolved).toBe('/tmp/test-workspace/reports/q1/summary.csv');
   });
 
-  it('sanitizes path separators in filenames', () => {
-    // Path separators become underscores — no directory traversal
-    const resolved = resolveWorkspacePath('../../etc/passwd');
-    // Leading dots stripped, slashes become underscores
-    expect(resolved).toBe('/tmp/test-workspace/_.._etc_passwd');
+  it('rejects path traversal via ..', () => {
+    expect(() => resolveWorkspacePath('../../etc/passwd')).toThrow(/traversal/);
   });
 
-  it('sanitizes absolute paths', () => {
-    const resolved = resolveWorkspacePath('/etc/passwd');
-    expect(resolved).toBe('/tmp/test-workspace/_etc_passwd');
+  it('sanitizes dangerous characters in path segments', () => {
+    const resolved = resolveWorkspacePath('reports/<bad>/file.txt');
+    expect(resolved).toBe('/tmp/test-workspace/reports/_bad_/file.txt');
   });
 
   it('sanitizes null bytes and control characters', () => {

--- a/src/executor/file-output.ts
+++ b/src/executor/file-output.ts
@@ -25,6 +25,7 @@ const TEXT_EXTENSIONS = [
 ];
 
 /** Image MIME types supported by MCP image content blocks. */
+/** Raster image types returned as MCP image blocks. SVG excluded — it's text/XML. */
 const IMAGE_MIME_MAP: Record<string, string> = {
   '.png': 'image/png',
   '.jpg': 'image/jpeg',
@@ -32,7 +33,6 @@ const IMAGE_MIME_MAP: Record<string, string> = {
   '.gif': 'image/gif',
   '.webp': 'image/webp',
   '.bmp': 'image/bmp',
-  '.svg': 'image/svg+xml',
 };
 
 const MAX_INLINE_SIZE = 100_000; // 100KB — larger text files are saved only

--- a/src/executor/file-output.ts
+++ b/src/executor/file-output.ts
@@ -4,12 +4,13 @@
  * sandboxed environments (Claude Desktop) can't read the MCP server's
  * local filesystem, so text content must be included in the response.
  *
- * Used by: getAttachment (gmail), download (drive), export (drive)
+ * Used by: getAttachment (gmail), download (drive), export (drive), workspace read
  */
 
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { ensureWorkspaceDir, resolveWorkspacePath, verifyPathSafety } from './workspace.js';
+import type { ContentBlock } from '../server/formatting/markdown.js';
 
 /** MIME types and extensions considered text-safe for inline return. */
 const TEXT_MIME_PREFIXES = [
@@ -23,7 +24,19 @@ const TEXT_EXTENSIONS = [
   '.sh', '.bash', '.zsh', '.css', '.svg',
 ];
 
+/** Image MIME types supported by MCP image content blocks. */
+const IMAGE_MIME_MAP: Record<string, string> = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.bmp': 'image/bmp',
+  '.svg': 'image/svg+xml',
+};
+
 const MAX_INLINE_SIZE = 100_000; // 100KB — larger text files are saved only
+const MAX_IMAGE_SIZE = 5_000_000; // 5MB — larger images are path-only
 
 /** Check if a file should have its content returned inline. */
 export function isTextFile(filename: string, mimeType?: string): boolean {
@@ -32,12 +45,47 @@ export function isTextFile(filename: string, mimeType?: string): boolean {
   return TEXT_EXTENSIONS.includes(ext);
 }
 
+/** Check if a file is an image that can be returned as an MCP image block. */
+export function isImageFile(filename: string, mimeType?: string): boolean {
+  if (mimeType && mimeType.startsWith('image/')) return true;
+  const ext = path.extname(filename).toLowerCase();
+  return ext in IMAGE_MIME_MAP;
+}
+
+/** Get the image MIME type for a filename or explicit MIME. */
+export function getImageMimeType(filename: string, mimeType?: string): string {
+  if (mimeType && mimeType.startsWith('image/')) return mimeType;
+  const ext = path.extname(filename).toLowerCase();
+  return IMAGE_MIME_MAP[ext] ?? 'image/png';
+}
+
+/** Build an MCP image content block from a buffer. Returns undefined if too large. */
+export function buildImageBlock(buffer: Buffer, filename: string, mimeType?: string): ContentBlock | undefined {
+  if (buffer.length > MAX_IMAGE_SIZE) return undefined;
+  return {
+    type: 'image',
+    data: buffer.toString('base64'),
+    mimeType: getImageMimeType(filename, mimeType),
+  };
+}
+
+/** Build an MCP image content block from a file on disk. Returns undefined if not an image or too large. */
+export async function buildImageBlockFromFile(filePath: string, filename: string, mimeType?: string): Promise<ContentBlock | undefined> {
+  if (!isImageFile(filename, mimeType)) return undefined;
+  const stat = await fs.stat(filePath);
+  if (stat.size > MAX_IMAGE_SIZE) return undefined;
+  const buffer = await fs.readFile(filePath);
+  return buildImageBlock(buffer, filename, mimeType);
+}
+
 export interface FileOutputResult {
   filename: string;
   path: string;
   size: number;
   /** Text content included inline for containerized agents. Undefined for binary files. */
   content?: string;
+  /** Image content block for visual files. */
+  imageBlock?: ContentBlock;
 }
 
 /**
@@ -66,6 +114,8 @@ export async function saveToWorkspace(
 
   if (isTextFile(filename, mimeType) && buffer.length < MAX_INLINE_SIZE) {
     result.content = buffer.toString('utf-8');
+  } else if (isImageFile(filename, mimeType)) {
+    result.imageBlock = buildImageBlock(buffer, filename, mimeType);
   }
 
   return result;
@@ -84,6 +134,8 @@ export function formatFileOutput(result: FileOutputResult): string {
     // Escape any triple backticks in the content to prevent markdown fence injection
     const safeContent = result.content.replace(/```/g, '` ` `');
     parts.push('', '---', '', '```', safeContent, '```');
+  } else if (result.imageBlock) {
+    parts.push('', '_Image included inline below._');
   }
 
   return parts.join('\n');

--- a/src/executor/workspace.ts
+++ b/src/executor/workspace.ts
@@ -111,7 +111,7 @@ export async function ensureWorkspaceDir(): Promise<WorkspaceStatus> {
 }
 
 /**
- * Sanitize a filename from external sources (email attachments, Drive metadata).
+ * Sanitize a single filename segment (no path separators).
  * Strips null bytes, control characters, path separators, and other dangerous chars.
  */
 export function sanitizeFilename(filename: string): string {
@@ -133,12 +133,34 @@ export function sanitizeFilename(filename: string): string {
 }
 
 /**
+ * Sanitize a path that may contain directory separators.
+ * Each segment is sanitized individually; empty and traversal segments are rejected.
+ */
+export function sanitizePath(inputPath: string): string {
+  // Normalize separators to forward slash, then split
+  const segments = inputPath.replace(/\\/g, '/').split('/').filter(Boolean);
+
+  if (segments.length === 0) return 'unnamed';
+
+  const sanitized = segments.map(segment => {
+    // Reject traversal segments before sanitization
+    if (segment === '..' || segment === '.') {
+      throw new Error(`Path traversal segment rejected: "${segment}"`);
+    }
+    return sanitizeFilename(segment);
+  });
+
+  return sanitized.join(path.sep);
+}
+
+/**
  * Resolve a file path within the workspace directory.
- * Prevents path traversal (e.g. ../../etc/passwd) and sanitizes the filename.
+ * Supports nested paths (e.g. "reports/q1/summary.csv").
+ * Prevents path traversal and sanitizes each path segment.
  */
 export function resolveWorkspacePath(filename: string): string {
   const dir = getWorkspaceDir();
-  const sanitized = sanitizeFilename(filename);
+  const sanitized = sanitizePath(filename);
   const resolved = path.resolve(dir, sanitized);
 
   // Ensure the resolved path is still inside the workspace

--- a/src/factory/manifest.yaml
+++ b/src/factory/manifest.yaml
@@ -195,6 +195,22 @@ services:
         defaults:
           userId: me
 
+      viewAttachment:
+        type: detail
+        description: "view an image attachment inline without saving to workspace (png, jpg, gif, webp). Use for quick preview — use getAttachment to save."
+        resource: users.messages.attachments.get
+        params:
+          messageId:
+            type: string
+            description: "Message ID containing the attachment"
+            required: true
+          filename:
+            type: string
+            description: "Image filename from the read response"
+            required: true
+        defaults:
+          userId: me
+
       modify:
         type: action
         description: "add or remove labels on a message (e.g. archive, mark read/unread)"
@@ -475,6 +491,16 @@ services:
         cli_args:
           name: "--name"
           parentFolderId: "--parent"
+
+      viewImage:
+        type: detail
+        description: "view an image file inline without saving to workspace (png, jpg, gif, webp). Use for quick preview — use download to save."
+        resource: files.get
+        params:
+          fileId:
+            type: string
+            description: "File ID of the image to view"
+            required: true
 
       download:
         type: detail

--- a/src/server/formatting/markdown.ts
+++ b/src/server/formatting/markdown.ts
@@ -9,10 +9,19 @@
  *   structured values queue $N.field resolution needs
  */
 
+/** MCP content block for inline image/audio return. */
+export interface ContentBlock {
+  type: 'image' | 'audio';
+  data: string;       // base64-encoded
+  mimeType: string;
+}
+
 /** Shared response shape — markdown text for agents, structured refs for queue $N.field. */
 export interface HandlerResponse {
   text: string;
   refs: Record<string, unknown>;
+  /** Optional content blocks (images, audio) returned alongside text. */
+  content?: ContentBlock[];
 }
 
 // --- Email body extraction ---

--- a/src/server/handlers/workspace.ts
+++ b/src/server/handlers/workspace.ts
@@ -12,26 +12,38 @@ import { ensureWorkspaceDir, resolveWorkspacePath, verifyPathSafety, getWorkspac
 import { isTextFile, buildImageBlockFromFile } from '../../executor/file-output.js';
 import type { HandlerResponse } from '../formatting/markdown.js';
 
-/** Recursively list files under a directory, returning relative paths. */
+/** Recursively list files under a directory, returning relative paths. Skips symlinks that escape the workspace. */
 async function listRecursive(root: string, subdir: string = ''): Promise<{ relativePath: string; size: number; isDir: boolean }[]> {
   const entries: { relativePath: string; size: number; isDir: boolean }[] = [];
   const dirPath = subdir ? path.join(root, subdir) : root;
+  const resolvedRoot = path.resolve(root);
 
   let dirents: import('node:fs').Dirent[];
   try {
     dirents = await fs.readdir(dirPath, { withFileTypes: true });
-  } catch {
-    return entries;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return entries;
+    throw err;
   }
 
   for (const dirent of dirents) {
     const rel = subdir ? path.join(subdir, dirent.name) : dirent.name;
+    const fullPath = path.join(root, rel);
+
+    // Verify symlinks don't escape the workspace
+    try {
+      const real = await fs.realpath(fullPath);
+      if (!real.startsWith(resolvedRoot + path.sep) && real !== resolvedRoot) continue;
+    } catch {
+      continue; // Skip broken symlinks
+    }
+
     if (dirent.isDirectory()) {
       entries.push({ relativePath: rel, size: 0, isDir: true });
       const children = await listRecursive(root, rel);
       entries.push(...children);
     } else {
-      const stat = await fs.stat(path.join(root, rel));
+      const stat = await fs.stat(fullPath);
       entries.push({ relativePath: rel, size: stat.size, isDir: false });
     }
   }
@@ -172,8 +184,41 @@ export async function handleWorkspace(params: Record<string, unknown>): Promise<
       const filePath = resolveWorkspacePath(filename);
       await verifyPathSafety(filePath);
 
-      const stat = await fs.stat(filePath);
+      // Prevent deleting the workspace root itself
+      const wsRoot = path.resolve(getWorkspaceDir());
+      if (path.resolve(filePath) === wsRoot) {
+        throw new Error('Cannot delete the workspace root directory');
+      }
+
+      const stat = await fs.lstat(filePath);
+
+      // If it's a symlink, just unlink it (don't follow)
+      if (stat.isSymbolicLink()) {
+        await fs.unlink(filePath);
+        return {
+          text: `Symlink deleted: **${filename}**`,
+          refs: { filename, status: 'deleted', type: 'symlink' },
+        };
+      }
+
       if (stat.isDirectory()) {
+        // Verify no symlinks inside escape the workspace before recursive delete
+        const resolvedRoot = path.resolve(getWorkspaceDir());
+        async function verifyTreeSafety(dir: string): Promise<void> {
+          const entries = await fs.readdir(dir, { withFileTypes: true });
+          for (const entry of entries) {
+            const entryPath = path.join(dir, entry.name);
+            const real = await fs.realpath(entryPath);
+            if (!real.startsWith(resolvedRoot + path.sep) && real !== resolvedRoot) {
+              throw new Error(`Cannot delete: "${entry.name}" links outside workspace`);
+            }
+            if (entry.isDirectory() && !entry.isSymbolicLink()) {
+              await verifyTreeSafety(entryPath);
+            }
+          }
+        }
+        await verifyTreeSafety(filePath);
+
         await fs.rm(filePath, { recursive: true });
         return {
           text: `Directory deleted: **${filename}/**`,

--- a/src/server/handlers/workspace.ts
+++ b/src/server/handlers/workspace.ts
@@ -188,6 +188,7 @@ export async function handleWorkspace(params: Record<string, unknown>): Promise<
       const srcPath = resolveWorkspacePath(source);
       const destPath = resolveWorkspacePath(destination);
       await verifyPathSafety(srcPath);
+      await verifyPathSafety(destPath);
 
       // Ensure destination parent exists
       await fs.mkdir(path.dirname(destPath), { recursive: true });

--- a/src/server/handlers/workspace.ts
+++ b/src/server/handlers/workspace.ts
@@ -9,7 +9,7 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { ensureWorkspaceDir, resolveWorkspacePath, verifyPathSafety, getWorkspaceDir, sanitizePath } from '../../executor/workspace.js';
-import { isTextFile } from '../../executor/file-output.js';
+import { isTextFile, buildImageBlockFromFile } from '../../executor/file-output.js';
 import type { HandlerResponse } from '../formatting/markdown.js';
 
 /** Recursively list files under a directory, returning relative paths. */
@@ -108,6 +108,16 @@ export async function handleWorkspace(params: Record<string, unknown>): Promise<
       const filePath = resolveWorkspacePath(filename);
       await verifyPathSafety(filePath);
       const stat = await fs.stat(filePath);
+
+      // Try image block first (up to 5MB)
+      const imageBlock = await buildImageBlockFromFile(filePath, filename);
+      if (imageBlock) {
+        return {
+          text: `## ${filename}\n\n**Path:** ${filePath}\n**Size:** ${stat.size} bytes\n\n_Image included inline below._`,
+          refs: { filename, path: filePath, size: stat.size },
+          content: [imageBlock],
+        };
+      }
 
       if (stat.size > 100_000) {
         return {

--- a/src/server/handlers/workspace.ts
+++ b/src/server/handlers/workspace.ts
@@ -3,14 +3,47 @@
  *
  * The workspace is the exchange point between the MCP server and the agent.
  * Files saved by getAttachment, download, and export land here. The agent
- * can also read, write, and manage files directly.
+ * can also read, write, and manage files directly — including nested directories.
  */
 
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
-import { ensureWorkspaceDir, resolveWorkspacePath, verifyPathSafety, getWorkspaceDir } from '../../executor/workspace.js';
+import { ensureWorkspaceDir, resolveWorkspacePath, verifyPathSafety, getWorkspaceDir, sanitizePath } from '../../executor/workspace.js';
 import { isTextFile } from '../../executor/file-output.js';
 import type { HandlerResponse } from '../formatting/markdown.js';
+
+/** Recursively list files under a directory, returning relative paths. */
+async function listRecursive(root: string, subdir: string = ''): Promise<{ relativePath: string; size: number; isDir: boolean }[]> {
+  const entries: { relativePath: string; size: number; isDir: boolean }[] = [];
+  const dirPath = subdir ? path.join(root, subdir) : root;
+
+  let dirents: import('node:fs').Dirent[];
+  try {
+    dirents = await fs.readdir(dirPath, { withFileTypes: true });
+  } catch {
+    return entries;
+  }
+
+  for (const dirent of dirents) {
+    const rel = subdir ? path.join(subdir, dirent.name) : dirent.name;
+    if (dirent.isDirectory()) {
+      entries.push({ relativePath: rel, size: 0, isDir: true });
+      const children = await listRecursive(root, rel);
+      entries.push(...children);
+    } else {
+      const stat = await fs.stat(path.join(root, rel));
+      entries.push({ relativePath: rel, size: stat.size, isDir: false });
+    }
+  }
+
+  return entries;
+}
+
+/** Format a size value for display. */
+function formatSize(size: number): string {
+  if (size < 1024) return `${size} B`;
+  return `${(size / 1024).toFixed(1)} KB`;
+}
 
 export async function handleWorkspace(params: Record<string, unknown>): Promise<HandlerResponse> {
   const operation = params.operation as string;
@@ -23,32 +56,48 @@ export async function handleWorkspace(params: Record<string, unknown>): Promise<
       }
 
       const dir = getWorkspaceDir();
-      let files: string[];
-      try {
-        files = await fs.readdir(dir);
-      } catch {
-        files = [];
+
+      // Optional subdirectory scope
+      let listRoot = dir;
+      if (params.path) {
+        const subPath = sanitizePath(String(params.path));
+        listRoot = path.join(dir, subPath);
+        await verifyPathSafety(listRoot);
       }
 
-      if (files.length === 0) {
+      const entries = await listRecursive(listRoot);
+
+      if (entries.length === 0) {
+        const label = listRoot === dir ? 'Workspace' : `${path.relative(dir, listRoot)}/`;
         return {
-          text: `## Workspace (empty)\n\n**Path:** ${dir}`,
-          refs: { count: 0, path: dir },
+          text: `## ${label} (empty)\n\n**Path:** ${listRoot}`,
+          refs: { count: 0, path: listRoot },
         };
       }
 
-      const entries = await Promise.all(files.map(async (name) => {
-        const filePath = path.join(dir, name);
-        const stat = await fs.stat(filePath);
-        const size = stat.isDirectory() ? 'dir' :
-          stat.size < 1024 ? `${stat.size} B` :
-          `${(stat.size / 1024).toFixed(1)} KB`;
-        return `${name} (${size})`;
-      }));
+      const lines = entries.map(e => {
+        const indent = '  '.repeat(e.relativePath.split(path.sep).length - 1);
+        const label = path.basename(e.relativePath);
+        const suffix = e.isDir ? '/' : ` (${formatSize(e.size)})`;
+        return `${indent}- ${label}${suffix}`;
+      });
+
+      const fileCount = entries.filter(e => !e.isDir).length;
+      const dirCount = entries.filter(e => e.isDir).length;
+      const summary = [
+        `${fileCount} file${fileCount !== 1 ? 's' : ''}`,
+        ...(dirCount > 0 ? [`${dirCount} director${dirCount !== 1 ? 'ies' : 'y'}`] : []),
+      ].join(', ');
 
       return {
-        text: `## Workspace (${files.length} files)\n\n**Path:** ${dir}\n\n${entries.map((e, i) => `${i + 1}. ${e}`).join('\n')}`,
-        refs: { count: files.length, path: dir, files },
+        text: `## Workspace (${summary})\n\n**Path:** ${listRoot}\n\n${lines.join('\n')}`,
+        refs: {
+          count: entries.length,
+          files: fileCount,
+          directories: dirCount,
+          path: listRoot,
+          entries: entries.map(e => e.relativePath),
+        },
       };
     }
 
@@ -112,11 +161,60 @@ export async function handleWorkspace(params: Record<string, unknown>): Promise<
 
       const filePath = resolveWorkspacePath(filename);
       await verifyPathSafety(filePath);
+
+      const stat = await fs.stat(filePath);
+      if (stat.isDirectory()) {
+        await fs.rm(filePath, { recursive: true });
+        return {
+          text: `Directory deleted: **${filename}/**`,
+          refs: { filename, status: 'deleted', type: 'directory' },
+        };
+      }
+
       await fs.unlink(filePath);
 
       return {
         text: `File deleted: **${filename}**`,
-        refs: { filename, status: 'deleted' },
+        refs: { filename, status: 'deleted', type: 'file' },
+      };
+    }
+
+    case 'move': {
+      const source = params.source as string;
+      const destination = params.destination as string;
+      if (!source) throw new Error('source is required');
+      if (!destination) throw new Error('destination is required');
+
+      const srcPath = resolveWorkspacePath(source);
+      const destPath = resolveWorkspacePath(destination);
+      await verifyPathSafety(srcPath);
+
+      // Ensure destination parent exists
+      await fs.mkdir(path.dirname(destPath), { recursive: true });
+      await fs.rename(srcPath, destPath);
+
+      return {
+        text: `Moved: **${source}** → **${destination}**\n\n**Path:** ${destPath}`,
+        refs: { source, destination, path: destPath },
+      };
+    }
+
+    case 'mkdir': {
+      const dirName = (params.path as string) || (params.filename as string);
+      if (!dirName) throw new Error('path is required');
+
+      const wsStatus = await ensureWorkspaceDir();
+      if (!wsStatus.valid) {
+        throw new Error(`Workspace invalid: ${wsStatus.warning}`);
+      }
+
+      const dirPath = resolveWorkspacePath(dirName);
+      await verifyPathSafety(dirPath);
+      await fs.mkdir(dirPath, { recursive: true, mode: 0o755 });
+
+      return {
+        text: `Directory created: **${dirName}/**\n\n**Path:** ${dirPath}`,
+        refs: { path: dirPath, name: dirName },
       };
     }
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -87,9 +87,13 @@ export function createServer(): Server {
       log(`call: ${name} ${JSON.stringify(args ?? {}).slice(0, 200)}`);
       const result = await handleToolCall(name, (args ?? {}) as Record<string, unknown>);
       log(`done: ${name}`);
-      return {
-        content: [{ type: 'text', text: result.text }],
-      };
+      const content: Array<Record<string, unknown>> = [{ type: 'text', text: result.text }];
+      if (result.content) {
+        for (const block of result.content) {
+          content.push({ type: block.type, data: block.data, mimeType: block.mimeType });
+        }
+      }
+      return { content };
     } catch (err) {
       if (err instanceof GwsError) {
         // Append auth remediation guidance for auth errors

--- a/src/server/tools.ts
+++ b/src/server/tools.ts
@@ -37,17 +37,20 @@ const handCodedSchemas: ToolSchema[] = [
   },
   {
     name: 'manage_workspace',
-    description: 'Read, write, list, or delete files in the workspace directory. The workspace is the exchange point for file operations (attachments, downloads, exports).',
+    description: 'Manage files and directories in the workspace sandbox. Supports nested paths (e.g. "reports/q1/summary.csv"). The workspace is the exchange point for file operations (attachments, downloads, exports).',
     inputSchema: {
       type: 'object',
       properties: {
         operation: {
           type: 'string',
-          enum: ['list', 'read', 'write', 'delete'],
-          description: 'list: show files in workspace | read: get file content | write: save content to file | delete: remove a file',
+          enum: ['list', 'read', 'write', 'delete', 'move', 'mkdir'],
+          description: 'list: show files (recursive) | read: get file content | write: save content to file | delete: remove file or directory | move: move or rename a file/directory | mkdir: create a directory',
         },
-        filename: { type: 'string', description: 'File name (for read, write, delete)' },
+        filename: { type: 'string', description: 'File path, may include directories (for read, write, delete). E.g. "reports/q1/summary.csv"' },
         content: { type: 'string', description: 'File content to write (for write)' },
+        path: { type: 'string', description: 'Directory path (for list: scope to subdirectory, for mkdir: directory to create)' },
+        source: { type: 'string', description: 'Source path (for move)' },
+        destination: { type: 'string', description: 'Destination path (for move). Also used for rename.' },
       },
       required: ['operation'],
       additionalProperties: false,
@@ -113,7 +116,7 @@ const handCodedSchemas: ToolSchema[] = [
             properties: {
               tool: {
                 type: 'string',
-                enum: ['manage_email', 'manage_calendar', 'manage_drive', 'manage_accounts', 'manage_scratchpad'],
+                enum: ['manage_email', 'manage_calendar', 'manage_drive', 'manage_accounts', 'manage_scratchpad', 'manage_workspace'],
                 description: 'Tool to call',
               },
               args: {

--- a/src/services/drive/patch.ts
+++ b/src/services/drive/patch.ts
@@ -8,12 +8,14 @@
  */
 
 import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { execute } from '../../executor/gws.js';
 import { formatFileList, formatFileDetail } from '../../server/formatting/markdown.js';
 import { nextSteps } from '../../server/formatting/next-steps.js';
 import { requireString } from '../../server/handlers/validate.js';
 import { ensureWorkspaceDir, resolveWorkspacePath, verifyPathSafety } from '../../executor/workspace.js';
-import { isTextFile, formatFileOutput, type FileOutputResult } from '../../executor/file-output.js';
+import { isTextFile, formatFileOutput, buildImageBlock, buildImageBlockFromFile, isImageFile, getImageMimeType, type FileOutputResult } from '../../executor/file-output.js';
 import type { ServicePatch } from '../../factory/types.js';
 import type { HandlerResponse } from '../../server/formatting/markdown.js';
 
@@ -28,6 +30,9 @@ async function readWorkspaceFile(filePath: string, filename: string, mimeType?: 
 
   if (isTextFile(filename, mimeType) && stat.size < 100_000) {
     result.content = await fs.readFile(filePath, 'utf-8');
+  } else {
+    const imageBlock = await buildImageBlockFromFile(filePath, filename, mimeType);
+    if (imageBlock) result.imageBlock = imageBlock;
   }
 
   return result;
@@ -88,7 +93,49 @@ export const drivePatch: ServicePatch = {
           size: output.size,
           ...(output.content ? { content: output.content } : {}),
         },
+        ...(output.imageBlock ? { content: [output.imageBlock] } : {}),
       };
+    },
+
+    viewImage: async (params, account): Promise<HandlerResponse> => {
+      const fileId = requireString(params, 'fileId');
+
+      // Get file metadata
+      const metaResult = await execute([
+        'drive', 'files', 'get',
+        '--params', JSON.stringify({ fileId, fields: 'name,mimeType,size' }),
+      ], { account });
+      const meta = metaResult.data as Record<string, unknown>;
+      const filename = String(meta.name || `image-${fileId}`);
+      const mimeType = String(meta.mimeType || '');
+
+      if (!isImageFile(filename, mimeType)) {
+        throw new Error(`File "${filename}" (${mimeType}) is not a viewable image type`);
+      }
+
+      // Download to temp file, read into memory, clean up
+      const tmpPath = path.join(os.tmpdir(), `gws-view-${fileId}-${Date.now()}`);
+      try {
+        await execute([
+          'drive', 'files', 'get',
+          '--params', JSON.stringify({ fileId, alt: 'media' }),
+          '--output', tmpPath,
+        ], { account });
+
+        const buffer = await fs.readFile(tmpPath);
+        const imageBlock = buildImageBlock(buffer, filename, mimeType);
+        if (!imageBlock) {
+          throw new Error(`Image too large to view inline (${(buffer.length / 1024 / 1024).toFixed(1)} MB). Use download instead.`);
+        }
+
+        return {
+          text: `## ${filename}\n\n**Type:** ${mimeType}\n**Size:** ${buffer.length} bytes\n\n_Image displayed inline below. Use download to save to workspace._`,
+          refs: { fileId, filename, mimeType, size: buffer.length },
+          content: [imageBlock],
+        };
+      } finally {
+        await fs.unlink(tmpPath).catch(() => {});
+      }
     },
 
     export: async (params, account): Promise<HandlerResponse> => {
@@ -141,6 +188,7 @@ export const drivePatch: ServicePatch = {
           mimeType,
           ...(output.content ? { content: output.content } : {}),
         },
+        ...(output.imageBlock ? { content: [output.imageBlock] } : {}),
       };
     },
   },

--- a/src/services/drive/patch.ts
+++ b/src/services/drive/patch.ts
@@ -114,7 +114,8 @@ export const drivePatch: ServicePatch = {
       }
 
       // Download to temp file, read into memory, clean up
-      const tmpPath = path.join(os.tmpdir(), `gws-view-${fileId}-${Date.now()}`);
+      const safeId = fileId.replace(/[^a-zA-Z0-9_-]/g, '_');
+      const tmpPath = path.join(os.tmpdir(), `gws-view-${safeId}-${Date.now()}`);
       try {
         await execute([
           'drive', 'files', 'get',

--- a/src/services/gmail/attachments.ts
+++ b/src/services/gmail/attachments.ts
@@ -1,18 +1,16 @@
 /**
- * Gmail attachment handler — downloads email attachments to the workspace directory.
+ * Gmail attachment handler — downloads or views email attachments.
  *
  * The agent discovers attachments via the `read` operation, which lists
- * filenames and sizes. Then calls `getAttachment` with just the messageId
- * and filename — we resolve the attachment ID internally by re-reading
- * the message payload. This keeps long Gmail attachment IDs out of the
- * agent's context.
+ * filenames and sizes. Then calls `getAttachment` to save to workspace,
+ * or `viewAttachment` to view images inline without saving.
  *
- * Flow: read → see filenames → getAttachment(messageId, filename) → file in workspace
+ * Flow: read → see filenames → getAttachment/viewAttachment(messageId, filename)
  */
 
 import { execute } from '../../executor/gws.js';
 import { requireString } from '../../server/handlers/validate.js';
-import { saveToWorkspace, formatFileOutput } from '../../executor/file-output.js';
+import { saveToWorkspace, formatFileOutput, isImageFile, buildImageBlock, getImageMimeType } from '../../executor/file-output.js';
 import type { HandlerResponse } from '../../server/formatting/markdown.js';
 
 /** Walk message parts recursively to find attachments. */
@@ -39,19 +37,12 @@ function findAttachments(parts: unknown[]): Array<{ filename: string; attachment
   return attachments;
 }
 
-/**
- * Download an email attachment by filename.
- *
- * Resolves the attachment ID internally by reading the message payload —
- * the agent only needs to provide messageId and filename (from the read response).
- */
-export async function handleGetAttachment(
-  params: Record<string, unknown>,
+/** Fetch raw attachment data by messageId and filename. Returns the buffer and metadata. */
+async function fetchAttachmentData(
+  messageId: string,
+  filename: string,
   account: string,
-): Promise<HandlerResponse> {
-  const messageId = requireString(params, 'messageId');
-  const filename = requireString(params, 'filename');
-
+): Promise<{ buffer: Buffer; match: { filename: string; attachmentId: string; mimeType: string; size: number } }> {
   // Read the message to find the attachment ID for this filename
   const msgResult = await execute([
     'gmail', 'users', 'messages', 'get',
@@ -92,7 +83,20 @@ export async function handleGetAttachment(
   const base64Standard = base64Data.replace(/-/g, '+').replace(/_/g, '/');
   const buffer = Buffer.from(base64Standard, 'base64');
 
-  // Save to workspace and return inline content for text files
+  return { buffer, match };
+}
+
+/**
+ * Download an email attachment by filename — saves to workspace.
+ */
+export async function handleGetAttachment(
+  params: Record<string, unknown>,
+  account: string,
+): Promise<HandlerResponse> {
+  const messageId = requireString(params, 'messageId');
+  const filename = requireString(params, 'filename');
+
+  const { buffer, match } = await fetchAttachmentData(messageId, filename, account);
   const output = await saveToWorkspace(filename, buffer, match.mimeType);
 
   return {
@@ -104,5 +108,40 @@ export async function handleGetAttachment(
       messageId,
       ...(output.content ? { content: output.content } : {}),
     },
+    ...(output.imageBlock ? { content: [output.imageBlock] } : {}),
+  };
+}
+
+/**
+ * View an image attachment inline without saving to workspace.
+ */
+export async function handleViewAttachment(
+  params: Record<string, unknown>,
+  account: string,
+): Promise<HandlerResponse> {
+  const messageId = requireString(params, 'messageId');
+  const filename = requireString(params, 'filename');
+
+  const { buffer, match } = await fetchAttachmentData(messageId, filename, account);
+
+  if (!isImageFile(filename, match.mimeType)) {
+    throw new Error(
+      `"${filename}" (${match.mimeType}) is not a viewable image type. ` +
+      `Use getAttachment to download it instead.`,
+    );
+  }
+
+  const imageBlock = buildImageBlock(buffer, filename, match.mimeType);
+  if (!imageBlock) {
+    throw new Error(
+      `Image too large to view inline (${(buffer.length / 1024 / 1024).toFixed(1)} MB). ` +
+      `Use getAttachment to download it instead.`,
+    );
+  }
+
+  return {
+    text: `## ${filename}\n\n**Type:** ${getImageMimeType(filename, match.mimeType)}\n**Size:** ${buffer.length} bytes\n\n_Image displayed inline below. Use getAttachment to save to workspace._`,
+    refs: { filename, messageId, mimeType: match.mimeType, size: buffer.length },
+    content: [imageBlock],
   };
 }

--- a/src/services/gmail/patch.ts
+++ b/src/services/gmail/patch.ts
@@ -13,7 +13,7 @@ import { resolveWorkspacePath, verifyPathSafety } from '../../executor/workspace
 import { formatEmailList, formatEmailDetail, extractBodyFromPayload } from '../../server/formatting/markdown.js';
 import { nextSteps } from '../../server/formatting/next-steps.js';
 import { requireString } from '../../server/handlers/validate.js';
-import { handleGetAttachment } from './attachments.js';
+import { handleGetAttachment, handleViewAttachment } from './attachments.js';
 import { buildMimeMessage, lookupMimeType, type MimeAttachment } from './mime.js';
 import type { ServicePatch, PatchContext } from '../../factory/types.js';
 import type { HandlerResponse } from '../../server/formatting/markdown.js';
@@ -293,6 +293,7 @@ export const gmailPatch: ServicePatch = {
     },
 
     getAttachment: handleGetAttachment,
+    viewAttachment: handleViewAttachment,
 
     reply: async (params, account): Promise<HandlerResponse> => {
       const messageId = requireString(params, 'messageId');


### PR DESCRIPTION
## Summary

### Workspace directory nesting
- Add `sanitizePath()` — path-aware sanitizer that preserves `/` separators while sanitizing each segment individually and rejecting `..`/`.` traversal
- `resolveWorkspacePath()` now supports nested paths like `reports/q1/summary.csv`
- `list` operation is recursive with tree-formatted output; accepts optional `path` param to scope to subdirectory
- `delete` handles directories recursively
- New `move` operation — mv semantics (move and rename), auto-creates destination parent dirs
- New `mkdir` operation — explicit directory creation
- `manage_workspace` added to `queue_operations` tool enum

### Inline image viewing
- Extend `HandlerResponse` with optional MCP content blocks (image type)
- `server.ts` spreads content blocks into MCP `CallToolResult`
- Workspace `read` returns images inline as base64 (up to 5MB)
- Gmail `getAttachment` and Drive `download`/`export` auto-include image blocks
- New `viewAttachment` (gmail) — view image attachment inline without saving to workspace
- New `viewImage` (drive) — view image file inline without saving to workspace
- Scratchpad image preview covered via workspace `read` + drive `viewImage`

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx jest` — 511 tests pass
- [ ] Manual: write nested path, list shows tree, move relocates, mkdir creates, delete removes dir
- [ ] Manual: download image via drive, verify inline image block in response
- [ ] Manual: viewAttachment on email with image attachment
- [ ] Manual: viewImage on drive image file
- [ ] Manual: workspace read on saved image file