### PR TITLE
fix(calendar): freebusy, agenda params, calendarId context (#98)

### DIFF
--- a/src/__tests__/factory/calendar-patch.test.ts
+++ b/src/__tests__/factory/calendar-patch.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Tests for the calendar service patch — custom handlers and formatters
+ * that extend the factory-generated handler.
+ */
+
+import {
+  mockExecute, mockGwsResponse,
+  calendarAgendaResponse, calendarEventsListResponse, calendarInsertResponse,
+  calendarFreeBusyResponse, calendarFreeBusyErrorResponse,
+} from '../server/handlers/__mocks__/executor.js';
+import { calendarPatch } from '../../services/calendar/patch.js';
+import type { PatchContext } from '../../factory/types.js';
+
+function ctx(overrides: Partial<PatchContext> = {}): PatchContext {
+  return {
+    operation: 'list',
+    params: {},
+    account: 'user@test.com',
+    ...overrides,
+  };
+}
+
+describe('calendarPatch', () => {
+  beforeEach(() => mockExecute.mockReset());
+
+  describe('formatList (events)', () => {
+    it('defaults calendarId to primary in refs', () => {
+      const result = calendarPatch.formatList!(calendarEventsListResponse, ctx({ operation: 'list' }));
+      expect(result.refs.calendarId).toBe('primary');
+    });
+
+    it('enriches refs with calendarId for shared calendars', () => {
+      const result = calendarPatch.formatList!(
+        calendarEventsListResponse,
+        ctx({ operation: 'list', params: { calendarId: 'shared@test.com' } }),
+      );
+      expect(result.refs.calendarId).toBe('shared@test.com');
+    });
+
+    it('adds calendar hint to output header for non-primary calendars', () => {
+      const result = calendarPatch.formatList!(
+        calendarEventsListResponse,
+        ctx({ operation: 'list', params: { calendarId: 'shared@test.com' } }),
+      );
+      expect(result.text).toContain('calendar: shared@test.com');
+    });
+
+    it('does not add hint for primary calendar', () => {
+      const result = calendarPatch.formatList!(calendarEventsListResponse, ctx({ operation: 'list' }));
+      expect(result.text).not.toContain('calendar:');
+    });
+  });
+
+  describe('agenda custom handler', () => {
+    it('defaults to --today flag', async () => {
+      mockExecute.mockResolvedValue(mockGwsResponse(calendarAgendaResponse));
+      await calendarPatch.customHandlers!.agenda({}, 'user@test.com');
+
+      const args = mockExecute.mock.calls[0][0];
+      expect(args).toContain('--today');
+    });
+
+    it('passes --week flag', async () => {
+      mockExecute.mockResolvedValue(mockGwsResponse(calendarAgendaResponse));
+      await calendarPatch.customHandlers!.agenda({ week: true }, 'user@test.com');
+
+      const args = mockExecute.mock.calls[0][0];
+      expect(args).toContain('--week');
+      expect(args).not.toContain('--today');
+    });
+
+    it('passes --tomorrow flag', async () => {
+      mockExecute.mockResolvedValue(mockGwsResponse(calendarAgendaResponse));
+      await calendarPatch.customHandlers!.agenda({ tomorrow: true }, 'user@test.com');
+
+      expect(mockExecute.mock.calls[0][0]).toContain('--tomorrow');
+    });
+
+    it('passes --days N', async () => {
+      mockExecute.mockResolvedValue(mockGwsResponse(calendarAgendaResponse));
+      await calendarPatch.customHandlers!.agenda({ days: 3 }, 'user@test.com');
+
+      const args = mockExecute.mock.calls[0][0];
+      expect(args).toContain('--days');
+      expect(args).toContain('3');
+    });
+
+    it('passes --calendar filter', async () => {
+      mockExecute.mockResolvedValue(mockGwsResponse(calendarAgendaResponse));
+      await calendarPatch.customHandlers!.agenda({ calendarId: 'work@test.com' }, 'user@test.com');
+
+      const args = mockExecute.mock.calls[0][0];
+      expect(args).toContain('--calendar');
+      expect(args).toContain('work@test.com');
+    });
+
+    it('includes calendarId in event refs', async () => {
+      const response = {
+        events: [{ id: 'evt-1', summary: 'Meeting', calendarId: 'shared@test.com' }],
+      };
+      mockExecute.mockResolvedValue(mockGwsResponse(response));
+      const result = await calendarPatch.customHandlers!.agenda({}, 'user@test.com');
+
+      const events = result.refs.events as Array<{ id: string; calendarId: string }>;
+      expect(events[0]).toEqual({ id: 'evt-1', calendarId: 'shared@test.com' });
+    });
+
+    it('falls back to organizer email when calendarId missing', async () => {
+      const response = {
+        events: [{ id: 'evt-1', summary: 'Meeting', organizer: { email: 'owner@test.com' } }],
+      };
+      mockExecute.mockResolvedValue(mockGwsResponse(response));
+      const result = await calendarPatch.customHandlers!.agenda({}, 'user@test.com');
+
+      const events = result.refs.events as Array<{ id: string; calendarId: string }>;
+      expect(events[0].calendarId).toBe('owner@test.com');
+    });
+  });
+
+  describe('freebusy custom handler', () => {
+    it('requires timeMin and timeMax', async () => {
+      await expect(
+        calendarPatch.customHandlers!.freebusy({ timeMax: 'Y' }, 'user@test.com'),
+      ).rejects.toThrow('timeMin');
+      await expect(
+        calendarPatch.customHandlers!.freebusy({ timeMin: 'X' }, 'user@test.com'),
+      ).rejects.toThrow('timeMax');
+    });
+
+    it('sends POST body via --json with own calendar', async () => {
+      mockExecute.mockResolvedValue(mockGwsResponse(calendarFreeBusyResponse));
+      await calendarPatch.customHandlers!.freebusy(
+        { timeMin: '2026-04-09T08:00:00Z', timeMax: '2026-04-09T17:00:00Z' },
+        'user@test.com',
+      );
+
+      const args = mockExecute.mock.calls[0][0];
+      expect(args.slice(0, 3)).toEqual(['calendar', 'freebusy', 'query']);
+      expect(args).toContain('--json');
+      const body = JSON.parse(args[args.indexOf('--json') + 1]);
+      expect(body).toEqual({
+        timeMin: '2026-04-09T08:00:00Z',
+        timeMax: '2026-04-09T17:00:00Z',
+        items: [{ id: 'user@test.com' }],
+      });
+    });
+
+    it('does not use --params (the original bug)', async () => {
+      mockExecute.mockResolvedValue(mockGwsResponse(calendarFreeBusyResponse));
+      await calendarPatch.customHandlers!.freebusy(
+        { timeMin: 'X', timeMax: 'Y' },
+        'user@test.com',
+      );
+
+      expect(mockExecute.mock.calls[0][0]).not.toContain('--params');
+    });
+
+    it('includes attendees in items', async () => {
+      mockExecute.mockResolvedValue(mockGwsResponse(calendarFreeBusyResponse));
+      await calendarPatch.customHandlers!.freebusy(
+        { timeMin: 'X', timeMax: 'Y', attendees: 'colleague@test.com, other@test.com' },
+        'user@test.com',
+      );
+
+      const args = mockExecute.mock.calls[0][0];
+      const body = JSON.parse(args[args.indexOf('--json') + 1]);
+      expect(body.items).toEqual([
+        { id: 'user@test.com' },
+        { id: 'colleague@test.com' },
+        { id: 'other@test.com' },
+      ]);
+    });
+
+    it('deduplicates own email from attendees', async () => {
+      mockExecute.mockResolvedValue(mockGwsResponse(calendarFreeBusyResponse));
+      await calendarPatch.customHandlers!.freebusy(
+        { timeMin: 'X', timeMax: 'Y', attendees: 'user@test.com, colleague@test.com' },
+        'user@test.com',
+      );
+
+      const args = mockExecute.mock.calls[0][0];
+      const body = JSON.parse(args[args.indexOf('--json') + 1]);
+      expect(body.items).toEqual([
+        { id: 'user@test.com' },
+        { id: 'colleague@test.com' },
+      ]);
+    });
+
+    it('deduplicates across attendees and calendarId params', async () => {
+      mockExecute.mockResolvedValue(mockGwsResponse(calendarFreeBusyResponse));
+      await calendarPatch.customHandlers!.freebusy(
+        { timeMin: 'X', timeMax: 'Y', attendees: 'a@test.com', calendarId: 'a@test.com, b@test.com' },
+        'user@test.com',
+      );
+
+      const args = mockExecute.mock.calls[0][0];
+      const body = JSON.parse(args[args.indexOf('--json') + 1]);
+      expect(body.items).toEqual([
+        { id: 'user@test.com' },
+        { id: 'a@test.com' },
+        { id: 'b@test.com' },
+      ]);
+    });
+
+    it('formats busy blocks with human-readable times', async () => {
+      mockExecute.mockResolvedValue(mockGwsResponse(calendarFreeBusyResponse));
+      const result = await calendarPatch.customHandlers!.freebusy(
+        { timeMin: 'X', timeMax: 'Y' },
+        'user@test.com',
+      );
+
+      expect(result.text).toContain('## Availability');
+      expect(result.text).toContain('user@test.com');
+      expect(result.text).toContain('2 busy blocks');
+      expect(result.text).toContain('colleague@test.com');
+      expect(result.text).toContain('Free for entire range');
+    });
+
+    it('populates busyBlocks in refs', async () => {
+      mockExecute.mockResolvedValue(mockGwsResponse(calendarFreeBusyResponse));
+      const result = await calendarPatch.customHandlers!.freebusy(
+        { timeMin: 'X', timeMax: 'Y' },
+        'user@test.com',
+      );
+
+      const busy = result.refs.busyBlocks as Array<{ calendar: string }>;
+      expect(busy).toHaveLength(2);
+      expect(busy[0].calendar).toBe('user@test.com');
+    });
+
+    it('surfaces API errors per calendar instead of showing Free', async () => {
+      mockExecute.mockResolvedValue(mockGwsResponse(calendarFreeBusyErrorResponse));
+      const result = await calendarPatch.customHandlers!.freebusy(
+        { timeMin: 'X', timeMax: 'Y' },
+        'user@test.com',
+      );
+
+      expect(result.text).toContain('Unable to check (notFound)');
+      expect(result.text).not.toContain('private@test.com**: Free');
+    });
+  });
+
+  describe('create custom handler', () => {
+    it('passes --meet flag when meet: true', async () => {
+      mockExecute.mockResolvedValue(mockGwsResponse(calendarInsertResponse));
+      const result = await calendarPatch.customHandlers!.create(
+        { summary: 'Meeting', start: 'X', end: 'Y', meet: true },
+        'user@test.com',
+      );
+
+      expect(mockExecute.mock.calls[0][0]).toContain('--meet');
+      expect(result.text).toContain('with Google Meet');
+    });
+
+    it('omits --meet flag when meet is false/undefined', async () => {
+      mockExecute.mockResolvedValue(mockGwsResponse(calendarInsertResponse));
+      await calendarPatch.customHandlers!.create(
+        { summary: 'Meeting', start: 'X', end: 'Y' },
+        'user@test.com',
+      );
+
+      expect(mockExecute.mock.calls[0][0]).not.toContain('--meet');
+    });
+
+    it('includes calendarId in refs', async () => {
+      mockExecute.mockResolvedValue(mockGwsResponse(calendarInsertResponse));
+      const result = await calendarPatch.customHandlers!.create(
+        { summary: 'X', start: 'Y', end: 'Z', calendarId: 'shared@test.com' },
+        'user@test.com',
+      );
+
+      expect(result.refs.calendarId).toBe('shared@test.com');
+      expect(result.text).toContain('**Calendar:** shared@test.com');
+    });
+
+    it('defaults calendarId to primary', async () => {
+      mockExecute.mockResolvedValue(mockGwsResponse(calendarInsertResponse));
+      const result = await calendarPatch.customHandlers!.create(
+        { summary: 'X', start: 'Y', end: 'Z' },
+        'user@test.com',
+      );
+
+      expect(result.refs.calendarId).toBe('primary');
+    });
+  });
+});

--- a/src/__tests__/server/handlers/__mocks__/executor.ts
+++ b/src/__tests__/server/handlers/__mocks__/executor.ts
@@ -107,6 +107,29 @@ export const calendarInsertResponse = {
   htmlLink: 'https://calendar.google.com/event?eid=xxx',
 };
 
+export const calendarFreeBusyResponse = {
+  calendars: {
+    'user@test.com': {
+      busy: [
+        { start: '2026-04-09T14:00:00Z', end: '2026-04-09T15:00:00Z' },
+        { start: '2026-04-09T16:00:00Z', end: '2026-04-09T16:30:00Z' },
+      ],
+    },
+    'colleague@test.com': {
+      busy: [],
+    },
+  },
+};
+
+export const calendarFreeBusyErrorResponse = {
+  calendars: {
+    'user@test.com': { busy: [] },
+    'private@test.com': {
+      errors: [{ domain: 'calendar', reason: 'notFound' }],
+    },
+  },
+};
+
 // --- Drive contract responses ---
 
 export const driveFileListResponse = {

--- a/src/factory/manifest.yaml
+++ b/src/factory/manifest.yaml
@@ -315,17 +315,30 @@ services:
 
       agenda:
         type: list
-        description: "today's schedule at a glance (all calendars)"
+        description: "today's schedule at a glance (all calendars). Returns calendarId per event for follow-up get calls."
         helper: "+agenda"
+        params:
+          calendarId:
+            type: string
+            description: "Filter to a specific calendar name or ID"
+          days:
+            type: number
+            description: "Number of days ahead to show (default: today only)"
+          tomorrow:
+            type: boolean
+            description: "Show tomorrow's events instead of today"
+          week:
+            type: boolean
+            description: "Show this week's events"
 
       get:
         type: detail
-        description: "full event details by ID"
+        description: "full event details by ID. For shared calendar events, calendarId is required (use agenda or list to discover it)."
         resource: events.get
         params:
           calendarId:
             type: string
-            description: "Calendar ID (default: 'primary')"
+            description: "Calendar ID (default: 'primary'). Required for events on shared calendars."
           eventId:
             type: string
             description: "Event ID"
@@ -364,6 +377,9 @@ services:
           attendees:
             type: string
             description: "Comma-separated attendee emails"
+          meet:
+            type: boolean
+            description: "Add a Google Meet video conference link to the event"
         cli_args:
           calendarId: "--calendar"
           summary: "--summary"
@@ -442,7 +458,7 @@ services:
 
       freebusy:
         type: detail
-        description: "check availability (free/busy) for a time range"
+        description: "check availability (free/busy) for a time range. Automatically includes own calendar; add attendees to check others."
         resource: freebusy.query
         params:
           timeMin:
@@ -453,6 +469,12 @@ services:
             type: string
             description: "End of range (ISO 8601)"
             required: true
+          attendees:
+            type: string
+            description: "Comma-separated email addresses to check availability for"
+          calendarId:
+            type: string
+            description: "Comma-separated calendar IDs to check (in addition to own calendar)"
 
   drive:
     tool_name: manage_drive

--- a/src/services/calendar/patch.ts
+++ b/src/services/calendar/patch.ts
@@ -2,9 +2,10 @@
  * Calendar patch — domain-specific hooks for the calendar service.
  *
  * Key customizations:
- * - List: default timeMin to today start
- * - Agenda: raw text passthrough with event refs extraction
- * - Create: custom response formatting with event details
+ * - List: default timeMin to today start, include calendarId in output
+ * - Agenda: rich helper with day-range params, calendarId per event
+ * - Freebusy: custom handler (POST body via --json, not --params)
+ * - Create: custom response formatting with event details + --meet flag
  * - Delete: custom confirmation message
  */
 
@@ -42,6 +43,78 @@ function formatCalendarList(data: unknown): HandlerResponse {
   };
 }
 
+/** Format event list with calendarId enrichment. */
+function formatEventListWithCalendar(data: unknown, ctx: PatchContext): HandlerResponse {
+  const result = formatEventList(data);
+  const calendarId = (ctx.params.calendarId as string) || 'primary';
+
+  // Enrich refs with calendarId so follow-up get calls work on shared calendars
+  result.refs = { ...result.refs, calendarId };
+
+  // Add calendarId hint to output when not primary
+  if (calendarId !== 'primary') {
+    result.text = result.text.replace(
+      /^## Events/,
+      `## Events (calendar: ${calendarId})`,
+    );
+  }
+
+  return result;
+}
+
+/** Format freebusy response into readable busy/free blocks. */
+function formatFreeBusy(data: unknown, ctx: PatchContext): HandlerResponse {
+  const raw = data as Record<string, unknown>;
+  const calendars = (raw?.calendars ?? {}) as Record<string, { busy?: Array<{ start: string; end: string }> }>;
+
+  const parts: string[] = ['## Availability\n'];
+  const allBusy: Array<{ calendar: string; start: string; end: string }> = [];
+
+  for (const [calId, info] of Object.entries(calendars)) {
+    const busy = info.busy ?? [];
+    if (busy.length === 0) {
+      parts.push(`**${calId}**: Free for entire range`);
+    } else {
+      parts.push(`**${calId}**: ${busy.length} busy block${busy.length !== 1 ? 's' : ''}`);
+      for (const block of busy) {
+        const start = new Date(block.start).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true });
+        const end = new Date(block.end).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true });
+        parts.push(`  - ${start} – ${end}`);
+        allBusy.push({ calendar: calId, start: block.start, end: block.end });
+      }
+    }
+  }
+
+  return {
+    text: parts.join('\n') + nextSteps('calendar', 'freebusy', { email: ctx.account }),
+    refs: {
+      calendars: Object.keys(calendars),
+      busyBlocks: allBusy,
+      timeMin: ctx.params.timeMin,
+      timeMax: ctx.params.timeMax,
+    },
+  };
+}
+
+/** Format agenda events with calendarId per event. */
+function formatAgenda(data: unknown, account: string): HandlerResponse {
+  const raw = data as Record<string, unknown>;
+  const events = (raw?.events ?? []) as Array<Record<string, unknown>>;
+  const text = typeof data === 'string' ? data : JSON.stringify(data, null, 2);
+
+  return {
+    text: text + nextSteps('calendar', 'agenda', { email: account }),
+    refs: {
+      count: events.length,
+      eventId: events[0]?.id as string | undefined,
+      events: events.map((e: Record<string, unknown>) => ({
+        id: e.id,
+        calendarId: e.calendarId ?? (e.organizer && (e.organizer as Record<string, unknown>).email),
+      })),
+    },
+  };
+}
+
 export const calendarPatch: ServicePatch = {
   beforeExecute: {
     list: async (args, ctx) => {
@@ -68,25 +141,51 @@ export const calendarPatch: ServicePatch = {
       case 'calendars':
         return formatCalendarList(data);
       default:
-        return formatEventList(data);
+        return formatEventListWithCalendar(data, ctx);
     }
   },
   formatDetail: (data: unknown) => formatEventDetail(data),
 
   customHandlers: {
     agenda: async (params, account): Promise<HandlerResponse> => {
-      const result = await execute(['calendar', '+agenda'], { account });
-      const data = result.data as Record<string, unknown> | undefined;
-      const text = typeof result.data === 'string' ? result.data : JSON.stringify(result.data, null, 2);
-      const events = Array.isArray(data?.events) ? data.events : [];
-      return {
-        text: text + nextSteps('calendar', 'agenda', { email: account }),
-        refs: {
-          count: events.length,
-          eventId: events[0]?.id,
-          events: events.map((e: Record<string, unknown>) => e.id),
-        },
-      };
+      const args = ['calendar', '+agenda'];
+
+      // Day-range flags
+      if (params.tomorrow) args.push('--tomorrow');
+      else if (params.week) args.push('--week');
+      else if (params.days) args.push('--days', String(params.days));
+      else args.push('--today');
+
+      // Calendar filter
+      if (params.calendarId) args.push('--calendar', String(params.calendarId));
+
+      const result = await execute(args, { account });
+      return formatAgenda(result.data, account);
+    },
+
+    freebusy: async (params, account): Promise<HandlerResponse> => {
+      const timeMin = requireString(params, 'timeMin');
+      const timeMax = requireString(params, 'timeMax');
+
+      // Build calendar items list from attendees + own calendar
+      const items: Array<{ id: string }> = [{ id: account }];
+      if (params.attendees) {
+        const emails = String(params.attendees).split(',').map(e => e.trim()).filter(Boolean);
+        for (const email of emails) {
+          items.push({ id: email });
+        }
+      }
+      if (params.calendarId) {
+        const ids = String(params.calendarId).split(',').map(e => e.trim()).filter(Boolean);
+        for (const id of ids) {
+          if (!items.some(i => i.id === id)) items.push({ id });
+        }
+      }
+
+      const body = { timeMin, timeMax, items };
+      const args = ['calendar', 'freebusy', 'query', '--json', JSON.stringify(body)];
+      const result = await execute(args, { account });
+      return formatFreeBusy(result.data, { operation: 'freebusy', params, account });
     },
 
     create: async (params, account): Promise<HandlerResponse> => {
@@ -98,15 +197,18 @@ export const calendarPatch: ServicePatch = {
       if (params.description) args.push('--description', String(params.description));
       if (params.location) args.push('--location', String(params.location));
       if (params.attendees) args.push('--attendees', String(params.attendees));
+      if (params.meet) args.push('--meet');
       const result = await execute(args, { account });
       const data = result.data as Record<string, unknown>;
+      const meetLink = params.meet ? ' (with Google Meet)' : '';
       return {
-        text: `Event created: **${summary}**\n\n` +
+        text: `Event created: **${summary}**${meetLink}\n\n` +
           `**When:** ${start} – ${end}\n` +
           (params.location ? `**Where:** ${params.location}\n` : '') +
+          `**Calendar:** ${calendarId}\n` +
           `**Event ID:** ${data.id ?? 'unknown'}` +
           nextSteps('calendar', 'create', { email: account }),
-        refs: { id: data.id, eventId: data.id, summary, start, end },
+        refs: { id: data.id, eventId: data.id, calendarId, summary, start, end },
       };
     },
 

--- a/src/services/calendar/patch.ts
+++ b/src/services/calendar/patch.ts
@@ -65,12 +65,18 @@ function formatEventListWithCalendar(data: unknown, ctx: PatchContext): HandlerR
 /** Format freebusy response into readable busy/free blocks. */
 function formatFreeBusy(data: unknown, ctx: PatchContext): HandlerResponse {
   const raw = data as Record<string, unknown>;
-  const calendars = (raw?.calendars ?? {}) as Record<string, { busy?: Array<{ start: string; end: string }> }>;
+  const calendars = (raw?.calendars ?? {}) as Record<string, { busy?: Array<{ start: string; end: string }>; errors?: Array<{ domain: string; reason: string }> }>;
 
   const parts: string[] = ['## Availability\n'];
   const allBusy: Array<{ calendar: string; start: string; end: string }> = [];
 
   for (const [calId, info] of Object.entries(calendars)) {
+    // Surface API errors (e.g., permission denied on a calendar)
+    if (info.errors && info.errors.length > 0) {
+      const reasons = info.errors.map(e => e.reason).join(', ');
+      parts.push(`**${calId}**: ⚠ Unable to check (${reasons})`);
+      continue;
+    }
     const busy = info.busy ?? [];
     if (busy.length === 0) {
       parts.push(`**${calId}**: Free for entire range`);
@@ -167,18 +173,19 @@ export const calendarPatch: ServicePatch = {
       const timeMin = requireString(params, 'timeMin');
       const timeMax = requireString(params, 'timeMax');
 
-      // Build calendar items list from attendees + own calendar
+      // Build calendar items list from attendees + own calendar (deduplicated)
+      const seen = new Set<string>([account]);
       const items: Array<{ id: string }> = [{ id: account }];
+      const addItem = (id: string) => { if (!seen.has(id)) { seen.add(id); items.push({ id }); } };
+
       if (params.attendees) {
-        const emails = String(params.attendees).split(',').map(e => e.trim()).filter(Boolean);
-        for (const email of emails) {
-          items.push({ id: email });
+        for (const email of String(params.attendees).split(',').map(e => e.trim()).filter(Boolean)) {
+          addItem(email);
         }
       }
       if (params.calendarId) {
-        const ids = String(params.calendarId).split(',').map(e => e.trim()).filter(Boolean);
-        for (const id of ids) {
-          if (!items.some(i => i.id === id)) items.push({ id });
+        for (const id of String(params.calendarId).split(',').map(e => e.trim()).filter(Boolean)) {
+          addItem(id);
         }
       }
 


### PR DESCRIPTION
## Summary

- **freebusy**: Fixed — was sending POST body as `--params` (query), now uses `--json` (request body). Added `attendees` and `calendarId` params with formatted busy/free output.
- **agenda**: Exposed `days`, `tomorrow`, `week`, `calendarId` filter params from the `+agenda` helper. Includes `calendarId` per event in refs for follow-up `get` calls.
- **list**: Enriched output with `calendarId` in refs and header when querying shared calendars.
- **create**: Added `--meet` flag for Google Meet video conference links.
- **get**: Updated description noting `calendarId` is required for shared calendar events.

Closes #98

## Test plan
- [ ] `freebusy` with timeMin/timeMax returns busy blocks (was always failing before)
- [ ] `freebusy` with attendees checks multiple calendars
- [ ] `agenda --week` and `agenda --days 3` return multi-day results
- [ ] `list` on shared calendar includes calendarId in refs
- [ ] `get` with calendarId from list refs succeeds on shared calendar events
- [ ] `create` with `meet: true` produces event with Meet link