### PR TITLE
fix(drive): create parent directories before export/download write

### DIFF
--- a/src/__tests__/factory/drive-patch.test.ts
+++ b/src/__tests__/factory/drive-patch.test.ts
@@ -36,6 +36,8 @@ const mockExecute = execute as jest.MockedFunction<typeof execute>;
 describe('drivePatch custom handlers', () => {
   beforeEach(async () => {
     mockExecute.mockReset();
+    // Start with a clean workspace — only the root dir exists
+    await fs.rm(tmpWorkspace, { recursive: true, force: true });
     await fs.mkdir(tmpWorkspace, { recursive: true });
   });
 
@@ -45,18 +47,20 @@ describe('drivePatch custom handlers', () => {
 
   describe('export', () => {
     it('creates parent directories before calling gws', async () => {
-      // First call: get file metadata; second call: export
-      mockExecute
-        .mockResolvedValueOnce({ success: true, data: { name: 'Report.gdoc' }, stderr: '' })
-        .mockResolvedValueOnce({ success: true, data: {}, stderr: '' });
-
-      // Write a dummy file so readWorkspaceFile finds something
       const outputPath = path.join(tmpWorkspace, 'subdir', 'Report.txt');
-      await fs.mkdir(path.dirname(outputPath), { recursive: true });
-      await fs.writeFile(outputPath, 'exported content');
 
       const { resolveWorkspacePath } = require('../../executor/workspace.js');
       (resolveWorkspacePath as jest.Mock).mockReturnValue(outputPath);
+
+      // First call: get file metadata
+      // Second call: export — simulate gws writing the file
+      mockExecute
+        .mockResolvedValueOnce({ success: true, data: { name: 'Report.gdoc' }, stderr: '' })
+        .mockImplementationOnce(async () => {
+          // gws would write the file here — parent dir must already exist
+          await fs.writeFile(outputPath, 'exported content');
+          return { success: true, data: {}, stderr: '' };
+        });
 
       const handler = drivePatch.customHandlers!.export!;
       await handler(
@@ -64,26 +68,51 @@ describe('drivePatch custom handlers', () => {
         'user@test.com',
       );
 
-      // The export call (second execute) should have --output pointing to the nested path
+      // The export call should have --output pointing to the nested path
       const exportCall = mockExecute.mock.calls[1][0];
       expect(exportCall).toContain('--output');
       expect(exportCall[exportCall.indexOf('--output') + 1]).toBe(outputPath);
-
-      // Parent directory must exist (we created it, but the handler also calls mkdir)
-      const parentExists = await fs.stat(path.dirname(outputPath)).then(() => true).catch(() => false);
-      expect(parentExists).toBe(true);
     });
 
-    it('works with flat filename (no subdirectory)', async () => {
-      mockExecute
-        .mockResolvedValueOnce({ success: true, data: { name: 'Doc' }, stderr: '' })
-        .mockResolvedValueOnce({ success: true, data: {}, stderr: '' });
-
-      const outputPath = path.join(tmpWorkspace, 'Doc.pdf');
-      await fs.writeFile(outputPath, 'pdf content');
+    it('handler mkdir is required — without it gws write would fail', async () => {
+      const outputPath = path.join(tmpWorkspace, 'deep', 'nested', 'Doc.txt');
 
       const { resolveWorkspacePath } = require('../../executor/workspace.js');
       (resolveWorkspacePath as jest.Mock).mockReturnValue(outputPath);
+
+      // Verify the parent directory does NOT exist before handler runs
+      const parentBefore = await fs.stat(path.dirname(outputPath)).catch(() => null);
+      expect(parentBefore).toBeNull();
+
+      mockExecute
+        .mockResolvedValueOnce({ success: true, data: { name: 'Doc' }, stderr: '' })
+        .mockImplementationOnce(async () => {
+          // Parent directory must exist at this point (handler created it)
+          const stat = await fs.stat(path.dirname(outputPath));
+          expect(stat.isDirectory()).toBe(true);
+          await fs.writeFile(outputPath, 'content');
+          return { success: true, data: {}, stderr: '' };
+        });
+
+      const handler = drivePatch.customHandlers!.export!;
+      await handler(
+        { fileId: 'abc123', mimeType: 'text/plain' },
+        'user@test.com',
+      );
+    });
+
+    it('works with flat filename (no subdirectory)', async () => {
+      const outputPath = path.join(tmpWorkspace, 'Doc.pdf');
+
+      const { resolveWorkspacePath } = require('../../executor/workspace.js');
+      (resolveWorkspacePath as jest.Mock).mockReturnValue(outputPath);
+
+      mockExecute
+        .mockResolvedValueOnce({ success: true, data: { name: 'Doc' }, stderr: '' })
+        .mockImplementationOnce(async () => {
+          await fs.writeFile(outputPath, 'pdf content');
+          return { success: true, data: {}, stderr: '' };
+        });
 
       const handler = drivePatch.customHandlers!.export!;
       const result = await handler(
@@ -98,16 +127,24 @@ describe('drivePatch custom handlers', () => {
 
   describe('download', () => {
     it('creates parent directories before calling gws', async () => {
-      mockExecute
-        .mockResolvedValueOnce({ success: true, data: { name: 'photo.png', mimeType: 'image/png' }, stderr: '' })
-        .mockResolvedValueOnce({ success: true, data: {}, stderr: '' });
-
       const outputPath = path.join(tmpWorkspace, 'images', 'photo.png');
-      await fs.mkdir(path.dirname(outputPath), { recursive: true });
-      await fs.writeFile(outputPath, 'png data');
 
       const { resolveWorkspacePath } = require('../../executor/workspace.js');
       (resolveWorkspacePath as jest.Mock).mockReturnValue(outputPath);
+
+      // Verify parent does NOT exist before handler runs
+      const parentBefore = await fs.stat(path.dirname(outputPath)).catch(() => null);
+      expect(parentBefore).toBeNull();
+
+      mockExecute
+        .mockResolvedValueOnce({ success: true, data: { name: 'photo.png', mimeType: 'image/png' }, stderr: '' })
+        .mockImplementationOnce(async () => {
+          // Parent directory must exist at this point
+          const stat = await fs.stat(path.dirname(outputPath));
+          expect(stat.isDirectory()).toBe(true);
+          await fs.writeFile(outputPath, 'png data');
+          return { success: true, data: {}, stderr: '' };
+        });
 
       const handler = drivePatch.customHandlers!.download!;
       await handler(

--- a/src/__tests__/factory/drive-patch.test.ts
+++ b/src/__tests__/factory/drive-patch.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Tests for the drive service patch — custom handlers for download/export
+ * that ensure parent directories are created before writing files.
+ */
+
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+// Mock executor before importing patch
+jest.mock('../../executor/gws.js');
+import { execute } from '../../executor/gws.js';
+
+// Mock workspace module with a temp dir
+const tmpWorkspace = path.join(os.tmpdir(), `gws-test-${Date.now()}`);
+jest.mock('../../executor/workspace.js', () => ({
+  ensureWorkspaceDir: jest.fn(async () => ({ path: tmpWorkspace, valid: true })),
+  getWorkspaceDir: jest.fn(() => tmpWorkspace),
+  resolveWorkspacePath: jest.fn((filename: string) => path.join(tmpWorkspace, filename)),
+  verifyPathSafety: jest.fn(async () => {}),
+}));
+
+// Mock file-output to avoid reading actual files
+jest.mock('../../executor/file-output.js', () => ({
+  isTextFile: jest.fn(() => true),
+  isImageFile: jest.fn(() => false),
+  formatFileOutput: jest.fn(() => '## Exported file\n'),
+  buildImageBlock: jest.fn(() => null),
+  buildImageBlockFromFile: jest.fn(() => null),
+}));
+
+import { drivePatch } from '../../services/drive/patch.js';
+
+const mockExecute = execute as jest.MockedFunction<typeof execute>;
+
+describe('drivePatch custom handlers', () => {
+  beforeEach(async () => {
+    mockExecute.mockReset();
+    await fs.mkdir(tmpWorkspace, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(tmpWorkspace, { recursive: true, force: true });
+  });
+
+  describe('export', () => {
+    it('creates parent directories before calling gws', async () => {
+      // First call: get file metadata; second call: export
+      mockExecute
+        .mockResolvedValueOnce({ success: true, data: { name: 'Report.gdoc' }, stderr: '' })
+        .mockResolvedValueOnce({ success: true, data: {}, stderr: '' });
+
+      // Write a dummy file so readWorkspaceFile finds something
+      const outputPath = path.join(tmpWorkspace, 'subdir', 'Report.txt');
+      await fs.mkdir(path.dirname(outputPath), { recursive: true });
+      await fs.writeFile(outputPath, 'exported content');
+
+      const { resolveWorkspacePath } = require('../../executor/workspace.js');
+      (resolveWorkspacePath as jest.Mock).mockReturnValue(outputPath);
+
+      const handler = drivePatch.customHandlers!.export!;
+      await handler(
+        { fileId: 'abc123', mimeType: 'text/plain', outputPath: 'subdir/Report.txt' },
+        'user@test.com',
+      );
+
+      // The export call (second execute) should have --output pointing to the nested path
+      const exportCall = mockExecute.mock.calls[1][0];
+      expect(exportCall).toContain('--output');
+      expect(exportCall[exportCall.indexOf('--output') + 1]).toBe(outputPath);
+
+      // Parent directory must exist (we created it, but the handler also calls mkdir)
+      const parentExists = await fs.stat(path.dirname(outputPath)).then(() => true).catch(() => false);
+      expect(parentExists).toBe(true);
+    });
+
+    it('works with flat filename (no subdirectory)', async () => {
+      mockExecute
+        .mockResolvedValueOnce({ success: true, data: { name: 'Doc' }, stderr: '' })
+        .mockResolvedValueOnce({ success: true, data: {}, stderr: '' });
+
+      const outputPath = path.join(tmpWorkspace, 'Doc.pdf');
+      await fs.writeFile(outputPath, 'pdf content');
+
+      const { resolveWorkspacePath } = require('../../executor/workspace.js');
+      (resolveWorkspacePath as jest.Mock).mockReturnValue(outputPath);
+
+      const handler = drivePatch.customHandlers!.export!;
+      const result = await handler(
+        { fileId: 'abc123', mimeType: 'application/pdf' },
+        'user@test.com',
+      );
+
+      expect(result.text).toBeDefined();
+      expect(mockExecute).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('download', () => {
+    it('creates parent directories before calling gws', async () => {
+      mockExecute
+        .mockResolvedValueOnce({ success: true, data: { name: 'photo.png', mimeType: 'image/png' }, stderr: '' })
+        .mockResolvedValueOnce({ success: true, data: {}, stderr: '' });
+
+      const outputPath = path.join(tmpWorkspace, 'images', 'photo.png');
+      await fs.mkdir(path.dirname(outputPath), { recursive: true });
+      await fs.writeFile(outputPath, 'png data');
+
+      const { resolveWorkspacePath } = require('../../executor/workspace.js');
+      (resolveWorkspacePath as jest.Mock).mockReturnValue(outputPath);
+
+      const handler = drivePatch.customHandlers!.download!;
+      await handler(
+        { fileId: 'img-1', outputPath: 'images/photo.png' },
+        'user@test.com',
+      );
+
+      const downloadCall = mockExecute.mock.calls[1][0];
+      expect(downloadCall).toContain('--output');
+      expect(downloadCall[downloadCall.indexOf('--output') + 1]).toBe(outputPath);
+    });
+  });
+});

--- a/src/services/drive/patch.ts
+++ b/src/services/drive/patch.ts
@@ -75,6 +75,9 @@ export const drivePatch: ServicePatch = {
       const outputPath = resolveWorkspacePath(filename);
       await verifyPathSafety(outputPath);
 
+      // Ensure parent directories exist (outputPath may contain subdirectories)
+      await fs.mkdir(path.dirname(outputPath), { recursive: true });
+
       // Download directly to disk via --output (preserves binary integrity)
       // cwd must match workspace so gws directory-fence accepts the output path
       await execute([
@@ -170,6 +173,9 @@ export const drivePatch: ServicePatch = {
       if (!wsStatus.valid) throw new Error(`Workspace invalid: ${wsStatus.warning}`);
       const outputPath = resolveWorkspacePath(filename);
       await verifyPathSafety(outputPath);
+
+      // Ensure parent directories exist (outputPath may contain subdirectories)
+      await fs.mkdir(path.dirname(outputPath), { recursive: true });
 
       // Export directly to disk via --output (preserves binary integrity)
       // cwd must match workspace so gws directory-fence accepts the output path


### PR DESCRIPTION
## Summary
- Export and download custom handlers resolve `outputPath` into the workspace sandbox via `resolveWorkspacePath()`, which can produce nested paths (e.g. user passes `/tmp/file.txt` → becomes `workspace/tmp/file.txt`)
- Neither handler created parent directories before invoking `gws --output`, causing "Failed to create output file: No such file or directory" errors
- Added `fs.mkdir(path.dirname(outputPath), { recursive: true })` before the `execute()` call in both handlers

Closes #100

## Test plan
- [x] New `drive-patch.test.ts` with 3 tests covering subdirectory creation for export and download
- [x] Full test suite passes (548 tests, 34 suites)
- [ ] Manual: export a Google Doc via `manage_drive` with default outputPath
- [ ] Manual: export with explicit nested `outputPath` like `reports/doc.txt`