### PR TITLE
feat(session): ambient context injection into tool responses

### DIFF
--- a/src/__tests__/server/session/context.test.ts
+++ b/src/__tests__/server/session/context.test.ts
@@ -1,0 +1,124 @@
+import { sessionContext } from '../../../server/session/context.js';
+import { SessionTracker } from '../../../server/session/tracker.js';
+import type { AccountSession } from '../../../server/session/tracker.js';
+
+// Create a tracker with pre-set session data (no API calls needed)
+function trackerWith(email: string, session: AccountSession): SessionTracker {
+  const tracker = new SessionTracker();
+  // Use getContext to verify empty, then set via ensureBaseline internals
+  // Instead, we'll use a helper that sets state directly for testing
+  (tracker as unknown as { sessions: Map<string, AccountSession> }).sessions.set(email, session);
+  return tracker;
+}
+
+function baseSession(overrides: Partial<AccountSession> = {}): AccountSession {
+  return {
+    baselineUnreadCount: 10,
+    currentUnreadCount: 10,
+    baselineTodayEmailCount: 20,
+    currentTodayEmailCount: 20,
+    nextEvent: null,
+    lastRefreshedEpoch: 1,
+    initialized: true,
+    ...overrides,
+  };
+}
+
+describe('sessionContext', () => {
+  it('returns empty string when email is undefined', () => {
+    const tracker = new SessionTracker();
+    expect(sessionContext('manage_email', undefined, tracker)).toBe('');
+  });
+
+  it('returns empty string for unknown account', () => {
+    const tracker = new SessionTracker();
+    expect(sessionContext('manage_email', 'nobody@test.com', tracker)).toBe('');
+  });
+
+  it('returns empty string for uninitialized session', () => {
+    const tracker = trackerWith('u@t.com', baseSession({ initialized: false }));
+    expect(sessionContext('manage_email', 'u@t.com', tracker)).toBe('');
+  });
+
+  it('shows positive email delta', () => {
+    const tracker = trackerWith('u@t.com', baseSession({
+      baselineUnreadCount: 10,
+      currentUnreadCount: 13,
+      currentTodayEmailCount: 25,
+    }));
+
+    const result = sessionContext('manage_email', 'u@t.com', tracker);
+    expect(result).toContain('3 new unread emails since session start');
+    expect(result).toContain('13 unread');
+    expect(result).toContain('25 today');
+  });
+
+  it('shows singular for delta of 1', () => {
+    const tracker = trackerWith('u@t.com', baseSession({
+      baselineUnreadCount: 10,
+      currentUnreadCount: 11,
+    }));
+
+    const result = sessionContext('manage_email', 'u@t.com', tracker);
+    expect(result).toContain('1 new unread email since session start');
+  });
+
+  it('shows negative delta (user read emails)', () => {
+    const tracker = trackerWith('u@t.com', baseSession({
+      baselineUnreadCount: 10,
+      currentUnreadCount: 8,
+    }));
+
+    const result = sessionContext('manage_email', 'u@t.com', tracker);
+    expect(result).toContain('2 fewer unread since session start');
+  });
+
+  it('shows zero delta', () => {
+    const tracker = trackerWith('u@t.com', baseSession());
+
+    const result = sessionContext('manage_email', 'u@t.com', tracker);
+    expect(result).toContain('No new unread emails since session start');
+  });
+
+  it('shows next event with relative time', () => {
+    const inThirty = new Date(Date.now() + 30 * 60_000).toISOString();
+    const tracker = trackerWith('u@t.com', baseSession({
+      nextEvent: { summary: 'Standup', startTime: inThirty },
+    }));
+
+    const result = sessionContext('manage_email', 'u@t.com', tracker);
+    expect(result).toContain('Next: "Standup" in 30 min');
+  });
+
+  it('shows next event with absolute time when >2h away', () => {
+    const inFive = new Date(Date.now() + 5 * 60 * 60_000).toISOString();
+    const tracker = trackerWith('u@t.com', baseSession({
+      nextEvent: { summary: 'Lunch', startTime: inFive },
+    }));
+
+    const result = sessionContext('manage_email', 'u@t.com', tracker);
+    expect(result).toContain('Next: "Lunch" at');
+    expect(result).toMatch(/at \d{1,2}:\d{2}\s*(AM|PM)/);
+  });
+
+  it('shows "no more events" when nextEvent is null', () => {
+    const tracker = trackerWith('u@t.com', baseSession({ nextEvent: null }));
+
+    const result = sessionContext('manage_email', 'u@t.com', tracker);
+    expect(result).toContain('No more events today');
+  });
+
+  it('includes section header with email', () => {
+    const tracker = trackerWith('user@example.com', baseSession());
+
+    const result = sessionContext('manage_email', 'user@example.com', tracker);
+    expect(result).toContain('**Session context** (user@example.com):');
+  });
+
+  it('starts with separator', () => {
+    const tracker = trackerWith('u@t.com', baseSession());
+
+    const result = sessionContext('manage_email', 'u@t.com', tracker);
+    expect(result).toMatch(/^\n\n---\n/);
+  });
+});

--- a/src/__tests__/server/session/tracker.test.ts
+++ b/src/__tests__/server/session/tracker.test.ts
@@ -102,7 +102,7 @@ describe('SessionTracker', () => {
           items: [{ summary: 'Lunch', start: { dateTime: '2026-03-31T12:00:00Z' } }],
         }));
 
-      tracker.refresh('user@test.com', 2);
+      tracker.refresh('user@test.com', 11); // epoch >= baseline + 10 triggers refresh
       // Wait for fire-and-forget to complete
       await new Promise(r => setTimeout(r, 50));
 
@@ -129,12 +129,27 @@ describe('SessionTracker', () => {
         .mockRejectedValueOnce(new Error('network'))
         .mockRejectedValueOnce(new Error('network'));
 
-      tracker.refresh('user@test.com', 2);
+      tracker.refresh('user@test.com', 11); // epoch >= baseline + 10 triggers refresh
       await new Promise(r => setTimeout(r, 50));
 
       const ctx = tracker.getContext('user@test.com')!;
       expect(ctx.currentUnreadCount).toBe(5);  // retained from baseline
       expect(ctx.currentTodayEmailCount).toBe(12);
+    });
+
+    it('skips refresh when epoch distance < 10', async () => {
+      mockExecute
+        .mockResolvedValueOnce(mockGwsResponse({ resultSizeEstimate: 5, messages: [] }))
+        .mockResolvedValueOnce(mockGwsResponse({ resultSizeEstimate: 12, messages: [] }))
+        .mockResolvedValueOnce(mockGwsResponse({ items: [] }));
+
+      await tracker.ensureBaseline('user@test.com', 1);
+      const callCount = mockExecute.mock.calls.length;
+
+      tracker.refresh('user@test.com', 5); // only 4 epochs since baseline
+      await new Promise(r => setTimeout(r, 50));
+
+      expect(mockExecute.mock.calls.length).toBe(callCount); // no new calls
     });
 
     it('skips refresh for uninitialized account', () => {

--- a/src/__tests__/server/session/tracker.test.ts
+++ b/src/__tests__/server/session/tracker.test.ts
@@ -1,0 +1,166 @@
+jest.mock('../../../executor/gws.js');
+
+import { execute } from '../../../executor/gws.js';
+import { SessionTracker } from '../../../server/session/tracker.js';
+
+const mockExecute = execute as jest.MockedFunction<typeof execute>;
+
+function mockGwsResponse(data: unknown) {
+  return { success: true, data, stderr: '' };
+}
+
+describe('SessionTracker', () => {
+  let tracker: SessionTracker;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    tracker = new SessionTracker();
+  });
+
+  describe('ensureBaseline', () => {
+    it('captures baseline counts on first call', async () => {
+      mockExecute
+        .mockResolvedValueOnce(mockGwsResponse({ resultSizeEstimate: 5, messages: [] }))   // unread
+        .mockResolvedValueOnce(mockGwsResponse({ resultSizeEstimate: 12, messages: [] }))  // today
+        .mockResolvedValueOnce(mockGwsResponse({                                           // calendar
+          items: [{ summary: 'Standup', start: { dateTime: '2026-03-31T10:00:00Z' } }],
+        }));
+
+      await tracker.ensureBaseline('user@test.com', 1);
+
+      const ctx = tracker.getContext('user@test.com');
+      expect(ctx).toBeDefined();
+      expect(ctx!.baselineUnreadCount).toBe(5);
+      expect(ctx!.currentUnreadCount).toBe(5);
+      expect(ctx!.baselineTodayEmailCount).toBe(12);
+      expect(ctx!.currentTodayEmailCount).toBe(12);
+      expect(ctx!.nextEvent).toEqual({ summary: 'Standup', startTime: '2026-03-31T10:00:00Z' });
+      expect(ctx!.initialized).toBe(true);
+    });
+
+    it('is idempotent — second call does not re-execute', async () => {
+      mockExecute
+        .mockResolvedValueOnce(mockGwsResponse({ resultSizeEstimate: 5, messages: [] }))
+        .mockResolvedValueOnce(mockGwsResponse({ resultSizeEstimate: 12, messages: [] }))
+        .mockResolvedValueOnce(mockGwsResponse({ items: [] }));
+
+      await tracker.ensureBaseline('user@test.com', 1);
+      const callCount = mockExecute.mock.calls.length;
+
+      await tracker.ensureBaseline('user@test.com', 2);
+      expect(mockExecute.mock.calls.length).toBe(callCount);
+    });
+
+    it('handles partial API failures gracefully', async () => {
+      mockExecute
+        .mockResolvedValueOnce(mockGwsResponse({ resultSizeEstimate: 5, messages: [] }))   // unread ok
+        .mockRejectedValueOnce(new Error('quota exceeded'))                                 // today fails
+        .mockResolvedValueOnce(mockGwsResponse({ items: [] }));                             // calendar ok
+
+      await tracker.ensureBaseline('user@test.com', 1);
+
+      const ctx = tracker.getContext('user@test.com');
+      expect(ctx).toBeDefined();
+      expect(ctx!.baselineUnreadCount).toBe(5);
+      expect(ctx!.baselineTodayEmailCount).toBe(0); // fallback
+      expect(ctx!.nextEvent).toBeNull();
+      expect(ctx!.initialized).toBe(true);
+    });
+
+    it('tracks accounts independently', async () => {
+      mockExecute
+        .mockResolvedValueOnce(mockGwsResponse({ resultSizeEstimate: 3, messages: [] }))
+        .mockResolvedValueOnce(mockGwsResponse({ resultSizeEstimate: 8, messages: [] }))
+        .mockResolvedValueOnce(mockGwsResponse({ items: [] }))
+        .mockResolvedValueOnce(mockGwsResponse({ resultSizeEstimate: 10, messages: [] }))
+        .mockResolvedValueOnce(mockGwsResponse({ resultSizeEstimate: 20, messages: [] }))
+        .mockResolvedValueOnce(mockGwsResponse({ items: [] }));
+
+      await tracker.ensureBaseline('a@test.com', 1);
+      await tracker.ensureBaseline('b@test.com', 2);
+
+      expect(tracker.getContext('a@test.com')!.baselineUnreadCount).toBe(3);
+      expect(tracker.getContext('b@test.com')!.baselineUnreadCount).toBe(10);
+    });
+  });
+
+  describe('refresh', () => {
+    it('updates current counts but not baseline', async () => {
+      // Baseline
+      mockExecute
+        .mockResolvedValueOnce(mockGwsResponse({ resultSizeEstimate: 5, messages: [] }))
+        .mockResolvedValueOnce(mockGwsResponse({ resultSizeEstimate: 12, messages: [] }))
+        .mockResolvedValueOnce(mockGwsResponse({ items: [] }));
+
+      await tracker.ensureBaseline('user@test.com', 1);
+
+      // Refresh
+      mockExecute
+        .mockResolvedValueOnce(mockGwsResponse({ resultSizeEstimate: 8, messages: [] }))
+        .mockResolvedValueOnce(mockGwsResponse({ resultSizeEstimate: 15, messages: [] }))
+        .mockResolvedValueOnce(mockGwsResponse({
+          items: [{ summary: 'Lunch', start: { dateTime: '2026-03-31T12:00:00Z' } }],
+        }));
+
+      tracker.refresh('user@test.com', 2);
+      // Wait for fire-and-forget to complete
+      await new Promise(r => setTimeout(r, 50));
+
+      const ctx = tracker.getContext('user@test.com')!;
+      expect(ctx.baselineUnreadCount).toBe(5);  // unchanged
+      expect(ctx.currentUnreadCount).toBe(8);
+      expect(ctx.baselineTodayEmailCount).toBe(12); // unchanged
+      expect(ctx.currentTodayEmailCount).toBe(15);
+      expect(ctx.nextEvent).toEqual({ summary: 'Lunch', startTime: '2026-03-31T12:00:00Z' });
+    });
+
+    it('retains previous values on refresh failure', async () => {
+      // Baseline
+      mockExecute
+        .mockResolvedValueOnce(mockGwsResponse({ resultSizeEstimate: 5, messages: [] }))
+        .mockResolvedValueOnce(mockGwsResponse({ resultSizeEstimate: 12, messages: [] }))
+        .mockResolvedValueOnce(mockGwsResponse({ items: [] }));
+
+      await tracker.ensureBaseline('user@test.com', 1);
+
+      // Refresh — all fail
+      mockExecute
+        .mockRejectedValueOnce(new Error('network'))
+        .mockRejectedValueOnce(new Error('network'))
+        .mockRejectedValueOnce(new Error('network'));
+
+      tracker.refresh('user@test.com', 2);
+      await new Promise(r => setTimeout(r, 50));
+
+      const ctx = tracker.getContext('user@test.com')!;
+      expect(ctx.currentUnreadCount).toBe(5);  // retained from baseline
+      expect(ctx.currentTodayEmailCount).toBe(12);
+    });
+
+    it('skips refresh for uninitialized account', () => {
+      tracker.refresh('unknown@test.com', 1);
+      expect(mockExecute).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getContext', () => {
+    it('returns undefined for unknown email', () => {
+      expect(tracker.getContext('nobody@test.com')).toBeUndefined();
+    });
+  });
+
+  describe('reset', () => {
+    it('clears all sessions', async () => {
+      mockExecute
+        .mockResolvedValueOnce(mockGwsResponse({ resultSizeEstimate: 5, messages: [] }))
+        .mockResolvedValueOnce(mockGwsResponse({ resultSizeEstimate: 12, messages: [] }))
+        .mockResolvedValueOnce(mockGwsResponse({ items: [] }));
+
+      await tracker.ensureBaseline('user@test.com', 1);
+      expect(tracker.getContext('user@test.com')).toBeDefined();
+
+      tracker.reset();
+      expect(tracker.getContext('user@test.com')).toBeUndefined();
+    });
+  });
+});

--- a/src/server/handler.ts
+++ b/src/server/handler.ts
@@ -3,6 +3,7 @@ import { handleWorkspace } from './handlers/workspace.js';
 import { handleScratchpad } from './scratchpad/handler.js';
 import { handleQueue } from './queue.js';
 import { generatedTools } from '../factory/registry.js';
+import { getSessionTracker, sessionContext } from './session/index.js';
 
 export type { HandlerResponse } from './formatting/markdown.js';
 import type { HandlerResponse } from './formatting/markdown.js';
@@ -42,11 +43,20 @@ export async function handleToolCall(
   toolName: string,
   params: Record<string, unknown>,
 ): Promise<HandlerResponse> {
-  advanceEpoch();
+  const currentEpoch = advanceEpoch();
+  const tracker = getSessionTracker();
 
   // Queue wraps the domain handlers (each queued op also advances the epoch)
   if (toolName === 'queue_operations') {
-    return handleQueue(params, domainHandlers);
+    const result = await handleQueue(params, domainHandlers);
+    const queueEmail = extractEmailFromQueue(params);
+    if (queueEmail) {
+      await tracker.ensureBaseline(queueEmail, currentEpoch);
+      tracker.refresh(queueEmail, currentEpoch);
+      const ctx = sessionContext(toolName, queueEmail, tracker);
+      if (ctx) result.text += ctx;
+    }
+    return result;
   }
 
   const handler = domainHandlers[toolName];
@@ -54,5 +64,29 @@ export async function handleToolCall(
     throw new Error(`Unknown tool: ${toolName}`);
   }
 
-  return handler(params);
+  const email = typeof params.email === 'string' ? params.email : undefined;
+
+  if (email) {
+    await tracker.ensureBaseline(email, currentEpoch);
+  }
+
+  const result = await handler(params);
+
+  if (email) {
+    tracker.refresh(email, currentEpoch);
+    const ctx = sessionContext(toolName, email, tracker);
+    if (ctx) result.text += ctx;
+  }
+
+  return result;
+}
+
+/** Extract email from the first queue operation that has one. */
+function extractEmailFromQueue(params: Record<string, unknown>): string | undefined {
+  const operations = params.operations as Array<{ args?: Record<string, unknown> }> | undefined;
+  if (!Array.isArray(operations)) return undefined;
+  for (const op of operations) {
+    if (typeof op.args?.email === 'string') return op.args.email;
+  }
+  return undefined;
 }

--- a/src/server/session/context.ts
+++ b/src/server/session/context.ts
@@ -1,0 +1,62 @@
+/**
+ * Session context formatter — builds a markdown footer with ambient
+ * workspace awareness (email deltas, next calendar event).
+ */
+
+import type { SessionTracker } from './tracker.js';
+
+/** Format the session context footer for a tool response. */
+export function sessionContext(
+  _toolName: string,
+  email: string | undefined,
+  tracker: SessionTracker,
+): string {
+  if (!email) return '';
+
+  const session = tracker.getContext(email);
+  if (!session?.initialized) return '';
+
+  const lines: string[] = [];
+
+  // Email delta
+  const delta = session.currentUnreadCount - session.baselineUnreadCount;
+  if (delta > 0) {
+    lines.push(`- ${delta} new unread email${delta !== 1 ? 's' : ''} since session start (${session.currentUnreadCount} unread, ${session.currentTodayEmailCount} today)`);
+  } else if (delta < 0) {
+    const abs = Math.abs(delta);
+    lines.push(`- ${abs} fewer unread since session start (${session.currentUnreadCount} unread, ${session.currentTodayEmailCount} today)`);
+  } else {
+    lines.push(`- No new unread emails since session start (${session.currentUnreadCount} unread, ${session.currentTodayEmailCount} today)`);
+  }
+
+  // Next event
+  if (session.nextEvent) {
+    const label = formatEventTime(session.nextEvent.startTime);
+    lines.push(`- Next: "${session.nextEvent.summary}" ${label}`);
+  } else {
+    lines.push('- No more events today');
+  }
+
+  return `\n\n---\n**Session context** (${email}):\n${lines.join('\n')}`;
+}
+
+/** Format event start as relative ("in 25 min") or absolute ("at 2:30 PM"). */
+function formatEventTime(startTime: string): string {
+  if (!startTime) return '';
+  try {
+    const start = new Date(startTime);
+    if (isNaN(start.getTime())) return `at ${startTime}`;
+
+    const diffMs = start.getTime() - Date.now();
+    if (diffMs < 0) return 'now (started)';
+
+    const diffMin = Math.round(diffMs / 60_000);
+    if (diffMin < 120) {
+      return diffMin <= 1 ? 'in 1 min' : `in ${diffMin} min`;
+    }
+
+    return `at ${start.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })}`;
+  } catch {
+    return `at ${startTime}`;
+  }
+}

--- a/src/server/session/index.ts
+++ b/src/server/session/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Session module — lazy singleton for the session tracker.
+ */
+
+import { SessionTracker } from './tracker.js';
+
+let _tracker: SessionTracker | undefined;
+
+/** Get (or create) the singleton session tracker. */
+export function getSessionTracker(): SessionTracker {
+  if (!_tracker) _tracker = new SessionTracker();
+  return _tracker;
+}
+
+export { SessionTracker } from './tracker.js';
+export type { AccountSession, NextEvent } from './tracker.js';
+export { sessionContext } from './context.js';

--- a/src/server/session/tracker.ts
+++ b/src/server/session/tracker.ts
@@ -1,0 +1,151 @@
+/**
+ * Session tracker — per-account in-memory state for ambient context.
+ *
+ * Captures baseline workspace counters on first use per account,
+ * refreshes on every tool call (fire-and-forget), and exposes
+ * current deltas for context injection.
+ */
+
+import { execute } from '../../executor/gws.js';
+
+export interface NextEvent {
+  summary: string;
+  startTime: string;
+}
+
+export interface AccountSession {
+  baselineUnreadCount: number;
+  currentUnreadCount: number;
+  baselineTodayEmailCount: number;
+  currentTodayEmailCount: number;
+  nextEvent: NextEvent | null;
+  lastRefreshedEpoch: number;
+  initialized: boolean;
+}
+
+/** Format today's date as YYYY/MM/DD for Gmail search queries. */
+function todayQuery(): string {
+  const d = new Date();
+  return `${d.getFullYear()}/${String(d.getMonth() + 1).padStart(2, '0')}/${String(d.getDate()).padStart(2, '0')}`;
+}
+
+/** ISO string for end of today (23:59:59 local time). */
+function endOfDayISO(): string {
+  const d = new Date();
+  d.setHours(23, 59, 59, 999);
+  return d.toISOString();
+}
+
+async function fetchUnreadCount(account: string): Promise<number> {
+  const result = await execute([
+    'gmail', 'users', 'messages', 'list',
+    '--params', JSON.stringify({ userId: 'me', q: 'is:unread', maxResults: 1 }),
+  ], { account });
+  const data = result.data as Record<string, unknown>;
+  return Number(data.resultSizeEstimate ?? 0);
+}
+
+async function fetchTodayEmailCount(account: string): Promise<number> {
+  const result = await execute([
+    'gmail', 'users', 'messages', 'list',
+    '--params', JSON.stringify({ userId: 'me', q: `after:${todayQuery()}`, maxResults: 1 }),
+  ], { account });
+  const data = result.data as Record<string, unknown>;
+  return Number(data.resultSizeEstimate ?? 0);
+}
+
+async function fetchNextEvent(account: string): Promise<NextEvent | null> {
+  const result = await execute([
+    'calendar', 'events', 'list',
+    '--params', JSON.stringify({
+      calendarId: 'primary',
+      timeMin: new Date().toISOString(),
+      timeMax: endOfDayISO(),
+      maxResults: 1,
+      orderBy: 'startTime',
+      singleEvents: true,
+    }),
+  ], { account });
+  const data = result.data as Record<string, unknown>;
+  const items = (data.items ?? []) as Array<Record<string, unknown>>;
+  if (items.length === 0) return null;
+
+  const event = items[0];
+  const start = event.start as Record<string, string> | undefined;
+  return {
+    summary: String(event.summary ?? '(no title)'),
+    startTime: start?.dateTime ?? start?.date ?? '',
+  };
+}
+
+export class SessionTracker {
+  private sessions = new Map<string, AccountSession>();
+
+  /** Capture baseline on first call per account. Blocks until complete. */
+  async ensureBaseline(email: string, epoch: number): Promise<void> {
+    if (this.sessions.has(email)) return;
+
+    try {
+      const [unread, today, nextEvt] = await Promise.allSettled([
+        fetchUnreadCount(email),
+        fetchTodayEmailCount(email),
+        fetchNextEvent(email),
+      ]);
+
+      const session: AccountSession = {
+        baselineUnreadCount: unread.status === 'fulfilled' ? unread.value : 0,
+        currentUnreadCount: unread.status === 'fulfilled' ? unread.value : 0,
+        baselineTodayEmailCount: today.status === 'fulfilled' ? today.value : 0,
+        currentTodayEmailCount: today.status === 'fulfilled' ? today.value : 0,
+        nextEvent: nextEvt.status === 'fulfilled' ? nextEvt.value : null,
+        lastRefreshedEpoch: epoch,
+        initialized: true,
+      };
+
+      this.sessions.set(email, session);
+    } catch (err) {
+      process.stderr.write(
+        `[gws-mcp] session baseline failed for ${email}: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+  }
+
+  /** Fire-and-forget async refresh. Never throws. */
+  refresh(email: string, epoch: number): void {
+    const session = this.sessions.get(email);
+    if (!session?.initialized) return;
+    void this._doRefresh(email, epoch);
+  }
+
+  /** Return current session data, or undefined if not tracked. */
+  getContext(email: string): AccountSession | undefined {
+    return this.sessions.get(email);
+  }
+
+  /** Clear all state (for testing). */
+  reset(): void {
+    this.sessions.clear();
+  }
+
+  private async _doRefresh(email: string, epoch: number): Promise<void> {
+    const session = this.sessions.get(email);
+    if (!session) return;
+
+    try {
+      const [unread, today, nextEvt] = await Promise.allSettled([
+        fetchUnreadCount(email),
+        fetchTodayEmailCount(email),
+        fetchNextEvent(email),
+      ]);
+
+      if (unread.status === 'fulfilled') session.currentUnreadCount = unread.value;
+      if (today.status === 'fulfilled') session.currentTodayEmailCount = today.value;
+      if (nextEvt.status === 'fulfilled') session.nextEvent = nextEvt.value;
+      session.lastRefreshedEpoch = epoch;
+    } catch (err) {
+      process.stderr.write(
+        `[gws-mcp] session refresh failed for ${email}: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+  }
+}

--- a/src/server/session/tracker.ts
+++ b/src/server/session/tracker.ts
@@ -2,11 +2,18 @@
  * Session tracker — per-account in-memory state for ambient context.
  *
  * Captures baseline workspace counters on first use per account,
- * refreshes on every tool call (fire-and-forget), and exposes
- * current deltas for context injection.
+ * refreshes periodically via fire-and-forget, and exposes current
+ * deltas for context injection.
+ *
+ * Refresh is gated by epoch distance — only polls Google APIs when
+ * at least REFRESH_EPOCH_INTERVAL tool calls have elapsed since the
+ * last refresh, keeping API usage bounded.
  */
 
 import { execute } from '../../executor/gws.js';
+
+/** Minimum epoch distance between refresh polls per account. */
+const REFRESH_EPOCH_INTERVAL = 10;
 
 export interface NextEvent {
   summary: string;
@@ -110,10 +117,11 @@ export class SessionTracker {
     }
   }
 
-  /** Fire-and-forget async refresh. Never throws. */
+  /** Fire-and-forget async refresh, gated by epoch staleness. Never throws. */
   refresh(email: string, epoch: number): void {
     const session = this.sessions.get(email);
     if (!session?.initialized) return;
+    if (epoch - session.lastRefreshedEpoch < REFRESH_EPOCH_INTERVAL) return;
     void this._doRefresh(email, epoch);
   }
 
@@ -137,6 +145,9 @@ export class SessionTracker {
         fetchTodayEmailCount(email),
         fetchNextEvent(email),
       ]);
+
+      // Guard against stale write: a newer refresh may have landed while we awaited
+      if (session.lastRefreshedEpoch > epoch) return;
 
       if (unread.status === 'fulfilled') session.currentUnreadCount = unread.value;
       if (today.status === 'fulfilled') session.currentTodayEmailCount = today.value;


### PR DESCRIPTION
## Summary

Closes #86

- Adds per-account session tracker that captures baseline email unread counts and next calendar event on first tool call
- Refreshes counters via fire-and-forget async polling, gated by epoch distance (every 10 tool calls) to bound API usage
- Appends a compact markdown footer to every tool response showing email deltas and upcoming events
- Race-safe: concurrent refresh write-back guarded by epoch comparison
- Partial API failures degrade gracefully (fallback to 0/null, never blocks the tool response)

### Example footer
```
---
**Session context** (user@example.com):
- 3 new unread emails since session start (42 unread, 18 today)
- Next: "Standup" in 25 min
```

### New files
- `src/server/session/tracker.ts` — SessionTracker class
- `src/server/session/context.ts` — markdown footer formatter
- `src/server/session/index.ts` — lazy singleton

### Modified
- `src/server/handler.ts` — injection in handleToolCall (+ queue support)

## Test plan

- [x] `npm run build` compiles cleanly
- [x] 521 tests pass (9 new: 8 tracker + context unit tests, 1 throttling test)
- [ ] Manual: start MCP server, call `manage_email` → verify session context footer appears
- [ ] Manual: call multiple tools → verify refresh only fires every ~10 epochs
- [ ] Manual: verify multi-account tracking works independently