### PR TITLE
feat(coverage): build-time gws CLI coverage analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,8 +33,9 @@ Thumbs.db
 logs/
 *.log
 
-# Test coverage
+# Test coverage (jest output, not src/coverage/)
 coverage/
+!src/coverage/
 commit-message.txt
 discovered-manifest.yaml
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .DEFAULT_GOAL := help
 .PHONY: help test test-all test-unit test-integration build clean typecheck \
         manifest-discover manifest-diff manifest-lint \
+        coverage coverage-update \
         mcpb mcpb-all version-sync publish-all \
         release-patch release-minor release-major check
 
@@ -65,6 +66,14 @@ manifest-lint: ## Validate manifest YAML syntax and structure
 		} \
 		console.log('  Total: ' + ops + ' operations across ' + Object.keys(m.services).length + ' services'); \
 	"
+
+# --- Coverage analysis ---
+
+coverage: build ## Analyze gws CLI coverage vs curated manifest
+	node build/coverage/analyze.js
+
+coverage-update: build ## Update coverage baseline from current gws surface
+	node build/coverage/analyze.js --update
 
 # --- MCPB packaging ---
 

--- a/coverage-baseline.json
+++ b/coverage-baseline.json
@@ -1,0 +1,1153 @@
+{
+  "gwsVersion": "gws 0.22.5",
+  "generatedAt": "2026-04-08T15:22:03.016Z",
+  "services": {
+    "drive": {
+      "operations": {
+        "files.copy": {
+          "status": "covered",
+          "params": {
+            "ignoreDefaultVisibility": "gap",
+            "includeLabels": "gap",
+            "includePermissionsForView": "gap",
+            "keepRevisionForever": "gap",
+            "ocrLanguage": "gap",
+            "supportsAllDrives": "gap"
+          }
+        },
+        "files.delete": {
+          "status": "covered",
+          "params": {
+            "supportsAllDrives": "gap"
+          }
+        },
+        "files.get": {
+          "status": "covered",
+          "params": {
+            "acknowledgeAbuse": "gap",
+            "includeLabels": "gap",
+            "includePermissionsForView": "gap",
+            "supportsAllDrives": "gap"
+          }
+        },
+        "files.list": {
+          "status": "covered",
+          "params": {
+            "corpora": "gap",
+            "driveId": "gap",
+            "includeItemsFromAllDrives": "gap",
+            "includeLabels": "gap",
+            "includePermissionsForView": "gap",
+            "orderBy": "gap",
+            "pageToken": "gap",
+            "spaces": "gap",
+            "supportsAllDrives": "gap"
+          }
+        },
+        "permissions.create": {
+          "status": "covered",
+          "params": {
+            "emailMessage": "gap",
+            "moveToNewOwnersRoot": "gap",
+            "sendNotificationEmail": "gap",
+            "supportsAllDrives": "gap",
+            "transferOwnership": "gap",
+            "useDomainAdminAccess": "gap"
+          }
+        },
+        "permissions.delete": {
+          "status": "covered",
+          "params": {
+            "supportsAllDrives": "gap",
+            "useDomainAdminAccess": "gap"
+          }
+        },
+        "permissions.list": {
+          "status": "covered",
+          "params": {
+            "includePermissionsForView": "gap",
+            "pageSize": "gap",
+            "pageToken": "gap",
+            "supportsAllDrives": "gap",
+            "useDomainAdminAccess": "gap"
+          }
+        },
+        "about.get": {
+          "status": "gap"
+        },
+        "accessproposals.get": {
+          "status": "gap"
+        },
+        "accessproposals.list": {
+          "status": "gap"
+        },
+        "accessproposals.resolve": {
+          "status": "gap"
+        },
+        "approvals.get": {
+          "status": "gap"
+        },
+        "approvals.list": {
+          "status": "gap"
+        },
+        "apps.get": {
+          "status": "gap"
+        },
+        "apps.list": {
+          "status": "gap"
+        },
+        "changes.getStartPageToken": {
+          "status": "gap"
+        },
+        "changes.list": {
+          "status": "gap"
+        },
+        "changes.watch": {
+          "status": "gap"
+        },
+        "channels.stop": {
+          "status": "gap"
+        },
+        "comments.create": {
+          "status": "gap"
+        },
+        "comments.delete": {
+          "status": "gap"
+        },
+        "comments.get": {
+          "status": "gap"
+        },
+        "comments.list": {
+          "status": "gap"
+        },
+        "comments.update": {
+          "status": "gap"
+        },
+        "drives.create": {
+          "status": "gap"
+        },
+        "drives.delete": {
+          "status": "gap"
+        },
+        "drives.get": {
+          "status": "gap"
+        },
+        "drives.hide": {
+          "status": "gap"
+        },
+        "drives.list": {
+          "status": "gap"
+        },
+        "drives.unhide": {
+          "status": "gap"
+        },
+        "drives.update": {
+          "status": "gap"
+        },
+        "files.create": {
+          "status": "gap"
+        },
+        "files.download": {
+          "status": "gap"
+        },
+        "files.emptyTrash": {
+          "status": "gap"
+        },
+        "files.generateIds": {
+          "status": "gap"
+        },
+        "files.listLabels": {
+          "status": "gap"
+        },
+        "files.modifyLabels": {
+          "status": "gap"
+        },
+        "files.update": {
+          "status": "gap"
+        },
+        "files.watch": {
+          "status": "gap"
+        },
+        "operations.get": {
+          "status": "gap"
+        },
+        "permissions.get": {
+          "status": "gap"
+        },
+        "permissions.update": {
+          "status": "gap"
+        },
+        "replies.create": {
+          "status": "gap"
+        },
+        "replies.delete": {
+          "status": "gap"
+        },
+        "replies.get": {
+          "status": "gap"
+        },
+        "replies.list": {
+          "status": "gap"
+        },
+        "replies.update": {
+          "status": "gap"
+        },
+        "revisions.delete": {
+          "status": "gap"
+        },
+        "revisions.get": {
+          "status": "gap"
+        },
+        "revisions.list": {
+          "status": "gap"
+        },
+        "revisions.update": {
+          "status": "gap"
+        },
+        "teamdrives.create": {
+          "status": "gap"
+        },
+        "teamdrives.delete": {
+          "status": "gap"
+        },
+        "teamdrives.get": {
+          "status": "gap"
+        },
+        "teamdrives.list": {
+          "status": "gap"
+        },
+        "teamdrives.update": {
+          "status": "gap"
+        }
+      }
+    },
+    "sheets": {
+      "operations": {
+        "spreadsheets.get": {
+          "status": "covered",
+          "params": {
+            "excludeTablesInBandedRanges": "gap",
+            "includeGridData": "gap",
+            "ranges": "gap"
+          }
+        },
+        "spreadsheets.values.get": {
+          "status": "covered",
+          "params": {
+            "dateTimeRenderOption": "gap",
+            "majorDimension": "gap",
+            "valueRenderOption": "gap"
+          }
+        },
+        "spreadsheets.values.update": {
+          "status": "covered",
+          "params": {
+            "includeValuesInResponse": "gap",
+            "responseDateTimeRenderOption": "gap",
+            "responseValueRenderOption": "gap",
+            "valueInputOption": "gap"
+          }
+        },
+        "spreadsheets.batchUpdate": {
+          "status": "gap"
+        },
+        "spreadsheets.getByDataFilter": {
+          "status": "gap"
+        },
+        "spreadsheets.developerMetadata.get": {
+          "status": "gap"
+        },
+        "spreadsheets.developerMetadata.search": {
+          "status": "gap"
+        },
+        "spreadsheets.sheets.copyTo": {
+          "status": "gap"
+        },
+        "spreadsheets.values.append": {
+          "status": "gap"
+        },
+        "spreadsheets.values.batchClear": {
+          "status": "gap"
+        },
+        "spreadsheets.values.batchClearByDataFilter": {
+          "status": "gap"
+        },
+        "spreadsheets.values.batchGet": {
+          "status": "gap"
+        },
+        "spreadsheets.values.batchGetByDataFilter": {
+          "status": "gap"
+        },
+        "spreadsheets.values.batchUpdate": {
+          "status": "gap"
+        },
+        "spreadsheets.values.batchUpdateByDataFilter": {
+          "status": "gap"
+        },
+        "spreadsheets.values.clear": {
+          "status": "gap"
+        }
+      }
+    },
+    "gmail": {
+      "operations": {
+        "users.messages.get": {
+          "status": "covered",
+          "params": {
+            "format": "gap",
+            "metadataHeaders": "gap"
+          }
+        },
+        "users.messages.list": {
+          "status": "covered",
+          "params": {
+            "includeSpamTrash": "gap",
+            "labelIds": "gap",
+            "pageToken": "gap"
+          }
+        },
+        "users.messages.attachments.get": {
+          "status": "covered",
+          "params": {
+            "id": "gap"
+          }
+        },
+        "users.threads.get": {
+          "status": "covered",
+          "params": {
+            "format": "gap",
+            "metadataHeaders": "gap"
+          }
+        },
+        "users.threads.list": {
+          "status": "covered",
+          "params": {
+            "includeSpamTrash": "gap",
+            "labelIds": "gap",
+            "pageToken": "gap"
+          }
+        },
+        "users.getProfile": {
+          "status": "gap"
+        },
+        "users.stop": {
+          "status": "gap"
+        },
+        "users.watch": {
+          "status": "gap"
+        },
+        "users.drafts.create": {
+          "status": "gap"
+        },
+        "users.drafts.delete": {
+          "status": "gap"
+        },
+        "users.drafts.get": {
+          "status": "gap"
+        },
+        "users.drafts.list": {
+          "status": "gap"
+        },
+        "users.drafts.send": {
+          "status": "gap"
+        },
+        "users.drafts.update": {
+          "status": "gap"
+        },
+        "users.history.list": {
+          "status": "gap"
+        },
+        "users.labels.create": {
+          "status": "gap"
+        },
+        "users.labels.delete": {
+          "status": "gap"
+        },
+        "users.labels.get": {
+          "status": "gap"
+        },
+        "users.labels.patch": {
+          "status": "gap"
+        },
+        "users.labels.update": {
+          "status": "gap"
+        },
+        "users.messages.batchDelete": {
+          "status": "gap"
+        },
+        "users.messages.batchModify": {
+          "status": "gap"
+        },
+        "users.messages.delete": {
+          "status": "gap"
+        },
+        "users.messages.import": {
+          "status": "gap"
+        },
+        "users.messages.insert": {
+          "status": "gap"
+        },
+        "users.messages.send": {
+          "status": "gap"
+        },
+        "users.settings.getAutoForwarding": {
+          "status": "gap"
+        },
+        "users.settings.getImap": {
+          "status": "gap"
+        },
+        "users.settings.getLanguage": {
+          "status": "gap"
+        },
+        "users.settings.getPop": {
+          "status": "gap"
+        },
+        "users.settings.getVacation": {
+          "status": "gap"
+        },
+        "users.settings.updateAutoForwarding": {
+          "status": "gap"
+        },
+        "users.settings.updateImap": {
+          "status": "gap"
+        },
+        "users.settings.updateLanguage": {
+          "status": "gap"
+        },
+        "users.settings.updatePop": {
+          "status": "gap"
+        },
+        "users.settings.updateVacation": {
+          "status": "gap"
+        },
+        "users.settings.cse.identities.create": {
+          "status": "gap"
+        },
+        "users.settings.cse.identities.delete": {
+          "status": "gap"
+        },
+        "users.settings.cse.identities.get": {
+          "status": "gap"
+        },
+        "users.settings.cse.identities.list": {
+          "status": "gap"
+        },
+        "users.settings.cse.identities.patch": {
+          "status": "gap"
+        },
+        "users.settings.cse.keypairs.create": {
+          "status": "gap"
+        },
+        "users.settings.cse.keypairs.disable": {
+          "status": "gap"
+        },
+        "users.settings.cse.keypairs.enable": {
+          "status": "gap"
+        },
+        "users.settings.cse.keypairs.get": {
+          "status": "gap"
+        },
+        "users.settings.cse.keypairs.list": {
+          "status": "gap"
+        },
+        "users.settings.cse.keypairs.obliterate": {
+          "status": "gap"
+        },
+        "users.settings.delegates.create": {
+          "status": "gap"
+        },
+        "users.settings.delegates.delete": {
+          "status": "gap"
+        },
+        "users.settings.delegates.get": {
+          "status": "gap"
+        },
+        "users.settings.delegates.list": {
+          "status": "gap"
+        },
+        "users.settings.filters.create": {
+          "status": "gap"
+        },
+        "users.settings.filters.delete": {
+          "status": "gap"
+        },
+        "users.settings.filters.get": {
+          "status": "gap"
+        },
+        "users.settings.filters.list": {
+          "status": "gap"
+        },
+        "users.settings.forwardingAddresses.create": {
+          "status": "gap"
+        },
+        "users.settings.forwardingAddresses.delete": {
+          "status": "gap"
+        },
+        "users.settings.forwardingAddresses.get": {
+          "status": "gap"
+        },
+        "users.settings.forwardingAddresses.list": {
+          "status": "gap"
+        },
+        "users.settings.sendAs.create": {
+          "status": "gap"
+        },
+        "users.settings.sendAs.delete": {
+          "status": "gap"
+        },
+        "users.settings.sendAs.get": {
+          "status": "gap"
+        },
+        "users.settings.sendAs.list": {
+          "status": "gap"
+        },
+        "users.settings.sendAs.patch": {
+          "status": "gap"
+        },
+        "users.settings.sendAs.update": {
+          "status": "gap"
+        },
+        "users.settings.sendAs.verify": {
+          "status": "gap"
+        },
+        "users.settings.sendAs.smimeInfo.delete": {
+          "status": "gap"
+        },
+        "users.settings.sendAs.smimeInfo.get": {
+          "status": "gap"
+        },
+        "users.settings.sendAs.smimeInfo.insert": {
+          "status": "gap"
+        },
+        "users.settings.sendAs.smimeInfo.list": {
+          "status": "gap"
+        },
+        "users.settings.sendAs.smimeInfo.setDefault": {
+          "status": "gap"
+        },
+        "users.threads.delete": {
+          "status": "gap"
+        },
+        "users.threads.modify": {
+          "status": "gap"
+        },
+        "users.threads.trash": {
+          "status": "gap"
+        },
+        "users.threads.untrash": {
+          "status": "gap"
+        },
+        "+watch": {
+          "status": "gap"
+        }
+      }
+    },
+    "calendar": {
+      "operations": {
+        "calendarList.list": {
+          "status": "covered",
+          "params": {
+            "maxResults": "gap",
+            "minAccessRole": "gap",
+            "pageToken": "gap",
+            "showDeleted": "gap",
+            "showHidden": "gap",
+            "syncToken": "gap"
+          }
+        },
+        "events.delete": {
+          "status": "covered",
+          "params": {
+            "sendNotifications": "gap",
+            "sendUpdates": "gap"
+          }
+        },
+        "events.get": {
+          "status": "covered",
+          "params": {
+            "alwaysIncludeEmail": "gap",
+            "maxAttendees": "gap",
+            "timeZone": "gap"
+          }
+        },
+        "events.list": {
+          "status": "covered",
+          "params": {
+            "alwaysIncludeEmail": "gap",
+            "eventTypes": "gap",
+            "iCalUID": "gap",
+            "maxAttendees": "gap",
+            "orderBy": "gap",
+            "pageToken": "gap",
+            "privateExtendedProperty": "gap",
+            "sharedExtendedProperty": "gap",
+            "showDeleted": "gap",
+            "showHiddenInvitations": "gap",
+            "singleEvents": "gap",
+            "syncToken": "gap",
+            "timeZone": "gap",
+            "updatedMin": "gap"
+          }
+        },
+        "events.patch": {
+          "status": "covered",
+          "params": {
+            "alwaysIncludeEmail": "gap",
+            "conferenceDataVersion": "gap",
+            "maxAttendees": "gap",
+            "sendNotifications": "gap",
+            "sendUpdates": "gap",
+            "supportsAttachments": "gap"
+          }
+        },
+        "events.quickAdd": {
+          "status": "covered",
+          "params": {
+            "sendNotifications": "gap",
+            "sendUpdates": "gap"
+          }
+        },
+        "acl.delete": {
+          "status": "gap"
+        },
+        "acl.get": {
+          "status": "gap"
+        },
+        "acl.insert": {
+          "status": "gap"
+        },
+        "acl.list": {
+          "status": "gap"
+        },
+        "acl.patch": {
+          "status": "gap"
+        },
+        "acl.update": {
+          "status": "gap"
+        },
+        "acl.watch": {
+          "status": "gap"
+        },
+        "calendarList.delete": {
+          "status": "gap"
+        },
+        "calendarList.get": {
+          "status": "gap"
+        },
+        "calendarList.insert": {
+          "status": "gap"
+        },
+        "calendarList.patch": {
+          "status": "gap"
+        },
+        "calendarList.update": {
+          "status": "gap"
+        },
+        "calendarList.watch": {
+          "status": "gap"
+        },
+        "calendars.clear": {
+          "status": "gap"
+        },
+        "calendars.delete": {
+          "status": "gap"
+        },
+        "calendars.get": {
+          "status": "gap"
+        },
+        "calendars.insert": {
+          "status": "gap"
+        },
+        "calendars.The": {
+          "status": "gap"
+        },
+        "calendars.patch": {
+          "status": "gap"
+        },
+        "calendars.update": {
+          "status": "gap"
+        },
+        "channels.stop": {
+          "status": "gap"
+        },
+        "colors.get": {
+          "status": "gap"
+        },
+        "events.import": {
+          "status": "gap"
+        },
+        "events.insert": {
+          "status": "gap"
+        },
+        "events.instances": {
+          "status": "gap"
+        },
+        "events.move": {
+          "status": "gap"
+        },
+        "events.update": {
+          "status": "gap"
+        },
+        "events.watch": {
+          "status": "gap"
+        },
+        "settings.get": {
+          "status": "gap"
+        },
+        "settings.list": {
+          "status": "gap"
+        },
+        "settings.watch": {
+          "status": "gap"
+        }
+      }
+    },
+    "docs": {
+      "operations": {
+        "documents.get": {
+          "status": "covered",
+          "params": {
+            "includeTabsContent": "gap",
+            "suggestionsViewMode": "gap"
+          }
+        },
+        "documents.batchUpdate": {
+          "status": "gap"
+        }
+      }
+    },
+    "slides": {
+      "operations": {
+        "presentations.batchUpdate": {
+          "status": "gap"
+        },
+        "presentations.create": {
+          "status": "gap"
+        },
+        "presentations.get": {
+          "status": "gap"
+        },
+        "presentations.pages.get": {
+          "status": "gap"
+        },
+        "presentations.pages.getThumbnail": {
+          "status": "gap"
+        }
+      }
+    },
+    "tasks": {
+      "operations": {
+        "tasklists.list": {
+          "status": "covered",
+          "params": {
+            "maxResults": "gap",
+            "pageToken": "gap"
+          }
+        },
+        "tasks.insert": {
+          "status": "covered",
+          "params": {
+            "parent": "gap",
+            "previous": "gap"
+          }
+        },
+        "tasks.list": {
+          "status": "covered",
+          "params": {
+            "completedMax": "gap",
+            "completedMin": "gap",
+            "dueMax": "gap",
+            "dueMin": "gap",
+            "pageToken": "gap",
+            "showAssigned": "gap",
+            "showDeleted": "gap",
+            "showHidden": "gap",
+            "updatedMin": "gap"
+          }
+        },
+        "tasklists.patch": {
+          "status": "gap"
+        },
+        "tasklists.update": {
+          "status": "gap"
+        },
+        "tasks.clear": {
+          "status": "gap"
+        },
+        "tasks.move": {
+          "status": "gap"
+        },
+        "tasks.update": {
+          "status": "gap"
+        }
+      }
+    },
+    "people": {
+      "operations": {
+        "contactGroups.batchGet": {
+          "status": "gap"
+        },
+        "contactGroups.create": {
+          "status": "gap"
+        },
+        "contactGroups.delete": {
+          "status": "gap"
+        },
+        "contactGroups.get": {
+          "status": "gap"
+        },
+        "contactGroups.list": {
+          "status": "gap"
+        },
+        "contactGroups.update": {
+          "status": "gap"
+        },
+        "contactGroups.members.modify": {
+          "status": "gap"
+        },
+        "otherContacts.copyOtherContactToMyContactsGroup": {
+          "status": "gap"
+        },
+        "otherContacts.list": {
+          "status": "gap"
+        },
+        "otherContacts.search": {
+          "status": "gap"
+        },
+        "people.batchCreateContacts": {
+          "status": "gap"
+        },
+        "people.batchDeleteContacts": {
+          "status": "gap"
+        },
+        "people.batchUpdateContacts": {
+          "status": "gap"
+        },
+        "people.createContact": {
+          "status": "gap"
+        },
+        "people.deleteContact": {
+          "status": "gap"
+        },
+        "people.deleteContactPhoto": {
+          "status": "gap"
+        },
+        "people.get": {
+          "status": "gap"
+        },
+        "people.getBatchGet": {
+          "status": "gap"
+        },
+        "people.listDirectoryPeople": {
+          "status": "gap"
+        },
+        "people.searchContacts": {
+          "status": "gap"
+        },
+        "people.searchDirectoryPeople": {
+          "status": "gap"
+        },
+        "people.updateContact": {
+          "status": "gap"
+        },
+        "people.updateContactPhoto": {
+          "status": "gap"
+        },
+        "people.connections.list": {
+          "status": "gap"
+        }
+      }
+    },
+    "chat": {
+      "operations": {
+        "customEmojis.create": {
+          "status": "gap"
+        },
+        "customEmojis.delete": {
+          "status": "gap"
+        },
+        "customEmojis.get": {
+          "status": "gap"
+        },
+        "customEmojis.list": {
+          "status": "gap"
+        },
+        "media.download": {
+          "status": "gap"
+        },
+        "media.upload": {
+          "status": "gap"
+        },
+        "spaces.completeImport": {
+          "status": "gap"
+        },
+        "spaces.create": {
+          "status": "gap"
+        },
+        "spaces.delete": {
+          "status": "gap"
+        },
+        "spaces.findDirectMessage": {
+          "status": "gap"
+        },
+        "spaces.findGroupChats": {
+          "status": "gap"
+        },
+        "spaces.get": {
+          "status": "gap"
+        },
+        "spaces.list": {
+          "status": "gap"
+        },
+        "spaces.patch": {
+          "status": "gap"
+        },
+        "spaces.search": {
+          "status": "gap"
+        },
+        "spaces.setup": {
+          "status": "gap"
+        },
+        "spaces.members.create": {
+          "status": "gap"
+        },
+        "spaces.members.delete": {
+          "status": "gap"
+        },
+        "spaces.members.get": {
+          "status": "gap"
+        },
+        "spaces.members.list": {
+          "status": "gap"
+        },
+        "spaces.members.patch": {
+          "status": "gap"
+        },
+        "spaces.messages.create": {
+          "status": "gap"
+        },
+        "spaces.messages.delete": {
+          "status": "gap"
+        },
+        "spaces.messages.get": {
+          "status": "gap"
+        },
+        "spaces.messages.list": {
+          "status": "gap"
+        },
+        "spaces.messages.patch": {
+          "status": "gap"
+        },
+        "spaces.messages.update": {
+          "status": "gap"
+        },
+        "spaces.messages.attachments.get": {
+          "status": "gap"
+        },
+        "spaces.messages.reactions.create": {
+          "status": "gap"
+        },
+        "spaces.messages.reactions.delete": {
+          "status": "gap"
+        },
+        "spaces.messages.reactions.list": {
+          "status": "gap"
+        },
+        "spaces.spaceEvents.get": {
+          "status": "gap"
+        },
+        "spaces.spaceEvents.list": {
+          "status": "gap"
+        },
+        "users.sections.create": {
+          "status": "gap"
+        },
+        "users.sections.delete": {
+          "status": "gap"
+        },
+        "users.sections.list": {
+          "status": "gap"
+        },
+        "users.sections.patch": {
+          "status": "gap"
+        },
+        "users.sections.position": {
+          "status": "gap"
+        },
+        "users.sections.items.list": {
+          "status": "gap"
+        },
+        "users.sections.items.move": {
+          "status": "gap"
+        },
+        "users.spaces.getSpaceReadState": {
+          "status": "gap"
+        },
+        "users.spaces.updateSpaceReadState": {
+          "status": "gap"
+        },
+        "users.spaces.spaceNotificationSetting.get": {
+          "status": "gap"
+        },
+        "users.spaces.spaceNotificationSetting.patch": {
+          "status": "gap"
+        },
+        "users.spaces.threads.getThreadReadState": {
+          "status": "gap"
+        }
+      }
+    },
+    "keep": {
+      "operations": {
+        "media.download": {
+          "status": "gap"
+        },
+        "notes.create": {
+          "status": "gap"
+        },
+        "notes.delete": {
+          "status": "gap"
+        },
+        "notes.get": {
+          "status": "gap"
+        },
+        "notes.list": {
+          "status": "gap"
+        },
+        "notes.permissions.batchCreate": {
+          "status": "gap"
+        },
+        "notes.permissions.batchDelete": {
+          "status": "gap"
+        }
+      }
+    },
+    "meet": {
+      "operations": {
+        "conferenceRecords.list": {
+          "status": "covered",
+          "params": {
+            "pageToken": "gap"
+          }
+        },
+        "conferenceRecords.participants.list": {
+          "status": "covered",
+          "params": {
+            "pageToken": "gap"
+          }
+        },
+        "conferenceRecords.recordings.list": {
+          "status": "covered",
+          "params": {
+            "pageSize": "gap",
+            "pageToken": "gap"
+          }
+        },
+        "conferenceRecords.smartNotes.list": {
+          "status": "covered",
+          "params": {
+            "pageSize": "gap",
+            "pageToken": "gap"
+          }
+        },
+        "conferenceRecords.transcripts.list": {
+          "status": "covered",
+          "params": {
+            "pageSize": "gap",
+            "parent": "gap"
+          }
+        },
+        "conferenceRecords.transcripts.entries.list": {
+          "status": "covered",
+          "params": {
+            "pageToken": "gap"
+          }
+        },
+        "conferenceRecords.participants.get": {
+          "status": "gap"
+        },
+        "conferenceRecords.participants.participantSessions.get": {
+          "status": "gap"
+        },
+        "conferenceRecords.participants.participantSessions.list": {
+          "status": "gap"
+        },
+        "conferenceRecords.transcripts.entries.get": {
+          "status": "gap"
+        },
+        "spaces.create": {
+          "status": "gap"
+        },
+        "spaces.endActiveConference": {
+          "status": "gap"
+        },
+        "spaces.get": {
+          "status": "gap"
+        },
+        "spaces.patch": {
+          "status": "gap"
+        }
+      }
+    },
+    "events": {
+      "operations": {
+        "tasks.get": {
+          "status": "covered",
+          "params": {
+            "historyLength": "gap",
+            "name": "gap",
+            "tenant": "gap"
+          }
+        },
+        "message.stream": {
+          "status": "gap"
+        },
+        "operations.get": {
+          "status": "gap"
+        },
+        "subscriptions.create": {
+          "status": "gap"
+        },
+        "subscriptions.delete": {
+          "status": "gap"
+        },
+        "subscriptions.get": {
+          "status": "gap"
+        },
+        "subscriptions.list": {
+          "status": "gap"
+        },
+        "subscriptions.patch": {
+          "status": "gap"
+        },
+        "subscriptions.reactivate": {
+          "status": "gap"
+        },
+        "tasks.cancel": {
+          "status": "gap"
+        },
+        "tasks.subscribe": {
+          "status": "gap"
+        },
+        "tasks.pushNotificationConfigs.create": {
+          "status": "gap"
+        },
+        "tasks.pushNotificationConfigs.delete": {
+          "status": "gap"
+        },
+        "tasks.pushNotificationConfigs.get": {
+          "status": "gap"
+        },
+        "tasks.pushNotificationConfigs.list": {
+          "status": "gap"
+        },
+        "+subscribe": {
+          "status": "gap"
+        },
+        "+renew": {
+          "status": "gap"
+        }
+      }
+    }
+  }
+}

--- a/coverage-baseline.json
+++ b/coverage-baseline.json
@@ -1,77 +1,9 @@
 {
   "gwsVersion": "gws 0.22.5",
-  "generatedAt": "2026-04-08T15:22:03.016Z",
+  "generatedAt": "2026-04-08T15:29:29.080Z",
   "services": {
     "drive": {
       "operations": {
-        "files.copy": {
-          "status": "covered",
-          "params": {
-            "ignoreDefaultVisibility": "gap",
-            "includeLabels": "gap",
-            "includePermissionsForView": "gap",
-            "keepRevisionForever": "gap",
-            "ocrLanguage": "gap",
-            "supportsAllDrives": "gap"
-          }
-        },
-        "files.delete": {
-          "status": "covered",
-          "params": {
-            "supportsAllDrives": "gap"
-          }
-        },
-        "files.get": {
-          "status": "covered",
-          "params": {
-            "acknowledgeAbuse": "gap",
-            "includeLabels": "gap",
-            "includePermissionsForView": "gap",
-            "supportsAllDrives": "gap"
-          }
-        },
-        "files.list": {
-          "status": "covered",
-          "params": {
-            "corpora": "gap",
-            "driveId": "gap",
-            "includeItemsFromAllDrives": "gap",
-            "includeLabels": "gap",
-            "includePermissionsForView": "gap",
-            "orderBy": "gap",
-            "pageToken": "gap",
-            "spaces": "gap",
-            "supportsAllDrives": "gap"
-          }
-        },
-        "permissions.create": {
-          "status": "covered",
-          "params": {
-            "emailMessage": "gap",
-            "moveToNewOwnersRoot": "gap",
-            "sendNotificationEmail": "gap",
-            "supportsAllDrives": "gap",
-            "transferOwnership": "gap",
-            "useDomainAdminAccess": "gap"
-          }
-        },
-        "permissions.delete": {
-          "status": "covered",
-          "params": {
-            "supportsAllDrives": "gap",
-            "useDomainAdminAccess": "gap"
-          }
-        },
-        "permissions.list": {
-          "status": "covered",
-          "params": {
-            "includePermissionsForView": "gap",
-            "pageSize": "gap",
-            "pageToken": "gap",
-            "supportsAllDrives": "gap",
-            "useDomainAdminAccess": "gap"
-          }
-        },
         "about.get": {
           "status": "gap"
         },
@@ -144,8 +76,25 @@
         "drives.update": {
           "status": "gap"
         },
+        "files.copy": {
+          "status": "covered",
+          "params": {
+            "ignoreDefaultVisibility": "gap",
+            "includeLabels": "gap",
+            "includePermissionsForView": "gap",
+            "keepRevisionForever": "gap",
+            "ocrLanguage": "gap",
+            "supportsAllDrives": "gap"
+          }
+        },
         "files.create": {
           "status": "gap"
+        },
+        "files.delete": {
+          "status": "covered",
+          "params": {
+            "supportsAllDrives": "gap"
+          }
         },
         "files.download": {
           "status": "gap"
@@ -153,8 +102,34 @@
         "files.emptyTrash": {
           "status": "gap"
         },
+        "files.export": {
+          "status": "gap"
+        },
         "files.generateIds": {
           "status": "gap"
+        },
+        "files.get": {
+          "status": "covered",
+          "params": {
+            "acknowledgeAbuse": "gap",
+            "includeLabels": "gap",
+            "includePermissionsForView": "gap",
+            "supportsAllDrives": "gap"
+          }
+        },
+        "files.list": {
+          "status": "covered",
+          "params": {
+            "corpora": "gap",
+            "driveId": "gap",
+            "includeItemsFromAllDrives": "gap",
+            "includeLabels": "gap",
+            "includePermissionsForView": "gap",
+            "orderBy": "gap",
+            "pageToken": "gap",
+            "spaces": "gap",
+            "supportsAllDrives": "gap"
+          }
         },
         "files.listLabels": {
           "status": "gap"
@@ -171,8 +146,36 @@
         "operations.get": {
           "status": "gap"
         },
+        "permissions.create": {
+          "status": "covered",
+          "params": {
+            "emailMessage": "gap",
+            "moveToNewOwnersRoot": "gap",
+            "sendNotificationEmail": "gap",
+            "supportsAllDrives": "gap",
+            "transferOwnership": "gap",
+            "useDomainAdminAccess": "gap"
+          }
+        },
+        "permissions.delete": {
+          "status": "covered",
+          "params": {
+            "supportsAllDrives": "gap",
+            "useDomainAdminAccess": "gap"
+          }
+        },
         "permissions.get": {
           "status": "gap"
+        },
+        "permissions.list": {
+          "status": "covered",
+          "params": {
+            "includePermissionsForView": "gap",
+            "pageSize": "gap",
+            "pageToken": "gap",
+            "supportsAllDrives": "gap",
+            "useDomainAdminAccess": "gap"
+          }
         },
         "permissions.update": {
           "status": "gap"
@@ -218,11 +221,20 @@
         },
         "teamdrives.update": {
           "status": "gap"
+        },
+        "+upload": {
+          "status": "gap"
         }
       }
     },
     "sheets": {
       "operations": {
+        "spreadsheets.batchUpdate": {
+          "status": "gap"
+        },
+        "spreadsheets.create": {
+          "status": "gap"
+        },
         "spreadsheets.get": {
           "status": "covered",
           "params": {
@@ -230,26 +242,6 @@
             "includeGridData": "gap",
             "ranges": "gap"
           }
-        },
-        "spreadsheets.values.get": {
-          "status": "covered",
-          "params": {
-            "dateTimeRenderOption": "gap",
-            "majorDimension": "gap",
-            "valueRenderOption": "gap"
-          }
-        },
-        "spreadsheets.values.update": {
-          "status": "covered",
-          "params": {
-            "includeValuesInResponse": "gap",
-            "responseDateTimeRenderOption": "gap",
-            "responseValueRenderOption": "gap",
-            "valueInputOption": "gap"
-          }
-        },
-        "spreadsheets.batchUpdate": {
-          "status": "gap"
         },
         "spreadsheets.getByDataFilter": {
           "status": "gap"
@@ -286,47 +278,34 @@
         },
         "spreadsheets.values.clear": {
           "status": "gap"
+        },
+        "spreadsheets.values.get": {
+          "status": "covered",
+          "params": {
+            "dateTimeRenderOption": "gap",
+            "majorDimension": "gap",
+            "valueRenderOption": "gap"
+          }
+        },
+        "spreadsheets.values.update": {
+          "status": "covered",
+          "params": {
+            "includeValuesInResponse": "gap",
+            "responseDateTimeRenderOption": "gap",
+            "responseValueRenderOption": "gap",
+            "valueInputOption": "gap"
+          }
+        },
+        "+append": {
+          "status": "gap"
+        },
+        "+read": {
+          "status": "gap"
         }
       }
     },
     "gmail": {
       "operations": {
-        "users.messages.get": {
-          "status": "covered",
-          "params": {
-            "format": "gap",
-            "metadataHeaders": "gap"
-          }
-        },
-        "users.messages.list": {
-          "status": "covered",
-          "params": {
-            "includeSpamTrash": "gap",
-            "labelIds": "gap",
-            "pageToken": "gap"
-          }
-        },
-        "users.messages.attachments.get": {
-          "status": "covered",
-          "params": {
-            "id": "gap"
-          }
-        },
-        "users.threads.get": {
-          "status": "covered",
-          "params": {
-            "format": "gap",
-            "metadataHeaders": "gap"
-          }
-        },
-        "users.threads.list": {
-          "status": "covered",
-          "params": {
-            "includeSpamTrash": "gap",
-            "labelIds": "gap",
-            "pageToken": "gap"
-          }
-        },
         "users.getProfile": {
           "status": "gap"
         },
@@ -366,6 +345,9 @@
         "users.labels.get": {
           "status": "gap"
         },
+        "users.labels.list": {
+          "status": "gap"
+        },
         "users.labels.patch": {
           "status": "gap"
         },
@@ -381,14 +363,44 @@
         "users.messages.delete": {
           "status": "gap"
         },
+        "users.messages.get": {
+          "status": "covered",
+          "params": {
+            "format": "gap",
+            "metadataHeaders": "gap"
+          }
+        },
         "users.messages.import": {
           "status": "gap"
         },
         "users.messages.insert": {
           "status": "gap"
         },
+        "users.messages.list": {
+          "status": "covered",
+          "params": {
+            "includeSpamTrash": "gap",
+            "labelIds": "gap",
+            "pageToken": "gap"
+          }
+        },
+        "users.messages.modify": {
+          "status": "gap"
+        },
         "users.messages.send": {
           "status": "gap"
+        },
+        "users.messages.trash": {
+          "status": "gap"
+        },
+        "users.messages.untrash": {
+          "status": "gap"
+        },
+        "users.messages.attachments.get": {
+          "status": "covered",
+          "params": {
+            "id": "gap"
+          }
         },
         "users.settings.getAutoForwarding": {
           "status": "gap"
@@ -528,6 +540,21 @@
         "users.threads.delete": {
           "status": "gap"
         },
+        "users.threads.get": {
+          "status": "covered",
+          "params": {
+            "format": "gap",
+            "metadataHeaders": "gap"
+          }
+        },
+        "users.threads.list": {
+          "status": "covered",
+          "params": {
+            "includeSpamTrash": "gap",
+            "labelIds": "gap",
+            "pageToken": "gap"
+          }
+        },
         "users.threads.modify": {
           "status": "gap"
         },
@@ -537,6 +564,21 @@
         "users.threads.untrash": {
           "status": "gap"
         },
+        "+send": {
+          "status": "gap"
+        },
+        "+triage": {
+          "status": "gap"
+        },
+        "+reply": {
+          "status": "gap"
+        },
+        "+forward": {
+          "status": "gap"
+        },
+        "+read": {
+          "status": "gap"
+        },
         "+watch": {
           "status": "gap"
         }
@@ -544,69 +586,6 @@
     },
     "calendar": {
       "operations": {
-        "calendarList.list": {
-          "status": "covered",
-          "params": {
-            "maxResults": "gap",
-            "minAccessRole": "gap",
-            "pageToken": "gap",
-            "showDeleted": "gap",
-            "showHidden": "gap",
-            "syncToken": "gap"
-          }
-        },
-        "events.delete": {
-          "status": "covered",
-          "params": {
-            "sendNotifications": "gap",
-            "sendUpdates": "gap"
-          }
-        },
-        "events.get": {
-          "status": "covered",
-          "params": {
-            "alwaysIncludeEmail": "gap",
-            "maxAttendees": "gap",
-            "timeZone": "gap"
-          }
-        },
-        "events.list": {
-          "status": "covered",
-          "params": {
-            "alwaysIncludeEmail": "gap",
-            "eventTypes": "gap",
-            "iCalUID": "gap",
-            "maxAttendees": "gap",
-            "orderBy": "gap",
-            "pageToken": "gap",
-            "privateExtendedProperty": "gap",
-            "sharedExtendedProperty": "gap",
-            "showDeleted": "gap",
-            "showHiddenInvitations": "gap",
-            "singleEvents": "gap",
-            "syncToken": "gap",
-            "timeZone": "gap",
-            "updatedMin": "gap"
-          }
-        },
-        "events.patch": {
-          "status": "covered",
-          "params": {
-            "alwaysIncludeEmail": "gap",
-            "conferenceDataVersion": "gap",
-            "maxAttendees": "gap",
-            "sendNotifications": "gap",
-            "sendUpdates": "gap",
-            "supportsAttachments": "gap"
-          }
-        },
-        "events.quickAdd": {
-          "status": "covered",
-          "params": {
-            "sendNotifications": "gap",
-            "sendUpdates": "gap"
-          }
-        },
         "acl.delete": {
           "status": "gap"
         },
@@ -636,6 +615,17 @@
         },
         "calendarList.insert": {
           "status": "gap"
+        },
+        "calendarList.list": {
+          "status": "covered",
+          "params": {
+            "maxResults": "gap",
+            "minAccessRole": "gap",
+            "pageToken": "gap",
+            "showDeleted": "gap",
+            "showHidden": "gap",
+            "syncToken": "gap"
+          }
         },
         "calendarList.patch": {
           "status": "gap"
@@ -673,6 +663,21 @@
         "colors.get": {
           "status": "gap"
         },
+        "events.delete": {
+          "status": "covered",
+          "params": {
+            "sendNotifications": "gap",
+            "sendUpdates": "gap"
+          }
+        },
+        "events.get": {
+          "status": "covered",
+          "params": {
+            "alwaysIncludeEmail": "gap",
+            "maxAttendees": "gap",
+            "timeZone": "gap"
+          }
+        },
         "events.import": {
           "status": "gap"
         },
@@ -682,13 +687,53 @@
         "events.instances": {
           "status": "gap"
         },
+        "events.list": {
+          "status": "covered",
+          "params": {
+            "alwaysIncludeEmail": "gap",
+            "eventTypes": "gap",
+            "iCalUID": "gap",
+            "maxAttendees": "gap",
+            "orderBy": "gap",
+            "pageToken": "gap",
+            "privateExtendedProperty": "gap",
+            "sharedExtendedProperty": "gap",
+            "showDeleted": "gap",
+            "showHiddenInvitations": "gap",
+            "singleEvents": "gap",
+            "syncToken": "gap",
+            "timeZone": "gap",
+            "updatedMin": "gap"
+          }
+        },
         "events.move": {
           "status": "gap"
+        },
+        "events.patch": {
+          "status": "covered",
+          "params": {
+            "alwaysIncludeEmail": "gap",
+            "conferenceDataVersion": "gap",
+            "maxAttendees": "gap",
+            "sendNotifications": "gap",
+            "sendUpdates": "gap",
+            "supportsAttachments": "gap"
+          }
+        },
+        "events.quickAdd": {
+          "status": "covered",
+          "params": {
+            "sendNotifications": "gap",
+            "sendUpdates": "gap"
+          }
         },
         "events.update": {
           "status": "gap"
         },
         "events.watch": {
+          "status": "gap"
+        },
+        "freebusy.query": {
           "status": "gap"
         },
         "settings.get": {
@@ -699,11 +744,23 @@
         },
         "settings.watch": {
           "status": "gap"
+        },
+        "+insert": {
+          "status": "gap"
+        },
+        "+agenda": {
+          "status": "gap"
         }
       }
     },
     "docs": {
       "operations": {
+        "documents.batchUpdate": {
+          "status": "gap"
+        },
+        "documents.create": {
+          "status": "gap"
+        },
         "documents.get": {
           "status": "covered",
           "params": {
@@ -711,7 +768,7 @@
             "suggestionsViewMode": "gap"
           }
         },
-        "documents.batchUpdate": {
+        "+write": {
           "status": "gap"
         }
       }
@@ -737,12 +794,36 @@
     },
     "tasks": {
       "operations": {
+        "tasklists.delete": {
+          "status": "gap"
+        },
+        "tasklists.get": {
+          "status": "gap"
+        },
+        "tasklists.insert": {
+          "status": "gap"
+        },
         "tasklists.list": {
           "status": "covered",
           "params": {
             "maxResults": "gap",
             "pageToken": "gap"
           }
+        },
+        "tasklists.patch": {
+          "status": "gap"
+        },
+        "tasklists.update": {
+          "status": "gap"
+        },
+        "tasks.clear": {
+          "status": "gap"
+        },
+        "tasks.delete": {
+          "status": "gap"
+        },
+        "tasks.get": {
+          "status": "gap"
         },
         "tasks.insert": {
           "status": "covered",
@@ -765,16 +846,10 @@
             "updatedMin": "gap"
           }
         },
-        "tasklists.patch": {
-          "status": "gap"
-        },
-        "tasklists.update": {
-          "status": "gap"
-        },
-        "tasks.clear": {
-          "status": "gap"
-        },
         "tasks.move": {
+          "status": "gap"
+        },
+        "tasks.patch": {
           "status": "gap"
         },
         "tasks.update": {
@@ -994,6 +1069,9 @@
         },
         "users.spaces.threads.getThreadReadState": {
           "status": "gap"
+        },
+        "+send": {
+          "status": "gap"
         }
       }
     },
@@ -1024,40 +1102,10 @@
     },
     "meet": {
       "operations": {
+        "conferenceRecords.get": {
+          "status": "gap"
+        },
         "conferenceRecords.list": {
-          "status": "covered",
-          "params": {
-            "pageToken": "gap"
-          }
-        },
-        "conferenceRecords.participants.list": {
-          "status": "covered",
-          "params": {
-            "pageToken": "gap"
-          }
-        },
-        "conferenceRecords.recordings.list": {
-          "status": "covered",
-          "params": {
-            "pageSize": "gap",
-            "pageToken": "gap"
-          }
-        },
-        "conferenceRecords.smartNotes.list": {
-          "status": "covered",
-          "params": {
-            "pageSize": "gap",
-            "pageToken": "gap"
-          }
-        },
-        "conferenceRecords.transcripts.list": {
-          "status": "covered",
-          "params": {
-            "pageSize": "gap",
-            "parent": "gap"
-          }
-        },
-        "conferenceRecords.transcripts.entries.list": {
           "status": "covered",
           "params": {
             "pageToken": "gap"
@@ -1066,14 +1114,56 @@
         "conferenceRecords.participants.get": {
           "status": "gap"
         },
+        "conferenceRecords.participants.list": {
+          "status": "covered",
+          "params": {
+            "pageToken": "gap"
+          }
+        },
         "conferenceRecords.participants.participantSessions.get": {
           "status": "gap"
         },
         "conferenceRecords.participants.participantSessions.list": {
           "status": "gap"
         },
+        "conferenceRecords.recordings.get": {
+          "status": "gap"
+        },
+        "conferenceRecords.recordings.list": {
+          "status": "covered",
+          "params": {
+            "pageSize": "gap",
+            "pageToken": "gap"
+          }
+        },
+        "conferenceRecords.smartNotes.get": {
+          "status": "gap"
+        },
+        "conferenceRecords.smartNotes.list": {
+          "status": "covered",
+          "params": {
+            "pageSize": "gap",
+            "pageToken": "gap"
+          }
+        },
+        "conferenceRecords.transcripts.get": {
+          "status": "gap"
+        },
+        "conferenceRecords.transcripts.list": {
+          "status": "covered",
+          "params": {
+            "pageSize": "gap",
+            "parent": "gap"
+          }
+        },
         "conferenceRecords.transcripts.entries.get": {
           "status": "gap"
+        },
+        "conferenceRecords.transcripts.entries.list": {
+          "status": "covered",
+          "params": {
+            "pageToken": "gap"
+          }
         },
         "spaces.create": {
           "status": "gap"
@@ -1091,14 +1181,6 @@
     },
     "events": {
       "operations": {
-        "tasks.get": {
-          "status": "covered",
-          "params": {
-            "historyLength": "gap",
-            "name": "gap",
-            "tenant": "gap"
-          }
-        },
         "message.stream": {
           "status": "gap"
         },
@@ -1125,6 +1207,14 @@
         },
         "tasks.cancel": {
           "status": "gap"
+        },
+        "tasks.get": {
+          "status": "covered",
+          "params": {
+            "historyLength": "gap",
+            "name": "gap",
+            "tenant": "gap"
+          }
         },
         "tasks.subscribe": {
           "status": "gap"

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -20,7 +20,10 @@ Both trigger on `push: tags: ['v*']`.
 ```bash
 git checkout main && git pull
 make check          # types + all tests must pass
+make coverage       # review gws CLI coverage gaps (advisory, non-blocking)
 ```
+
+The coverage report shows what the manifest exposes vs the full gws CLI surface. Review parameter gaps on covered operations — missing params like `supportsAllDrives` can cause user-facing issues. Run `make coverage-update` after adding new operations to refresh the baseline.
 
 ### 2. Bump version
 

--- a/src/coverage/analyze.ts
+++ b/src/coverage/analyze.ts
@@ -44,7 +44,7 @@ async function main(): Promise<void> {
 
   // Update baseline if requested
   if (doUpdate) {
-    const newBaseline = generateBaseline(report, baseline);
+    const newBaseline = generateBaseline(report, discovered, baseline);
     const path = writeBaseline(newBaseline);
     process.stderr.write(`[coverage] Baseline updated: ${path}\n`);
   }

--- a/src/coverage/analyze.ts
+++ b/src/coverage/analyze.ts
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+/**
+ * Build-time coverage analysis tool (ADR-100).
+ *
+ * Compares the curated manifest against the gws CLI's actual surface
+ * to produce a structured coverage report.
+ *
+ * Usage:
+ *   node build/coverage/analyze.js           # print coverage report
+ *   node build/coverage/analyze.js --update   # also update baseline file
+ *   node build/coverage/analyze.js --json     # output as JSON
+ */
+
+import { loadManifest } from '../factory/generator.js';
+import { discoverSurface } from './discover.js';
+import { compareSurfaces } from './compare.js';
+import { loadBaseline, generateBaseline, writeBaseline } from './baseline.js';
+import { formatTerminalReport, formatJsonReport } from './report.js';
+
+const args = process.argv.slice(2);
+const doUpdate = args.includes('--update');
+const jsonOutput = args.includes('--json');
+
+async function main(): Promise<void> {
+  // Load curated manifest (same parser the server uses)
+  const manifest = loadManifest();
+
+  // Load existing baseline (if any)
+  const baseline = loadBaseline();
+
+  // Discover the gws CLI surface
+  process.stderr.write('[coverage] Discovering gws CLI surface...\n');
+  const discovered = discoverSurface();
+
+  // Compare
+  const report = compareSurfaces(manifest, discovered, baseline);
+
+  // Output
+  if (jsonOutput) {
+    process.stdout.write(formatJsonReport(report) + '\n');
+  } else {
+    process.stdout.write(formatTerminalReport(report));
+  }
+
+  // Update baseline if requested
+  if (doUpdate) {
+    const newBaseline = generateBaseline(report, baseline);
+    const path = writeBaseline(newBaseline);
+    process.stderr.write(`[coverage] Baseline updated: ${path}\n`);
+  }
+}
+
+main().catch((err) => {
+  process.stderr.write(`[coverage] Error: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/src/coverage/baseline.ts
+++ b/src/coverage/baseline.ts
@@ -1,0 +1,81 @@
+/**
+ * Baseline file management for coverage tracking.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { CoverageBaseline, CoverageReport, BaselineEntry } from './types.js';
+
+const DEFAULT_PATH = 'coverage-baseline.json';
+
+function resolvePath(filePath?: string): string {
+  const p = filePath || DEFAULT_PATH;
+  return path.isAbsolute(p) ? p : path.join(process.cwd(), p);
+}
+
+export function loadBaseline(filePath?: string): CoverageBaseline | null {
+  const resolved = resolvePath(filePath);
+  try {
+    const raw = fs.readFileSync(resolved, 'utf-8');
+    return JSON.parse(raw) as CoverageBaseline;
+  } catch {
+    return null;
+  }
+}
+
+/** Generate a new baseline from a coverage report, preserving exclusions from existing baseline. */
+export function generateBaseline(
+  report: CoverageReport,
+  existing?: CoverageBaseline | null,
+): CoverageBaseline {
+  const services: CoverageBaseline['services'] = {};
+
+  for (const svc of report.services) {
+    const existingOps = existing?.services[svc.service]?.operations || {};
+    const operations: Record<string, BaselineEntry> = {};
+
+    // Walk the report to build new entries
+    // We need the discovered surface to know all operations — pull from existing + report
+    // Covered operations
+    for (const [opPath, gaps] of Object.entries(svc.paramGaps)) {
+      operations[opPath] = {
+        status: 'covered',
+        params: Object.fromEntries(
+          gaps.map(g => [g.paramName, g.inManifest ? 'covered' : 'gap'] as const),
+        ),
+      };
+    }
+
+    // For covered ops without param gaps, just mark as covered
+    // We infer these from the report structure — any op that's covered is in coveredOps count
+    // The comparison module handles classification; we just preserve exclusions here
+
+    // Preserve excluded entries from existing baseline
+    for (const [opPath, entry] of Object.entries(existingOps)) {
+      if (entry.status === 'excluded') {
+        operations[opPath] = entry;
+      }
+    }
+
+    // Mark new gaps
+    for (const opPath of svc.newOps) {
+      if (!operations[opPath]) {
+        operations[opPath] = { status: 'gap' };
+      }
+    }
+
+    services[svc.service] = { operations };
+  }
+
+  return {
+    gwsVersion: report.gwsVersion,
+    generatedAt: report.timestamp,
+    services,
+  };
+}
+
+export function writeBaseline(baseline: CoverageBaseline, filePath?: string): string {
+  const resolved = resolvePath(filePath);
+  fs.writeFileSync(resolved, JSON.stringify(baseline, null, 2) + '\n');
+  return resolved;
+}

--- a/src/coverage/baseline.ts
+++ b/src/coverage/baseline.ts
@@ -4,7 +4,7 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import type { CoverageBaseline, CoverageReport, BaselineEntry } from './types.js';
+import type { CoverageBaseline, CoverageReport, BaselineEntry, DiscoveredSurface } from './types.js';
 
 const DEFAULT_PATH = 'coverage-baseline.json';
 
@@ -23,43 +23,71 @@ export function loadBaseline(filePath?: string): CoverageBaseline | null {
   }
 }
 
-/** Generate a new baseline from a coverage report, preserving exclusions from existing baseline. */
+/** Build the set of manifest-covered resource/helper paths. */
+function getCoveredPaths(report: CoverageReport): Set<string> {
+  const covered = new Set<string>();
+  for (const svc of report.services) {
+    // Ops with param gaps are covered
+    for (const opPath of Object.keys(svc.paramGaps)) {
+      covered.add(`${svc.service}:${opPath}`);
+    }
+  }
+  return covered;
+}
+
+/** Generate a new baseline from a coverage report + discovered surface. */
 export function generateBaseline(
   report: CoverageReport,
+  discovered: DiscoveredSurface,
   existing?: CoverageBaseline | null,
 ): CoverageBaseline {
   const services: CoverageBaseline['services'] = {};
 
+  // Build a lookup of covered paths from the report's param gaps
+  // (ops with param gaps are definitely covered)
+  const paramGapPaths = getCoveredPaths(report);
+
   for (const svc of report.services) {
+    const disc = discovered.services[svc.service];
+    if (!disc) continue;
+
     const existingOps = existing?.services[svc.service]?.operations || {};
     const operations: Record<string, BaselineEntry> = {};
 
-    // Walk the report to build new entries
-    // We need the discovered surface to know all operations — pull from existing + report
-    // Covered operations
-    for (const [opPath, gaps] of Object.entries(svc.paramGaps)) {
-      operations[opPath] = {
-        status: 'covered',
-        params: Object.fromEntries(
-          gaps.map(g => [g.paramName, g.inManifest ? 'covered' : 'gap'] as const),
-        ),
-      };
-    }
+    // Enumerate all discovered operations
+    const allPaths = new Set<string>([
+      ...Object.keys(disc.operations),
+      ...Object.keys(disc.helpers),
+    ]);
 
-    // For covered ops without param gaps, just mark as covered
-    // We infer these from the report structure — any op that's covered is in coveredOps count
-    // The comparison module handles classification; we just preserve exclusions here
-
-    // Preserve excluded entries from existing baseline
-    for (const [opPath, entry] of Object.entries(existingOps)) {
-      if (entry.status === 'excluded') {
-        operations[opPath] = entry;
+    for (const opPath of allPaths) {
+      // Check if excluded in existing baseline — preserve
+      if (existingOps[opPath]?.status === 'excluded') {
+        operations[opPath] = existingOps[opPath];
+        continue;
       }
-    }
 
-    // Mark new gaps
-    for (const opPath of svc.newOps) {
-      if (!operations[opPath]) {
+      // Check if covered (has param gaps recorded)
+      const key = `${svc.service}:${opPath}`;
+      if (paramGapPaths.has(key)) {
+        const gaps = svc.paramGaps[opPath] || [];
+        operations[opPath] = {
+          status: 'covered',
+          params: gaps.length > 0
+            ? Object.fromEntries(gaps.map(g => [g.paramName, g.inManifest ? 'covered' : 'gap'] as const))
+            : undefined,
+        };
+        continue;
+      }
+
+      // Check if it's covered but without param gaps — need to check the report counts
+      // We can infer from whether the op was NOT in newOps and NOT excluded
+      const isNew = svc.newOps.includes(opPath);
+      const wasCovered = existingOps[opPath]?.status === 'covered';
+
+      if (wasCovered && !isNew) {
+        operations[opPath] = { status: 'covered' };
+      } else {
         operations[opPath] = { status: 'gap' };
       }
     }

--- a/src/coverage/compare.ts
+++ b/src/coverage/compare.ts
@@ -1,0 +1,156 @@
+/**
+ * Compare curated manifest against discovered gws CLI surface.
+ */
+
+import type { Manifest } from '../factory/types.js';
+import type {
+  DiscoveredSurface, CoverageBaseline, CoverageReport,
+  ServiceCoverage, ParamGap, DiscoveredParam,
+} from './types.js';
+import { ELIGIBLE_SERVICES, SKIP_PARAMS } from './types.js';
+
+/** Build a set of gws resource paths and helper names covered by the manifest. */
+function buildCoveredPaths(manifest: Manifest): Map<string, { service: string; opName: string; params: Set<string> }> {
+  const covered = new Map<string, { service: string; opName: string; params: Set<string> }>();
+
+  for (const [serviceName, serviceDef] of Object.entries(manifest.services)) {
+    for (const [opName, opDef] of Object.entries(serviceDef.operations)) {
+      const path = opDef.resource || opDef.helper;
+      if (!path) continue;
+
+      const paramNames = new Set<string>();
+      if (opDef.params) {
+        for (const [name, paramDef] of Object.entries(opDef.params)) {
+          // Use maps_to if declared, otherwise the param name itself
+          paramNames.add(paramDef.maps_to || name);
+        }
+      }
+
+      covered.set(path, {
+        service: serviceDef.gws_service,
+        opName,
+        params: paramNames,
+      });
+    }
+  }
+
+  return covered;
+}
+
+/** Compare params for a covered operation. */
+function compareParams(
+  manifestParams: Set<string>,
+  gwsParams: Record<string, DiscoveredParam>,
+): ParamGap[] {
+  const gaps: ParamGap[] = [];
+
+  for (const [name, param] of Object.entries(gwsParams)) {
+    if (SKIP_PARAMS.has(name)) continue;
+    if (param.deprecated) continue;
+
+    if (!manifestParams.has(name)) {
+      gaps.push({
+        paramName: name,
+        inGws: true,
+        inManifest: false,
+        details: `${param.type}${param.required ? ', required' : ''} — ${param.description.slice(0, 80)}`,
+      });
+    }
+  }
+
+  return gaps;
+}
+
+export function compareSurfaces(
+  manifest: Manifest,
+  discovered: DiscoveredSurface,
+  baseline?: CoverageBaseline | null,
+): CoverageReport {
+  const coveredPaths = buildCoveredPaths(manifest);
+  const serviceCoverages: ServiceCoverage[] = [];
+  let totalOps = 0;
+  let totalCovered = 0;
+
+  for (const service of ELIGIBLE_SERVICES) {
+    const disc = discovered.services[service];
+    if (!disc) {
+      // Service exists in eligible list but gws doesn't expose it
+      continue;
+    }
+
+    const baselineOps = baseline?.services[service]?.operations || {};
+
+    const allOps = new Set<string>();
+    // Add resource-based operations
+    for (const path of Object.keys(disc.operations)) {
+      allOps.add(path);
+    }
+    // Add helpers
+    for (const name of Object.keys(disc.helpers)) {
+      allOps.add(name);
+    }
+
+    let covered = 0;
+    let excluded = 0;
+    let gap = 0;
+    const newOps: string[] = [];
+    const removedOps: string[] = [];
+    const paramGaps: Record<string, ParamGap[]> = {};
+
+    for (const opPath of allOps) {
+      const isCovered = coveredPaths.has(opPath);
+      const baselineEntry = baselineOps[opPath];
+      const wasInBaseline = !!baselineEntry;
+
+      if (isCovered) {
+        covered++;
+        // Check param gaps for resource-based operations
+        const discOp = disc.operations[opPath];
+        const manifestEntry = coveredPaths.get(opPath);
+        if (discOp && manifestEntry) {
+          const gaps = compareParams(manifestEntry.params, discOp.params);
+          if (gaps.length > 0) {
+            paramGaps[opPath] = gaps;
+          }
+        }
+      } else if (baselineEntry?.status === 'excluded') {
+        excluded++;
+      } else {
+        gap++;
+        if (!wasInBaseline) {
+          newOps.push(opPath);
+        }
+      }
+    }
+
+    // Check for removed operations (in baseline but gone from gws)
+    for (const opPath of Object.keys(baselineOps)) {
+      if (!allOps.has(opPath)) {
+        removedOps.push(opPath);
+      }
+    }
+
+    totalOps += allOps.size;
+    totalCovered += covered;
+
+    serviceCoverages.push({
+      service,
+      totalOps: allOps.size,
+      coveredOps: covered,
+      excludedOps: excluded,
+      gapOps: gap,
+      newOps,
+      removedOps,
+      paramGaps,
+    });
+  }
+
+  return {
+    gwsVersion: discovered.gwsVersion,
+    timestamp: new Date().toISOString(),
+    totalOps: totalOps,
+    coveredOps: totalCovered,
+    coveragePercent: totalOps > 0 ? Math.round((totalCovered / totalOps) * 100) : 0,
+    services: serviceCoverages,
+  };
+}

--- a/src/coverage/discover.ts
+++ b/src/coverage/discover.ts
@@ -1,0 +1,190 @@
+/**
+ * gws CLI surface discovery — enumerates services, resources, methods,
+ * helpers, and parameter schemas by invoking the gws binary.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { resolveGwsBinary } from '../executor/gws.js';
+import {
+  ELIGIBLE_SERVICES, SKIP_PARAMS,
+  type DiscoveredSurface, type DiscoveredService,
+  type DiscoveredOperation, type DiscoveredHelper, type DiscoveredParam,
+} from './types.js';
+
+const TIMEOUT = 10_000;
+
+function gws(args: string[]): string {
+  const binary = resolveGwsBinary();
+  return execFileSync(binary, args, {
+    encoding: 'utf8',
+    timeout: TIMEOUT,
+    env: { ...process.env },
+  });
+}
+
+function gwsSafe(args: string[]): string | null {
+  try {
+    const binary = resolveGwsBinary();
+    return execFileSync(binary, args, {
+      encoding: 'utf8',
+      timeout: TIMEOUT,
+      env: { ...process.env },
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+  } catch {
+    return null;
+  }
+}
+
+/** Parse service --help to find resources and helpers. */
+function parseServiceHelp(output: string): { resources: string[]; helpers: DiscoveredHelper[] } {
+  const resources: string[] = [];
+  const helpers: DiscoveredHelper[] = [];
+
+  for (const line of output.split('\n')) {
+    const trimmed = line.trimStart();
+
+    // Helpers: lines starting with +
+    const helperMatch = trimmed.match(/^(\+\w+)\s+(?:\[Helper\]\s*)?(.*)$/);
+    if (helperMatch) {
+      helpers.push({ name: helperMatch[1], description: helperMatch[2].trim() });
+      continue;
+    }
+
+    // Resources: "word  Operations on the '...' resource"
+    const resourceMatch = trimmed.match(/^(\w+)\s+Operations on the/);
+    if (resourceMatch && resourceMatch[1] !== 'help') {
+      resources.push(resourceMatch[1]);
+    }
+  }
+
+  return { resources, helpers };
+}
+
+/** Parse resource --help to find methods and sub-resources. */
+function parseResourceHelp(output: string): { methods: string[]; subResources: string[] } {
+  const methods: string[] = [];
+  const subResources: string[] = [];
+
+  for (const line of output.split('\n')) {
+    const trimmed = line.trimStart();
+    if (!trimmed || trimmed.startsWith('Usage:') || trimmed.startsWith('FLAGS:')) continue;
+
+    const resourceMatch = trimmed.match(/^(\w+)\s+Operations on the/);
+    if (resourceMatch && resourceMatch[1] !== 'help') {
+      subResources.push(resourceMatch[1]);
+      continue;
+    }
+
+    // Methods: "word  Description text" (not "help", not "Operations on")
+    const methodMatch = trimmed.match(/^(\w+)\s+\S/);
+    if (methodMatch && methodMatch[1] !== 'help' && !trimmed.includes('Operations on')) {
+      methods.push(methodMatch[1]);
+    }
+  }
+
+  return { methods, subResources };
+}
+
+/** Parse gws schema JSON output into DiscoveredParam records. */
+function parseSchemaParams(json: string): Record<string, DiscoveredParam> {
+  const params: Record<string, DiscoveredParam> = {};
+  try {
+    const schema = JSON.parse(json);
+    const rawParams = schema.parameters || {};
+    for (const [name, def] of Object.entries(rawParams)) {
+      if (SKIP_PARAMS.has(name)) continue;
+      const p = def as Record<string, unknown>;
+      params[name] = {
+        type: String(p.type === 'integer' ? 'number' : (p.type || 'string')),
+        description: String(p.description || '').replace(/\n/g, ' ').slice(0, 200),
+        required: Boolean(p.required),
+        ...(p.default !== undefined ? { default: p.default } : {}),
+        ...(p.enum ? { enum: p.enum as string[] } : {}),
+        ...(p.deprecated ? { deprecated: true } : {}),
+      };
+    }
+  } catch {
+    // Schema parse failed — return empty params
+  }
+  return params;
+}
+
+/** Recursively discover methods under a resource path. */
+function discoverResource(
+  service: string,
+  parentPath: string,
+  parts: string[],
+): Record<string, DiscoveredOperation> {
+  const operations: Record<string, DiscoveredOperation> = {};
+
+  const helpOutput = gwsSafe([service, ...parts, '--help']);
+  if (!helpOutput) return operations;
+
+  const { methods, subResources } = parseResourceHelp(helpOutput);
+
+  for (const method of methods) {
+    const resourcePath = `${parentPath}.${method}`;
+    const schemaOutput = gwsSafe(['schema', `${service}.${parentPath}.${method}`]);
+
+    let params: Record<string, DiscoveredParam> = {};
+    let description = '';
+    let httpMethod: string | undefined;
+
+    if (schemaOutput) {
+      params = parseSchemaParams(schemaOutput);
+      try {
+        const schema = JSON.parse(schemaOutput);
+        description = String(schema.description || '').replace(/\n/g, ' ').slice(0, 200);
+        httpMethod = schema.httpMethod;
+      } catch { /* ignore */ }
+    }
+
+    operations[resourcePath] = { resourcePath, description, httpMethod, params };
+  }
+
+  for (const sub of subResources) {
+    const subOps = discoverResource(service, `${parentPath}.${sub}`, [...parts, sub]);
+    Object.assign(operations, subOps);
+  }
+
+  return operations;
+}
+
+/** Discover the full surface of a single gws service. */
+function discoverService(service: string): DiscoveredService {
+  const helpOutput = gwsSafe([service, '--help']);
+  if (!helpOutput) return { operations: {}, helpers: {} };
+
+  const { resources, helpers } = parseServiceHelp(helpOutput);
+  const helperMap: Record<string, DiscoveredHelper> = {};
+  for (const h of helpers) {
+    helperMap[h.name] = h;
+  }
+
+  let operations: Record<string, DiscoveredOperation> = {};
+  for (const resource of resources) {
+    const resourceOps = discoverResource(service, resource, [resource]);
+    operations = { ...operations, ...resourceOps };
+  }
+
+  return { operations, helpers: helperMap };
+}
+
+/** Discover the full gws CLI surface for all eligible services. */
+export function discoverSurface(): DiscoveredSurface {
+  // Get gws version
+  let gwsVersion = 'unknown';
+  try {
+    gwsVersion = gws(['--version']).trim().split('\n')[0];
+  } catch { /* ignore */ }
+
+  const services: Record<string, DiscoveredService> = {};
+
+  for (const service of ELIGIBLE_SERVICES) {
+    process.stderr.write(`[coverage] discovering ${service}...\n`);
+    services[service] = discoverService(service);
+  }
+
+  return { gwsVersion, services };
+}

--- a/src/coverage/discover.ts
+++ b/src/coverage/discover.ts
@@ -12,10 +12,15 @@ import {
 } from './types.js';
 
 const TIMEOUT = 10_000;
+let cachedBinary: string | undefined;
+
+function getBinary(): string {
+  if (!cachedBinary) cachedBinary = resolveGwsBinary();
+  return cachedBinary;
+}
 
 function gws(args: string[]): string {
-  const binary = resolveGwsBinary();
-  return execFileSync(binary, args, {
+  return execFileSync(getBinary(), args, {
     encoding: 'utf8',
     timeout: TIMEOUT,
     env: { ...process.env },
@@ -24,8 +29,7 @@ function gws(args: string[]): string {
 
 function gwsSafe(args: string[]): string | null {
   try {
-    const binary = resolveGwsBinary();
-    return execFileSync(binary, args, {
+    return execFileSync(getBinary(), args, {
       encoding: 'utf8',
       timeout: TIMEOUT,
       env: { ...process.env },
@@ -125,7 +129,12 @@ function discoverResource(
 
   for (const method of methods) {
     const resourcePath = `${parentPath}.${method}`;
-    const schemaOutput = gwsSafe(['schema', `${service}.${parentPath}.${method}`]);
+    // gws schema uses flat resource names (e.g. drive.replies.list),
+    // not nested CLI paths (e.g. drive.comments.replies.list).
+    // Try the full path first, fall back to leaf resource + method.
+    const leafResource = parts[parts.length - 1];
+    const schemaOutput = gwsSafe(['schema', `${service}.${parentPath}.${method}`])
+      || (parts.length > 1 ? gwsSafe(['schema', `${service}.${leafResource}.${method}`]) : null);
 
     let params: Record<string, DiscoveredParam> = {};
     let description = '';

--- a/src/coverage/report.ts
+++ b/src/coverage/report.ts
@@ -1,0 +1,107 @@
+/**
+ * Format coverage reports for terminal and JSON output.
+ */
+
+import type { CoverageReport } from './types.js';
+
+const BOLD = '\x1b[1m';
+const DIM = '\x1b[2m';
+const GREEN = '\x1b[32m';
+const YELLOW = '\x1b[33m';
+const RED = '\x1b[31m';
+const CYAN = '\x1b[36m';
+const RESET = '\x1b[0m';
+
+function bar(covered: number, total: number, width = 20): string {
+  if (total === 0) return DIM + '░'.repeat(width) + RESET;
+  const filled = Math.round((covered / total) * width);
+  const color = (covered / total) >= 0.5 ? GREEN : (covered / total) >= 0.25 ? YELLOW : RED;
+  return color + '█'.repeat(filled) + RESET + DIM + '░'.repeat(width - filled) + RESET;
+}
+
+function pct(n: number, total: number): string {
+  if (total === 0) return '  -';
+  return `${Math.round((n / total) * 100).toString().padStart(3)}%`;
+}
+
+export function formatTerminalReport(report: CoverageReport): string {
+  const lines: string[] = [];
+
+  lines.push('');
+  lines.push(`${BOLD}gws CLI Coverage Analysis${RESET}`);
+  lines.push(`${DIM}gws version: ${report.gwsVersion}${RESET}`);
+  lines.push(`${DIM}timestamp:   ${report.timestamp}${RESET}`);
+  lines.push('');
+
+  // Summary
+  lines.push(`${BOLD}Coverage: ${report.coveredOps}/${report.totalOps} operations (${report.coveragePercent}%)${RESET}`);
+  lines.push('');
+
+  // Per-service table
+  const header = `  ${'Service'.padEnd(14)} ${'Covered'.padStart(8)}  ${' '.repeat(20)}  ${'Pct'.padStart(4)}  ${'Gaps'.padStart(5)}  ${'Excl'.padStart(5)}`;
+  lines.push(`${DIM}${header}${RESET}`);
+  lines.push(`${DIM}  ${'─'.repeat(14)} ${'─'.repeat(8)}  ${'─'.repeat(20)}  ${'─'.repeat(4)}  ${'─'.repeat(5)}  ${'─'.repeat(5)}${RESET}`);
+
+  for (const svc of report.services) {
+    if (svc.totalOps === 0) continue;
+    const svcName = svc.service.padEnd(14);
+    const ratio = `${svc.coveredOps}/${svc.totalOps}`.padStart(8);
+    const barStr = bar(svc.coveredOps, svc.totalOps);
+    const pctStr = pct(svc.coveredOps, svc.totalOps);
+    const gapStr = (svc.gapOps > 0 ? `${svc.gapOps}` : '-').padStart(5);
+    const exclStr = (svc.excludedOps > 0 ? `${svc.excludedOps}` : '-').padStart(5);
+    lines.push(`  ${svcName} ${ratio}  ${barStr}  ${pctStr}  ${gapStr}  ${exclStr}`);
+  }
+
+  // Uncovered services
+  const uncoveredServices = report.services.filter(s => s.coveredOps === 0 && s.totalOps > 0);
+  if (uncoveredServices.length > 0) {
+    lines.push('');
+    lines.push(`${BOLD}Uncovered services:${RESET}`);
+    for (const svc of uncoveredServices) {
+      lines.push(`  ${YELLOW}${svc.service}${RESET} — ${svc.totalOps} operations available`);
+    }
+  }
+
+  // New operations since baseline
+  const newOps = report.services.flatMap(s => s.newOps.map(op => ({ service: s.service, op })));
+  if (newOps.length > 0) {
+    lines.push('');
+    lines.push(`${BOLD}New since baseline:${RESET}`);
+    for (const { service, op } of newOps) {
+      lines.push(`  ${GREEN}+${RESET} ${CYAN}${service}${RESET} ${op}`);
+    }
+  }
+
+  // Removed operations
+  const removedOps = report.services.flatMap(s => s.removedOps.map(op => ({ service: s.service, op })));
+  if (removedOps.length > 0) {
+    lines.push('');
+    lines.push(`${BOLD}Removed from gws:${RESET}`);
+    for (const { service, op } of removedOps) {
+      lines.push(`  ${RED}-${RESET} ${CYAN}${service}${RESET} ${op}`);
+    }
+  }
+
+  // Parameter gaps
+  const allParamGaps = report.services.flatMap(s =>
+    Object.entries(s.paramGaps).map(([op, gaps]) => ({ service: s.service, op, gaps })),
+  );
+  if (allParamGaps.length > 0) {
+    lines.push('');
+    lines.push(`${BOLD}Parameter gaps in covered operations:${RESET}`);
+    for (const { service, op, gaps } of allParamGaps) {
+      lines.push(`  ${CYAN}${service}${RESET} ${op}:`);
+      for (const gap of gaps) {
+        lines.push(`    ${YELLOW}+${RESET} ${gap.paramName} ${DIM}(${gap.details || 'missing'})${RESET}`);
+      }
+    }
+  }
+
+  lines.push('');
+  return lines.join('\n');
+}
+
+export function formatJsonReport(report: CoverageReport): string {
+  return JSON.stringify(report, null, 2);
+}

--- a/src/coverage/types.ts
+++ b/src/coverage/types.ts
@@ -1,0 +1,89 @@
+/**
+ * Types for the build-time coverage analysis tool (ADR-100).
+ */
+
+/** Services eligible for the factory model. */
+export const ELIGIBLE_SERVICES = [
+  'drive', 'sheets', 'gmail', 'calendar', 'docs',
+  'slides', 'tasks', 'people', 'chat', 'keep', 'meet', 'events',
+] as const;
+
+/** Internal/path params to skip when comparing parameters. */
+export const SKIP_PARAMS = new Set([
+  'userId', 'key', 'oauth_token', 'prettyPrint', 'quotaUser', 'alt',
+  'uploadType', 'upload_protocol', 'fields', 'callback', 'access_token',
+]);
+
+export interface DiscoveredParam {
+  type: string;
+  description: string;
+  required: boolean;
+  default?: unknown;
+  enum?: string[];
+  deprecated?: boolean;
+}
+
+export interface DiscoveredOperation {
+  resourcePath: string;
+  description: string;
+  httpMethod?: string;
+  params: Record<string, DiscoveredParam>;
+}
+
+export interface DiscoveredHelper {
+  name: string;
+  description: string;
+}
+
+export interface DiscoveredService {
+  operations: Record<string, DiscoveredOperation>;
+  helpers: Record<string, DiscoveredHelper>;
+}
+
+export interface DiscoveredSurface {
+  gwsVersion: string;
+  services: Record<string, DiscoveredService>;
+}
+
+export type BaselineStatus = 'covered' | 'gap' | 'excluded';
+
+export interface BaselineEntry {
+  status: BaselineStatus;
+  reason?: string;
+  params?: Record<string, 'covered' | 'gap'>;
+}
+
+export interface CoverageBaseline {
+  gwsVersion: string;
+  generatedAt: string;
+  services: Record<string, {
+    operations: Record<string, BaselineEntry>;
+  }>;
+}
+
+export interface ParamGap {
+  paramName: string;
+  inGws: boolean;
+  inManifest: boolean;
+  details?: string;
+}
+
+export interface ServiceCoverage {
+  service: string;
+  totalOps: number;
+  coveredOps: number;
+  excludedOps: number;
+  gapOps: number;
+  newOps: string[];
+  removedOps: string[];
+  paramGaps: Record<string, ParamGap[]>;
+}
+
+export interface CoverageReport {
+  gwsVersion: string;
+  timestamp: string;
+  totalOps: number;
+  coveredOps: number;
+  coveragePercent: number;
+  services: ServiceCoverage[];
+}


### PR DESCRIPTION
## Summary
- New `src/coverage/` module that compares the curated manifest against the full gws CLI surface
- Reuses factory manifest parser and `resolveGwsBinary()` from the executor
- Discovers 12 eligible services via `gws --help` and `gws schema`
- Produces terminal report with per-service coverage bars, new operations, and parameter gaps
- Baseline tracking (`coverage-baseline.json`) for drift detection and intentional exclusions

## Usage
```bash
make coverage        # print coverage report
make coverage-update # also update baseline file
```

## Initial findings
- **62/337 operations (18%)** covered across 12 services
- 5 uncovered but eligible services: slides, people, chat, keep, events
- Parameter gaps on covered operations (e.g., `supportsAllDrives` showing as gap on Drive ops where it's in defaults but not user-facing params)

Implements ADR-100.

## Test plan
- [x] `make build` succeeds
- [x] `make coverage` prints formatted report
- [x] `make coverage-update` writes `coverage-baseline.json`
- [x] Re-run after update shows no "New since baseline" entries