### PR TITLE
feat(docs,drive): comments and inline editing

### DIFF
--- a/src/factory/manifest.yaml
+++ b/src/factory/manifest.yaml
@@ -456,7 +456,7 @@ services:
 
   drive:
     tool_name: manage_drive
-    description: "Search, upload, download, share, or manage files in Google Drive."
+    description: "Search, upload, download, share, comment on, or manage files in Google Drive."
     requires_email: true
     gws_service: drive
     operations:
@@ -642,6 +642,103 @@ services:
         defaults:
           supportsAllDrives: true
 
+      # --- Comments ---
+
+      listComments:
+        type: list
+        description: "list comments on a file"
+        resource: comments.list
+        params:
+          fileId:
+            type: string
+            description: "File ID"
+            required: true
+          includeDeleted:
+            type: boolean
+            description: "Include deleted comments (default: false)"
+        defaults:
+          fields: "comments(id, content, htmlContent, author(displayName, emailAddress), createdTime, modifiedTime, resolved, quotedFileContent, replies(id, content, htmlContent, author(displayName), createdTime)), nextPageToken"
+          supportsAllDrives: true
+
+      getComment:
+        type: detail
+        description: "get a specific comment by ID"
+        resource: comments.get
+        params:
+          fileId:
+            type: string
+            description: "File ID"
+            required: true
+          commentId:
+            type: string
+            description: "Comment ID"
+            required: true
+        defaults:
+          fields: "id, content, htmlContent, author(displayName, emailAddress), createdTime, modifiedTime, resolved, quotedFileContent, replies(id, content, htmlContent, author(displayName), createdTime)"
+          supportsAllDrives: true
+
+      addComment:
+        type: action
+        description: "add a comment to a file (optionally anchored to quoted text)"
+        resource: comments.create
+        params:
+          fileId:
+            type: string
+            description: "File ID"
+            required: true
+          content:
+            type: string
+            description: "Comment text"
+            required: true
+          quotedText:
+            type: string
+            description: "Text to anchor the comment to (optional — if provided, comment is anchored to first occurrence)"
+        defaults:
+          fields: "id, content, htmlContent, author(displayName), createdTime, quotedFileContent"
+          supportsAllDrives: true
+
+      resolveComment:
+        type: action
+        description: "resolve or reopen a comment"
+        resource: comments.update
+        params:
+          fileId:
+            type: string
+            description: "File ID"
+            required: true
+          commentId:
+            type: string
+            description: "Comment ID"
+            required: true
+          resolved:
+            type: boolean
+            description: "true to resolve, false to reopen"
+            required: true
+        defaults:
+          fields: "id, content, resolved"
+          supportsAllDrives: true
+
+      replyToComment:
+        type: action
+        description: "reply to an existing comment"
+        resource: replies.create
+        params:
+          fileId:
+            type: string
+            description: "File ID"
+            required: true
+          commentId:
+            type: string
+            description: "Comment ID to reply to"
+            required: true
+          content:
+            type: string
+            description: "Reply text"
+            required: true
+        defaults:
+          fields: "id, content, htmlContent, author(displayName), createdTime"
+          supportsAllDrives: true
+
   # ========================================================================
   # Sheets
   # ========================================================================
@@ -739,7 +836,7 @@ services:
 
   docs:
     tool_name: manage_docs
-    description: "Read and write Google Docs documents."
+    description: "Read, write, insert, and find-replace text in Google Docs documents."
     requires_email: true
     gws_service: docs
     operations:
@@ -775,6 +872,46 @@ services:
         cli_args:
           documentId: "--document"
           text: "--text"
+
+      insertText:
+        type: action
+        description: "insert text at a specific position in a document"
+        resource: documents.batchUpdate
+        params:
+          documentId:
+            type: string
+            description: "Document ID"
+            required: true
+          text:
+            type: string
+            description: "Text to insert"
+            required: true
+          index:
+            type: number
+            description: "Character index to insert at (1 = start of document body)"
+            required: true
+
+      replaceText:
+        type: action
+        description: "find and replace text in a document"
+        resource: documents.batchUpdate
+        params:
+          documentId:
+            type: string
+            description: "Document ID"
+            required: true
+          findText:
+            type: string
+            description: "Text to find"
+            required: true
+          replaceWith:
+            type: string
+            description: "Replacement text"
+            required: true
+          matchCase:
+            type: boolean
+            description: "Case-sensitive match (default: true)"
+            default: true
 
   # ========================================================================
   # Tasks

--- a/src/factory/patches.ts
+++ b/src/factory/patches.ts
@@ -6,6 +6,7 @@
 import { gmailPatch } from '../services/gmail/patch.js';
 import { calendarPatch } from '../services/calendar/patch.js';
 import { drivePatch } from '../services/drive/patch.js';
+import { docsPatch } from '../services/docs/patch.js';
 import { meetPatch } from '../services/meet/patch.js';
 import type { ServicePatch } from './types.js';
 
@@ -13,5 +14,6 @@ export const patches: Record<string, ServicePatch> = {
   gmail: gmailPatch,
   calendar: calendarPatch,
   drive: drivePatch,
+  docs: docsPatch,
   meet: meetPatch,
 };

--- a/src/services/docs/patch.ts
+++ b/src/services/docs/patch.ts
@@ -17,7 +17,7 @@ export const docsPatch: ServicePatch = {
       const documentId = requireString(params, 'documentId');
       const text = requireString(params, 'text');
       const index = Number(params.index);
-      if (!Number.isFinite(index) || index < 1) {
+      if (!Number.isInteger(index) || index < 1) {
         throw new Error('index must be a positive integer (1 = start of document body)');
       }
 

--- a/src/services/docs/patch.ts
+++ b/src/services/docs/patch.ts
@@ -1,0 +1,83 @@
+/**
+ * Docs patch — custom handlers for operations that use batchUpdate.
+ *
+ * insertText and replaceText use documents.batchUpdate which requires
+ * a --json request body, not --params.
+ */
+
+import { execute } from '../../executor/gws.js';
+import { nextSteps } from '../../server/formatting/next-steps.js';
+import { requireString } from '../../server/handlers/validate.js';
+import type { ServicePatch } from '../../factory/types.js';
+import type { HandlerResponse } from '../../server/formatting/markdown.js';
+
+export const docsPatch: ServicePatch = {
+  customHandlers: {
+    insertText: async (params, account): Promise<HandlerResponse> => {
+      const documentId = requireString(params, 'documentId');
+      const text = requireString(params, 'text');
+      const index = Number(params.index);
+      if (!Number.isFinite(index) || index < 1) {
+        throw new Error('index must be a positive integer (1 = start of document body)');
+      }
+
+      const body = {
+        requests: [{
+          insertText: {
+            text,
+            location: { index },
+          },
+        }],
+      };
+
+      await execute([
+        'docs', 'documents', 'batchUpdate',
+        '--params', JSON.stringify({ documentId }),
+        '--json', JSON.stringify(body),
+      ], { account });
+
+      return {
+        text: `Text inserted at index ${index}.\n\n**Document:** ${documentId}\n**Inserted:** ${text.length} characters` +
+          nextSteps('docs', 'insertText', { email: account }),
+        refs: { documentId, index, length: text.length },
+      };
+    },
+
+    replaceText: async (params, account): Promise<HandlerResponse> => {
+      const documentId = requireString(params, 'documentId');
+      const findText = requireString(params, 'findText');
+      const replaceWith = requireString(params, 'replaceWith');
+      const matchCase = params.matchCase !== false;
+
+      const body = {
+        requests: [{
+          replaceAllText: {
+            containsText: {
+              text: findText,
+              matchCase,
+            },
+            replaceText: replaceWith,
+          },
+        }],
+      };
+
+      const result = await execute([
+        'docs', 'documents', 'batchUpdate',
+        '--params', JSON.stringify({ documentId }),
+        '--json', JSON.stringify(body),
+      ], { account });
+
+      // Extract occurrence count from the reply
+      const data = result.data as Record<string, unknown>;
+      const replies = (data.replies as Array<Record<string, unknown>>) || [];
+      const replaceReply = replies[0]?.replaceAllText as Record<string, unknown> | undefined;
+      const occurrences = replaceReply?.occurrencesChanged || 0;
+
+      return {
+        text: `Text replaced.\n\n**Document:** ${documentId}\n**Found:** "${findText}"\n**Replaced with:** "${replaceWith}"\n**Occurrences:** ${occurrences}` +
+          nextSteps('docs', 'replaceText', { email: account }),
+        refs: { documentId, occurrences },
+      };
+    },
+  },
+};

--- a/src/services/drive/patch.ts
+++ b/src/services/drive/patch.ts
@@ -194,5 +194,86 @@ export const drivePatch: ServicePatch = {
         ...(output.imageBlock ? { content: [output.imageBlock] } : {}),
       };
     },
+
+    addComment: async (params, account): Promise<HandlerResponse> => {
+      const fileId = requireString(params, 'fileId');
+      const content = requireString(params, 'content');
+      const quotedText = params.quotedText ? String(params.quotedText) : undefined;
+
+      const body: Record<string, unknown> = { content };
+      if (quotedText) {
+        body.quotedFileContent = { value: quotedText };
+      }
+
+      const result = await execute([
+        'drive', 'comments', 'create',
+        '--params', JSON.stringify({
+          fileId,
+          fields: 'id, content, htmlContent, author(displayName), createdTime, quotedFileContent',
+          supportsAllDrives: true,
+        }),
+        '--json', JSON.stringify(body),
+      ], { account });
+      const data = result.data as Record<string, unknown>;
+      return {
+        text: `Comment added.\n\n**ID:** ${data.id}\n**Content:** ${data.content}` +
+          (quotedText ? `\n**Anchored to:** "${quotedText}"` : '') +
+          nextSteps('drive', 'addComment', { email: account }),
+        refs: { commentId: data.id, fileId },
+      };
+    },
+
+    resolveComment: async (params, account): Promise<HandlerResponse> => {
+      const fileId = requireString(params, 'fileId');
+      const commentId = requireString(params, 'commentId');
+      const resolved = params.resolved !== false;
+
+      // To resolve: set content to existing + resolve action
+      // The Drive API resolves by updating with resolved=true via the comment's action
+      const body: Record<string, unknown> = {};
+      if (resolved) {
+        body.content = '';  // content is required but preserved server-side
+      }
+
+      const result = await execute([
+        'drive', 'comments', 'update',
+        '--params', JSON.stringify({
+          fileId,
+          commentId,
+          fields: 'id, content, resolved',
+          supportsAllDrives: true,
+        }),
+        '--json', JSON.stringify({ ...body, resolved }),
+      ], { account });
+      const data = result.data as Record<string, unknown>;
+      return {
+        text: `Comment ${resolved ? 'resolved' : 'reopened'}.\n\n**ID:** ${data.id}\n**Resolved:** ${data.resolved}` +
+          nextSteps('drive', 'resolveComment', { email: account }),
+        refs: { commentId: data.id, fileId, resolved: data.resolved },
+      };
+    },
+
+    replyToComment: async (params, account): Promise<HandlerResponse> => {
+      const fileId = requireString(params, 'fileId');
+      const commentId = requireString(params, 'commentId');
+      const content = requireString(params, 'content');
+
+      const result = await execute([
+        'drive', 'replies', 'create',
+        '--params', JSON.stringify({
+          fileId,
+          commentId,
+          fields: 'id, content, htmlContent, author(displayName), createdTime',
+          supportsAllDrives: true,
+        }),
+        '--json', JSON.stringify({ content }),
+      ], { account });
+      const data = result.data as Record<string, unknown>;
+      return {
+        text: `Reply added.\n\n**ID:** ${data.id}\n**Content:** ${data.content}` +
+          nextSteps('drive', 'replyToComment', { email: account }),
+        refs: { replyId: data.id, commentId, fileId },
+      };
+    },
   },
 };

--- a/src/services/drive/patch.ts
+++ b/src/services/drive/patch.ts
@@ -228,12 +228,17 @@ export const drivePatch: ServicePatch = {
       const commentId = requireString(params, 'commentId');
       const resolved = params.resolved !== false;
 
-      // To resolve: set content to existing + resolve action
-      // The Drive API resolves by updating with resolved=true via the comment's action
-      const body: Record<string, unknown> = {};
-      if (resolved) {
-        body.content = '';  // content is required but preserved server-side
-      }
+      // Fetch existing comment to preserve content when updating
+      const existing = await execute([
+        'drive', 'comments', 'get',
+        '--params', JSON.stringify({
+          fileId,
+          commentId,
+          fields: 'content',
+          supportsAllDrives: true,
+        }),
+      ], { account });
+      const existingData = existing.data as Record<string, unknown>;
 
       const result = await execute([
         'drive', 'comments', 'update',
@@ -243,7 +248,10 @@ export const drivePatch: ServicePatch = {
           fields: 'id, content, resolved',
           supportsAllDrives: true,
         }),
-        '--json', JSON.stringify({ ...body, resolved }),
+        '--json', JSON.stringify({
+          content: existingData.content || '',
+          resolved,
+        }),
       ], { account });
       const data = result.data as Record<string, unknown>;
       return {


### PR DESCRIPTION
## Summary
Adds document comments and inline editing operations, following the inject-after-factory pattern.

### Drive comments (via Drive API v3)
- **listComments** / **getComment** — manifest-driven with `fields` defaults
- **addComment** — custom handler, supports optional `quotedText` anchor
- **resolveComment** — custom handler to resolve/reopen threads
- **replyToComment** — custom handler for comment replies

### Docs inline editing (via `documents.batchUpdate`)
- **insertText** — insert at character index position
- **replaceText** — find and replace with occurrence count feedback

### Architecture
- New `src/services/docs/patch.ts` for batchUpdate-based operations
- Drive comment handlers added to existing `src/services/drive/patch.ts`
- All comment operations include `supportsAllDrives: true`

Fixes #92

## Test plan
- [ ] `make build` succeeds
- [ ] `listComments` returns comments on a document
- [ ] `addComment` creates a comment (with and without `quotedText` anchor)
- [ ] `resolveComment` resolves and reopens a comment
- [ ] `replyToComment` adds a reply to a comment thread
- [ ] `insertText` inserts text at a given index
- [ ] `replaceText` replaces text and reports occurrence count