### PR TITLE
fix(sheets): surface values + expand manage_sheets to 13 ops (#90)

### DIFF
--- a/src/__tests__/factory/patch-coverage.test.ts
+++ b/src/__tests__/factory/patch-coverage.test.ts
@@ -148,6 +148,20 @@ describe('patch coverage', () => {
     expect(driveCustom).toContain('download');
   });
 
+  it('sheets core operations have custom formatting', () => {
+    const sheetsCustom = coverage
+      .filter(e => e.service === 'sheets' && e.usesCustomFormat)
+      .map(e => e.operation)
+      .sort();
+
+    expect(sheetsCustom).toContain('get');
+    expect(sheetsCustom).toContain('read');
+    expect(sheetsCustom).toContain('getValues');
+    expect(sheetsCustom).toContain('create');
+    expect(sheetsCustom).toContain('append');
+    expect(sheetsCustom).toContain('updateValues');
+  });
+
   it('meet core operations have custom formatting', () => {
     const meetCustom = coverage
       .filter(e => e.service === 'meet' && e.usesCustomFormat)

--- a/src/__tests__/factory/patch-coverage.test.ts
+++ b/src/__tests__/factory/patch-coverage.test.ts
@@ -154,12 +154,20 @@ describe('patch coverage', () => {
       .map(e => e.operation)
       .sort();
 
+    // Data ops
     expect(sheetsCustom).toContain('get');
     expect(sheetsCustom).toContain('read');
     expect(sheetsCustom).toContain('getValues');
     expect(sheetsCustom).toContain('create');
     expect(sheetsCustom).toContain('append');
     expect(sheetsCustom).toContain('updateValues');
+    // Tab management
+    expect(sheetsCustom).toContain('addSheet');
+    expect(sheetsCustom).toContain('renameSheet');
+    expect(sheetsCustom).toContain('deleteSheet');
+    expect(sheetsCustom).toContain('duplicateSheet');
+    expect(sheetsCustom).toContain('renameSpreadsheet');
+    expect(sheetsCustom).toContain('copySheetTo');
   });
 
   it('meet core operations have custom formatting', () => {

--- a/src/__tests__/factory/sheets-patch.test.ts
+++ b/src/__tests__/factory/sheets-patch.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Tests for the sheets service patch — formatters preserve the `values`
+ * and `sheets` arrays that the generic detail formatter drops, and
+ * `updateValues` writes a request body the manifest can't express.
+ */
+
+jest.mock('../../executor/gws.js');
+import { execute } from '../../executor/gws.js';
+import { sheetsPatch } from '../../services/sheets/patch.js';
+import type { PatchContext } from '../../factory/types.js';
+
+const mockExecute = execute as jest.MockedFunction<typeof execute>;
+
+const ctx = (operation: string): PatchContext => ({
+  operation,
+  params: {},
+  account: 'user@test.com',
+});
+
+describe('sheetsPatch formatDetail', () => {
+  it('read renders the values array as a markdown table', () => {
+    const data = {
+      range: "'Clean Logs'!A1:C2",
+      majorDimension: 'ROWS',
+      values: [
+        ['Date', 'Level', 'Message'],
+        ['2026-04-15', 'INFO', 'started'],
+      ],
+    };
+    const res = sheetsPatch.formatDetail!(data, ctx('read'));
+    expect(res.text).toContain("'Clean Logs'!A1:C2");
+    expect(res.text).toContain('Date | Level | Message');
+    expect(res.text).toContain('2026-04-15 | INFO | started');
+    expect(res.text).toContain('**Rows:** 2');
+    expect(res.text).toContain('**Columns:** 3');
+    expect(res.refs.values).toEqual(data.values);
+    expect(res.refs.rowCount).toBe(2);
+  });
+
+  it('getValues uses the same values renderer', () => {
+    const res = sheetsPatch.formatDetail!(
+      { range: 'Sheet1!A1:B1', majorDimension: 'ROWS', values: [['a', 'b']] },
+      ctx('getValues'),
+    );
+    expect(res.text).toContain('a | b');
+  });
+
+  it('read handles empty range gracefully', () => {
+    const res = sheetsPatch.formatDetail!(
+      { range: 'Sheet1!A1:A1', majorDimension: 'ROWS' },
+      ctx('read'),
+    );
+    expect(res.text).toContain('**Rows:** 0');
+    expect(res.text).toContain('_(empty range)_');
+  });
+
+  it('escapes pipe characters so they do not break the table', () => {
+    const res = sheetsPatch.formatDetail!(
+      { range: 'S!A1', majorDimension: 'ROWS', values: [['a|b', 'c']] },
+      ctx('read'),
+    );
+    expect(res.text).toContain('a\\|b | c');
+  });
+
+  it('get renders spreadsheet metadata including sheet tabs', () => {
+    const data = {
+      spreadsheetId: 'sheet123',
+      spreadsheetUrl: 'https://docs.google.com/spreadsheets/d/sheet123',
+      properties: { title: 'Budget', locale: 'en_US', timeZone: 'America/New_York' },
+      sheets: [
+        { properties: { sheetId: 0, title: 'Summary', gridProperties: { rowCount: 100, columnCount: 26 } } },
+        { properties: { sheetId: 1, title: 'Details', gridProperties: { rowCount: 500, columnCount: 10 } } },
+      ],
+    };
+    const res = sheetsPatch.formatDetail!(data, ctx('get'));
+    expect(res.text).toContain('## Budget');
+    expect(res.text).toContain('**Spreadsheet ID:** sheet123');
+    expect(res.text).toContain('### Sheets (2)');
+    expect(res.text).toContain('**Summary** (sheetId: 0) — 100 rows × 26 cols');
+    expect(res.text).toContain('**Details** (sheetId: 1) — 500 rows × 10 cols');
+    expect(res.refs.spreadsheetId).toBe('sheet123');
+    expect(Array.isArray(res.refs.sheets)).toBe(true);
+  });
+});
+
+describe('sheetsPatch formatAction', () => {
+  it('create surfaces spreadsheetId and url', () => {
+    const res = sheetsPatch.formatAction!(
+      {
+        spreadsheetId: 'new1',
+        spreadsheetUrl: 'https://docs.google.com/spreadsheets/d/new1',
+        properties: { title: 'New' },
+        sheets: [{ properties: { title: 'Sheet1' } }],
+      },
+      ctx('create'),
+    );
+    expect(res.text).toContain('**Spreadsheet ID:** new1');
+    expect(res.text).toContain('**URL:** https://docs.google.com/spreadsheets/d/new1');
+    expect(res.text).toContain('**Sheets:** Sheet1');
+    expect(res.refs.spreadsheetId).toBe('new1');
+  });
+
+  it('append surfaces updatedRange/rows/cells', () => {
+    const res = sheetsPatch.formatAction!(
+      {
+        spreadsheetId: 'sheet123',
+        updates: {
+          updatedRange: 'Sheet1!A5:C5',
+          updatedRows: 1,
+          updatedColumns: 3,
+          updatedCells: 3,
+        },
+      },
+      ctx('append'),
+    );
+    expect(res.text).toContain('**Range:** Sheet1!A5:C5');
+    expect(res.text).toContain('**Rows:** 1');
+    expect(res.text).toContain('**Cells:** 3');
+    expect(res.refs.updatedRange).toBe('Sheet1!A5:C5');
+  });
+});
+
+describe('sheetsPatch customHandlers.updateValues', () => {
+  beforeEach(() => {
+    mockExecute.mockReset();
+  });
+
+  const okResponse = {
+    success: true,
+    data: {
+      spreadsheetId: 'sheet123',
+      updatedRange: 'Sheet1!A1:B1',
+      updatedRows: 1,
+      updatedColumns: 2,
+      updatedCells: 2,
+    },
+    stderr: '',
+  } as const;
+
+  it('sends values via --json with the expected body shape', async () => {
+    mockExecute.mockResolvedValueOnce(okResponse);
+    const handler = sheetsPatch.customHandlers!.updateValues!;
+
+    const res = await handler(
+      {
+        spreadsheetId: 'sheet123',
+        range: 'Sheet1!A1:B1',
+        jsonValues: '[["a","b"]]',
+      },
+      'user@test.com',
+    );
+
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+    const args = mockExecute.mock.calls[0][0];
+    expect(args.slice(0, 4)).toEqual(['sheets', 'spreadsheets', 'values', 'update']);
+
+    const jsonIdx = args.indexOf('--json');
+    expect(jsonIdx).toBeGreaterThan(-1);
+    const body = JSON.parse(args[jsonIdx + 1]);
+    expect(body.values).toEqual([['a', 'b']]);
+    expect(body.majorDimension).toBe('ROWS');
+
+    const paramsIdx = args.indexOf('--params');
+    const params = JSON.parse(args[paramsIdx + 1]);
+    expect(params).toEqual({
+      spreadsheetId: 'sheet123',
+      range: 'Sheet1!A1:B1',
+      valueInputOption: 'USER_ENTERED',
+    });
+
+    expect(res.text).toContain('**Range:** Sheet1!A1:B1');
+    expect(res.refs.updatedCells).toBe(2);
+  });
+
+  it('accepts CSV values for single-row writes', async () => {
+    mockExecute.mockResolvedValueOnce(okResponse);
+    const handler = sheetsPatch.customHandlers!.updateValues!;
+
+    await handler(
+      { spreadsheetId: 'sheet123', range: 'Sheet1!A1', values: 'Alice,100,true' },
+      'user@test.com',
+    );
+
+    const args = mockExecute.mock.calls[0][0];
+    const body = JSON.parse(args[args.indexOf('--json') + 1]);
+    expect(body.values).toEqual([['Alice', '100', 'true']]);
+  });
+
+  it('honors a caller-supplied valueInputOption', async () => {
+    mockExecute.mockResolvedValueOnce(okResponse);
+    const handler = sheetsPatch.customHandlers!.updateValues!;
+
+    await handler(
+      {
+        spreadsheetId: 'sheet123',
+        range: 'Sheet1!A1',
+        jsonValues: '[["=1+1"]]',
+        valueInputOption: 'RAW',
+      },
+      'user@test.com',
+    );
+
+    const args = mockExecute.mock.calls[0][0];
+    const params = JSON.parse(args[args.indexOf('--params') + 1]);
+    expect(params.valueInputOption).toBe('RAW');
+  });
+
+  it('rejects malformed jsonValues', async () => {
+    const handler = sheetsPatch.customHandlers!.updateValues!;
+    await expect(
+      handler(
+        { spreadsheetId: 'sheet123', range: 'Sheet1!A1', jsonValues: '"not an array"' },
+        'user@test.com',
+      ),
+    ).rejects.toThrow(/jsonValues must be a JSON 2D array/);
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it('requires either values or jsonValues', async () => {
+    const handler = sheetsPatch.customHandlers!.updateValues!;
+    await expect(
+      handler({ spreadsheetId: 'sheet123', range: 'Sheet1!A1' }, 'user@test.com'),
+    ).rejects.toThrow(/values .* or jsonValues/);
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/factory/sheets-patch.test.ts
+++ b/src/__tests__/factory/sheets-patch.test.ts
@@ -226,6 +226,33 @@ describe('sheetsPatch customHandlers.updateValues', () => {
     expect(mockExecute).not.toHaveBeenCalled();
   });
 
+  it('parses CSV values with quoted fields containing commas', async () => {
+    mockExecute.mockResolvedValueOnce(okResponse);
+    const handler = sheetsPatch.customHandlers!.updateValues!;
+
+    await handler(
+      { spreadsheetId: 'sheet123', range: 'Sheet1!A1', values: '"Smith, John",42,"Remote, WFH"' },
+      'user@test.com',
+    );
+
+    const body = JSON.parse(mockExecute.mock.calls[0][0][mockExecute.mock.calls[0][0].indexOf('--json') + 1]);
+    expect(body.values).toEqual([['Smith, John', '42', 'Remote, WFH']]);
+  });
+
+  it('parses CSV values with escaped double quotes', async () => {
+    mockExecute.mockResolvedValueOnce(okResponse);
+    const handler = sheetsPatch.customHandlers!.updateValues!;
+
+    // Google-style CSV escaping: "" inside a quoted field = literal "
+    await handler(
+      { spreadsheetId: 'sheet123', range: 'Sheet1!A1', values: '"She said ""hi""",ok' },
+      'user@test.com',
+    );
+
+    const body = JSON.parse(mockExecute.mock.calls[0][0][mockExecute.mock.calls[0][0].indexOf('--json') + 1]);
+    expect(body.values).toEqual([['She said "hi"', 'ok']]);
+  });
+
   it('requires either values or jsonValues', async () => {
     const handler = sheetsPatch.customHandlers!.updateValues!;
     await expect(
@@ -568,5 +595,69 @@ describe('sheetsPatch customHandlers.copySheetTo', () => {
     expect(body).toEqual({ destinationSpreadsheetId: 'dstSheet' });
     expect(res.refs.destinationSpreadsheetId).toBe('dstSheet');
     expect(res.refs.sheetId).toBe(500);
+  });
+
+  it('rejects missing destinationSpreadsheetId', async () => {
+    const handler = sheetsPatch.customHandlers!.copySheetTo!;
+    await expect(
+      handler({ spreadsheetId: 'srcSheet', sheetId: 5 }, 'user@test.com'),
+    ).rejects.toThrow(/destinationSpreadsheetId is required/);
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it('propagates gws execution errors', async () => {
+    mockExecute.mockRejectedValueOnce(new Error('destination spreadsheet not found'));
+    const handler = sheetsPatch.customHandlers!.copySheetTo!;
+    await expect(
+      handler(
+        { spreadsheetId: 'srcSheet', sheetId: 5, destinationSpreadsheetId: 'missing' },
+        'user@test.com',
+      ),
+    ).rejects.toThrow(/destination spreadsheet not found/);
+  });
+});
+
+describe('sheetsPatch — nextSteps guidance (regression for PR #103 review)', () => {
+  beforeEach(() => mockExecute.mockReset());
+
+  it('updateValues appends next-steps footer to response text', async () => {
+    mockExecute.mockResolvedValueOnce({
+      success: true,
+      data: { spreadsheetId: 'sheet123', updatedRange: 'Sheet1!A1:B1', updatedRows: 1, updatedColumns: 2, updatedCells: 2 },
+      stderr: '',
+    });
+    const handler = sheetsPatch.customHandlers!.updateValues!;
+    const res = await handler(
+      { spreadsheetId: 'sheet123', range: 'Sheet1!A1', jsonValues: '[["a","b"]]' },
+      'user@test.com',
+    );
+    expect(res.text).toContain('Next steps:');
+    expect(res.text).toContain('manage_sheets');
+  });
+
+  it('addSheet appends next-steps footer', async () => {
+    mockExecute.mockResolvedValueOnce({
+      success: true,
+      data: { replies: [{ addSheet: { properties: { sheetId: 42, title: 'T', gridProperties: {} } } }] },
+      stderr: '',
+    });
+    const handler = sheetsPatch.customHandlers!.addSheet!;
+    const res = await handler(
+      { spreadsheetId: 'sheet123', title: 'T' },
+      'user@test.com',
+    );
+    expect(res.text).toContain('Next steps:');
+  });
+
+  it('resolves spreadsheetId placeholder from handler context', async () => {
+    mockExecute.mockResolvedValueOnce({ success: true, data: { replies: [{}] }, stderr: '' });
+    const handler = sheetsPatch.customHandlers!.renameSheet!;
+    const res = await handler(
+      { spreadsheetId: 'sheet-xyz', sheetId: 0, title: 'Main' },
+      'user@test.com',
+    );
+    // Next-steps entry for renameSheet references <spreadsheetId> — verify resolution
+    expect(res.text).toContain('sheet-xyz');
+    expect(res.text).not.toContain('<spreadsheetId>');
   });
 });

--- a/src/__tests__/factory/sheets-patch.test.ts
+++ b/src/__tests__/factory/sheets-patch.test.ts
@@ -224,3 +224,242 @@ describe('sheetsPatch customHandlers.updateValues', () => {
     expect(mockExecute).not.toHaveBeenCalled();
   });
 });
+
+// --- Tab management (batchUpdate-based customHandlers) ---
+
+/** Assert batchUpdate was called with the expected single-request body. */
+function expectBatchUpdateCall(
+  call: readonly string[],
+  expectedSpreadsheetId: string,
+  expectedRequest: Record<string, unknown>,
+): void {
+  expect(call.slice(0, 3)).toEqual(['sheets', 'spreadsheets', 'batchUpdate']);
+  const params = JSON.parse(call[call.indexOf('--params') + 1]);
+  expect(params).toEqual({ spreadsheetId: expectedSpreadsheetId });
+  const body = JSON.parse(call[call.indexOf('--json') + 1]);
+  expect(body).toEqual({ requests: [expectedRequest] });
+}
+
+describe('sheetsPatch customHandlers.addSheet', () => {
+  beforeEach(() => mockExecute.mockReset());
+
+  it('sends addSheet with title and returns the new sheetId', async () => {
+    mockExecute.mockResolvedValueOnce({
+      success: true,
+      data: {
+        replies: [{
+          addSheet: { properties: { sheetId: 42, title: 'Logs', gridProperties: { rowCount: 1000, columnCount: 26 } } },
+        }],
+      },
+      stderr: '',
+    });
+    const handler = sheetsPatch.customHandlers!.addSheet!;
+
+    const res = await handler(
+      { spreadsheetId: 'sheet123', title: 'Logs' },
+      'user@test.com',
+    );
+
+    expectBatchUpdateCall(mockExecute.mock.calls[0][0], 'sheet123', {
+      addSheet: { properties: { title: 'Logs' } },
+    });
+    expect(res.text).toContain('**Sheet ID:** 42');
+    expect(res.text).toContain('Logs');
+    expect(res.refs.sheetId).toBe(42);
+  });
+
+  it('passes gridProperties when rowCount/columnCount provided', async () => {
+    mockExecute.mockResolvedValueOnce({
+      success: true,
+      data: { replies: [{ addSheet: { properties: { sheetId: 1, title: 'Big', gridProperties: { rowCount: 500, columnCount: 10 } } } }] },
+      stderr: '',
+    });
+    const handler = sheetsPatch.customHandlers!.addSheet!;
+    await handler(
+      { spreadsheetId: 'sheet123', title: 'Big', rowCount: 500, columnCount: 10 },
+      'user@test.com',
+    );
+    const body = JSON.parse(mockExecute.mock.calls[0][0][mockExecute.mock.calls[0][0].indexOf('--json') + 1]);
+    expect(body.requests[0].addSheet.properties.gridProperties).toEqual({ rowCount: 500, columnCount: 10 });
+  });
+
+  it('passes index when provided', async () => {
+    mockExecute.mockResolvedValueOnce({
+      success: true,
+      data: { replies: [{ addSheet: { properties: { sheetId: 2, title: 'First', gridProperties: {} } } }] },
+      stderr: '',
+    });
+    const handler = sheetsPatch.customHandlers!.addSheet!;
+    await handler(
+      { spreadsheetId: 'sheet123', title: 'First', index: 0 },
+      'user@test.com',
+    );
+    const body = JSON.parse(mockExecute.mock.calls[0][0][mockExecute.mock.calls[0][0].indexOf('--json') + 1]);
+    expect(body.requests[0].addSheet.properties.index).toBe(0);
+  });
+
+  it('rejects missing title', async () => {
+    const handler = sheetsPatch.customHandlers!.addSheet!;
+    await expect(handler({ spreadsheetId: 'sheet123' }, 'user@test.com'))
+      .rejects.toThrow(/title is required/);
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+});
+
+describe('sheetsPatch customHandlers.renameSheet', () => {
+  beforeEach(() => mockExecute.mockReset());
+
+  it('sends updateSheetProperties with title fieldmask', async () => {
+    mockExecute.mockResolvedValueOnce({ success: true, data: { replies: [{}] }, stderr: '' });
+    const handler = sheetsPatch.customHandlers!.renameSheet!;
+
+    const res = await handler(
+      { spreadsheetId: 'sheet123', sheetId: 7, title: 'Renamed' },
+      'user@test.com',
+    );
+
+    expectBatchUpdateCall(mockExecute.mock.calls[0][0], 'sheet123', {
+      updateSheetProperties: {
+        properties: { sheetId: 7, title: 'Renamed' },
+        fields: 'title',
+      },
+    });
+    expect(res.text).toContain('**Sheet ID:** 7');
+    expect(res.text).toContain('**New title:** Renamed');
+  });
+
+  it('accepts sheetId = 0 (valid Google Sheets ID)', async () => {
+    mockExecute.mockResolvedValueOnce({ success: true, data: { replies: [{}] }, stderr: '' });
+    const handler = sheetsPatch.customHandlers!.renameSheet!;
+    await handler(
+      { spreadsheetId: 'sheet123', sheetId: 0, title: 'Main' },
+      'user@test.com',
+    );
+    const body = JSON.parse(mockExecute.mock.calls[0][0][mockExecute.mock.calls[0][0].indexOf('--json') + 1]);
+    expect(body.requests[0].updateSheetProperties.properties.sheetId).toBe(0);
+  });
+
+  it('rejects non-integer sheetId', async () => {
+    const handler = sheetsPatch.customHandlers!.renameSheet!;
+    await expect(
+      handler({ spreadsheetId: 'sheet123', sheetId: 'abc', title: 'X' }, 'user@test.com'),
+    ).rejects.toThrow(/sheetId must be an integer/);
+  });
+
+  it('rejects missing sheetId', async () => {
+    const handler = sheetsPatch.customHandlers!.renameSheet!;
+    await expect(
+      handler({ spreadsheetId: 'sheet123', title: 'X' }, 'user@test.com'),
+    ).rejects.toThrow(/sheetId is required/);
+  });
+});
+
+describe('sheetsPatch customHandlers.deleteSheet', () => {
+  beforeEach(() => mockExecute.mockReset());
+
+  it('sends deleteSheet with the sheetId', async () => {
+    mockExecute.mockResolvedValueOnce({ success: true, data: { replies: [{}] }, stderr: '' });
+    const handler = sheetsPatch.customHandlers!.deleteSheet!;
+
+    const res = await handler(
+      { spreadsheetId: 'sheet123', sheetId: 99 },
+      'user@test.com',
+    );
+
+    expectBatchUpdateCall(mockExecute.mock.calls[0][0], 'sheet123', {
+      deleteSheet: { sheetId: 99 },
+    });
+    expect(res.refs.deleted).toBe(true);
+  });
+});
+
+describe('sheetsPatch customHandlers.duplicateSheet', () => {
+  beforeEach(() => mockExecute.mockReset());
+
+  it('sends duplicateSheet with source id and optional name/index', async () => {
+    mockExecute.mockResolvedValueOnce({
+      success: true,
+      data: { replies: [{ duplicateSheet: { properties: { sheetId: 101, title: 'Logs Copy' } } }] },
+      stderr: '',
+    });
+    const handler = sheetsPatch.customHandlers!.duplicateSheet!;
+
+    const res = await handler(
+      { spreadsheetId: 'sheet123', sheetId: 10, title: 'Logs Copy', index: 2 },
+      'user@test.com',
+    );
+
+    expectBatchUpdateCall(mockExecute.mock.calls[0][0], 'sheet123', {
+      duplicateSheet: {
+        sourceSheetId: 10,
+        newSheetName: 'Logs Copy',
+        insertSheetIndex: 2,
+      },
+    });
+    expect(res.refs.sheetId).toBe(101);
+  });
+
+  it('omits optional fields when not provided', async () => {
+    mockExecute.mockResolvedValueOnce({
+      success: true,
+      data: { replies: [{ duplicateSheet: { properties: { sheetId: 102, title: 'Copy of Logs' } } }] },
+      stderr: '',
+    });
+    const handler = sheetsPatch.customHandlers!.duplicateSheet!;
+    await handler(
+      { spreadsheetId: 'sheet123', sheetId: 10 },
+      'user@test.com',
+    );
+    const body = JSON.parse(mockExecute.mock.calls[0][0][mockExecute.mock.calls[0][0].indexOf('--json') + 1]);
+    expect(body.requests[0].duplicateSheet).toEqual({ sourceSheetId: 10 });
+  });
+});
+
+describe('sheetsPatch customHandlers.renameSpreadsheet', () => {
+  beforeEach(() => mockExecute.mockReset());
+
+  it('sends updateSpreadsheetProperties with title fieldmask', async () => {
+    mockExecute.mockResolvedValueOnce({ success: true, data: { replies: [{}] }, stderr: '' });
+    const handler = sheetsPatch.customHandlers!.renameSpreadsheet!;
+
+    const res = await handler(
+      { spreadsheetId: 'sheet123', title: 'Q2 Budget' },
+      'user@test.com',
+    );
+
+    expectBatchUpdateCall(mockExecute.mock.calls[0][0], 'sheet123', {
+      updateSpreadsheetProperties: {
+        properties: { title: 'Q2 Budget' },
+        fields: 'title',
+      },
+    });
+    expect(res.refs.title).toBe('Q2 Budget');
+  });
+});
+
+describe('sheetsPatch customHandlers.copySheetTo', () => {
+  beforeEach(() => mockExecute.mockReset());
+
+  it('calls sheets.copyTo with destination in --json body', async () => {
+    mockExecute.mockResolvedValueOnce({
+      success: true,
+      data: { sheetId: 500, title: 'Imported Logs' },
+      stderr: '',
+    });
+    const handler = sheetsPatch.customHandlers!.copySheetTo!;
+
+    const res = await handler(
+      { spreadsheetId: 'srcSheet', sheetId: 5, destinationSpreadsheetId: 'dstSheet' },
+      'user@test.com',
+    );
+
+    const args = mockExecute.mock.calls[0][0];
+    expect(args.slice(0, 4)).toEqual(['sheets', 'spreadsheets', 'sheets', 'copyTo']);
+    const params = JSON.parse(args[args.indexOf('--params') + 1]);
+    expect(params).toEqual({ spreadsheetId: 'srcSheet', sheetId: 5 });
+    const body = JSON.parse(args[args.indexOf('--json') + 1]);
+    expect(body).toEqual({ destinationSpreadsheetId: 'dstSheet' });
+    expect(res.refs.destinationSpreadsheetId).toBe('dstSheet');
+    expect(res.refs.sheetId).toBe(500);
+  });
+});

--- a/src/__tests__/factory/sheets-patch.test.ts
+++ b/src/__tests__/factory/sheets-patch.test.ts
@@ -235,6 +235,103 @@ describe('sheetsPatch customHandlers.updateValues', () => {
   });
 });
 
+describe('sheetsPatch customHandlers.append', () => {
+  beforeEach(() => mockExecute.mockReset());
+
+  const apiResponse = {
+    success: true,
+    data: {
+      spreadsheetId: 'sheet123',
+      tableRange: "'Q2 Metrics'!A1:C3",
+      updates: {
+        updatedRange: "'Q2 Metrics'!A4:C4",
+        updatedRows: 1,
+        updatedColumns: 3,
+        updatedCells: 3,
+      },
+    },
+    stderr: '',
+  } as const;
+
+  it('hits spreadsheets.values.append (not the +append helper)', async () => {
+    mockExecute.mockResolvedValueOnce(apiResponse);
+    const handler = sheetsPatch.customHandlers!.append!;
+
+    await handler(
+      { spreadsheetId: 'sheet123', range: 'Q2 Metrics', jsonValues: '[["a","b","c"]]' },
+      'user@test.com',
+    );
+
+    const args = mockExecute.mock.calls[0][0];
+    expect(args.slice(0, 4)).toEqual(['sheets', 'spreadsheets', 'values', 'append']);
+    // Sanity: make sure we did NOT fall back to the helper form
+    expect(args).not.toContain('+append');
+  });
+
+  it('passes range through --params (fixes the Sheet1-only bug)', async () => {
+    mockExecute.mockResolvedValueOnce(apiResponse);
+    const handler = sheetsPatch.customHandlers!.append!;
+
+    await handler(
+      { spreadsheetId: 'sheet123', range: 'Q2 Metrics!A:Z', jsonValues: '[["a","b"]]' },
+      'user@test.com',
+    );
+
+    const args = mockExecute.mock.calls[0][0];
+    const params = JSON.parse(args[args.indexOf('--params') + 1]);
+    expect(params.range).toBe('Q2 Metrics!A:Z');
+    expect(params.valueInputOption).toBe('USER_ENTERED');
+  });
+
+  it('defaults range to Sheet1 when omitted (backward compatible)', async () => {
+    mockExecute.mockResolvedValueOnce(apiResponse);
+    const handler = sheetsPatch.customHandlers!.append!;
+
+    await handler(
+      { spreadsheetId: 'sheet123', jsonValues: '[["a"]]' },
+      'user@test.com',
+    );
+
+    const params = JSON.parse(mockExecute.mock.calls[0][0][mockExecute.mock.calls[0][0].indexOf('--params') + 1]);
+    expect(params.range).toBe('Sheet1');
+  });
+
+  it('accepts CSV values for single-row appends', async () => {
+    mockExecute.mockResolvedValueOnce(apiResponse);
+    const handler = sheetsPatch.customHandlers!.append!;
+
+    await handler(
+      { spreadsheetId: 'sheet123', range: 'Q2 Metrics', values: 'Alice,100,true' },
+      'user@test.com',
+    );
+
+    const body = JSON.parse(mockExecute.mock.calls[0][0][mockExecute.mock.calls[0][0].indexOf('--json') + 1]);
+    expect(body.values).toEqual([['Alice', '100', 'true']]);
+  });
+
+  it('surfaces the updated range from the response', async () => {
+    mockExecute.mockResolvedValueOnce(apiResponse);
+    const handler = sheetsPatch.customHandlers!.append!;
+
+    const res = await handler(
+      { spreadsheetId: 'sheet123', range: 'Q2 Metrics', jsonValues: '[["a","b","c"]]' },
+      'user@test.com',
+    );
+
+    expect(res.text).toContain("'Q2 Metrics'!A4:C4");
+    expect(res.refs.updatedRows).toBe(1);
+    expect(res.refs.updatedCells).toBe(3);
+  });
+
+  it('rejects missing values input', async () => {
+    const handler = sheetsPatch.customHandlers!.append!;
+    await expect(
+      handler({ spreadsheetId: 'sheet123', range: 'Q2 Metrics' }, 'user@test.com'),
+    ).rejects.toThrow(/append requires .* values .* jsonValues/);
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+});
+
 // --- Tab management (batchUpdate-based customHandlers) ---
 
 /** Assert batchUpdate was called with the expected single-request body. */

--- a/src/__tests__/factory/sheets-patch.test.ts
+++ b/src/__tests__/factory/sheets-patch.test.ts
@@ -100,6 +100,16 @@ describe('sheetsPatch formatAction', () => {
     expect(res.refs.spreadsheetId).toBe('new1');
   });
 
+  it('clearValues surfaces the clearedRange', () => {
+    const res = sheetsPatch.formatAction!(
+      { spreadsheetId: 'sheet123', clearedRange: "'Q2'!A1:C3" },
+      ctx('clearValues'),
+    );
+    expect(res.text).toContain('Range cleared');
+    expect(res.text).toContain("**Range:** 'Q2'!A1:C3");
+    expect(res.refs.clearedRange).toBe("'Q2'!A1:C3");
+  });
+
   it('append surfaces updatedRange/rows/cells', () => {
     const res = sheetsPatch.formatAction!(
       {

--- a/src/factory/manifest.yaml
+++ b/src/factory/manifest.yaml
@@ -851,6 +851,17 @@ services:
             type: string
             description: "A1 notation range to write to"
             required: true
+          values:
+            type: string
+            description: "Comma-separated values for a single row (e.g. 'Alice,100,true')"
+          jsonValues:
+            type: string
+            description: "JSON 2D array of rows (e.g. '[[\"a\",\"b\"],[\"c\",\"d\"]]'). Use for multi-row writes."
+          valueInputOption:
+            type: string
+            description: "How input is interpreted: USER_ENTERED (default, parses formulas/types) or RAW"
+            enum: [USER_ENTERED, RAW]
+            default: USER_ENTERED
 
   # ========================================================================
   # Docs

--- a/src/factory/manifest.yaml
+++ b/src/factory/manifest.yaml
@@ -806,23 +806,27 @@ services:
 
       append:
         type: action
-        description: "append rows to a spreadsheet"
-        helper: "+append"
+        description: "append rows to a spreadsheet (rows land after the last row of existing data in the target range)"
+        resource: spreadsheets.values.append
         params:
           spreadsheetId:
             type: string
             description: "Spreadsheet ID"
             required: true
+          range:
+            type: string
+            description: "Target range; defaults to 'Sheet1'. Use 'MyTab' or 'MyTab!A:Z' to append to a specific tab."
           values:
             type: string
             description: "Comma-separated values for a single row (e.g. 'Alice,100,true')"
           jsonValues:
             type: string
-            description: "JSON array of rows for bulk insert (e.g. '[[\"a\",\"b\"],[\"c\",\"d\"]]')"
-        cli_args:
-          spreadsheetId: "--spreadsheet"
-          values: "--values"
-          jsonValues: "--json-values"
+            description: "JSON 2D array of rows for bulk insert (e.g. '[[\"a\",\"b\"],[\"c\",\"d\"]]')"
+          valueInputOption:
+            type: string
+            description: "How input is interpreted: USER_ENTERED (default, parses formulas/types) or RAW"
+            enum: [USER_ENTERED, RAW]
+            default: USER_ENTERED
 
       getValues:
         type: detail

--- a/src/factory/manifest.yaml
+++ b/src/factory/manifest.yaml
@@ -863,6 +863,127 @@ services:
             enum: [USER_ENTERED, RAW]
             default: USER_ENTERED
 
+      clearValues:
+        type: action
+        description: "clear cell values from a range (structure preserved)"
+        resource: spreadsheets.values.clear
+        params:
+          spreadsheetId:
+            type: string
+            description: "Spreadsheet ID"
+            required: true
+          range:
+            type: string
+            description: "A1 notation range to clear"
+            required: true
+
+      addSheet:
+        type: action
+        description: "add a new tab (sheet) to the spreadsheet"
+        resource: spreadsheets.batchUpdate
+        params:
+          spreadsheetId:
+            type: string
+            description: "Spreadsheet ID"
+            required: true
+          title:
+            type: string
+            description: "Name of the new sheet tab"
+            required: true
+          index:
+            type: number
+            description: "Position among tabs (0-based). Appended at the end if omitted."
+          rowCount:
+            type: number
+            description: "Initial row count (default 1000)"
+          columnCount:
+            type: number
+            description: "Initial column count (default 26)"
+
+      renameSheet:
+        type: action
+        description: "rename a tab (sheet) within a spreadsheet"
+        resource: spreadsheets.batchUpdate
+        params:
+          spreadsheetId:
+            type: string
+            description: "Spreadsheet ID"
+            required: true
+          sheetId:
+            type: number
+            description: "Sheet ID of the tab to rename (from manage_sheets get)"
+            required: true
+          title:
+            type: string
+            description: "New title for the tab"
+            required: true
+
+      deleteSheet:
+        type: action
+        description: "delete a tab (sheet) from the spreadsheet — irreversible"
+        resource: spreadsheets.batchUpdate
+        params:
+          spreadsheetId:
+            type: string
+            description: "Spreadsheet ID"
+            required: true
+          sheetId:
+            type: number
+            description: "Sheet ID of the tab to delete"
+            required: true
+
+      duplicateSheet:
+        type: action
+        description: "duplicate a tab within the same spreadsheet"
+        resource: spreadsheets.batchUpdate
+        params:
+          spreadsheetId:
+            type: string
+            description: "Spreadsheet ID"
+            required: true
+          sheetId:
+            type: number
+            description: "Source sheet ID (the tab to copy)"
+            required: true
+          title:
+            type: string
+            description: "Name for the duplicated sheet (defaults to 'Copy of <source>')"
+          index:
+            type: number
+            description: "Position to insert the duplicate (0-based)"
+
+      renameSpreadsheet:
+        type: action
+        description: "rename the spreadsheet (the document title, not a tab)"
+        resource: spreadsheets.batchUpdate
+        params:
+          spreadsheetId:
+            type: string
+            description: "Spreadsheet ID"
+            required: true
+          title:
+            type: string
+            description: "New spreadsheet title"
+            required: true
+
+      copySheetTo:
+        type: action
+        description: "copy a tab from this spreadsheet into another spreadsheet"
+        resource: spreadsheets.sheets.copyTo
+        params:
+          spreadsheetId:
+            type: string
+            description: "Source spreadsheet ID"
+            required: true
+          sheetId:
+            type: number
+            description: "Source sheet ID (the tab to copy)"
+            required: true
+          destinationSpreadsheetId:
+            type: string
+            description: "Destination spreadsheet ID"
+            required: true
+
   # ========================================================================
   # Docs
   # ========================================================================

--- a/src/factory/patches.ts
+++ b/src/factory/patches.ts
@@ -8,6 +8,7 @@ import { calendarPatch } from '../services/calendar/patch.js';
 import { drivePatch } from '../services/drive/patch.js';
 import { docsPatch } from '../services/docs/patch.js';
 import { meetPatch } from '../services/meet/patch.js';
+import { sheetsPatch } from '../services/sheets/patch.js';
 import type { ServicePatch } from './types.js';
 
 export const patches: Record<string, ServicePatch> = {
@@ -16,4 +17,5 @@ export const patches: Record<string, ServicePatch> = {
   drive: drivePatch,
   docs: docsPatch,
   meet: meetPatch,
+  sheets: sheetsPatch,
 };

--- a/src/server/formatting/next-steps.ts
+++ b/src/server/formatting/next-steps.ts
@@ -127,6 +127,29 @@ const suggestions: Record<string, Record<string, NextStep[]>> = {
       { description: 'Search for more files', tool: 'manage_drive', example: { operation: 'search', email: '<email>' } },
     ],
   },
+  sheets: {
+    create: [
+      { description: 'Write values', tool: 'manage_sheets', example: { operation: 'updateValues', email: '<email>', spreadsheetId: '<spreadsheetId>', range: 'Sheet1!A1', jsonValues: '[["header1","header2"]]' } },
+      { description: 'Append rows', tool: 'manage_sheets', example: { operation: 'append', email: '<email>', spreadsheetId: '<spreadsheetId>', jsonValues: '[["a","b"]]' } },
+    ],
+    get: [
+      { description: 'Read a range', tool: 'manage_sheets', example: { operation: 'read', email: '<email>', spreadsheetId: '<spreadsheetId>', range: '<Sheet1!A1:Z>' } },
+      { description: 'Append rows', tool: 'manage_sheets', example: { operation: 'append', email: '<email>', spreadsheetId: '<spreadsheetId>', jsonValues: '[["a","b"]]' } },
+    ],
+    read: [
+      { description: 'Write values to a range', tool: 'manage_sheets', example: { operation: 'updateValues', email: '<email>', spreadsheetId: '<spreadsheetId>', range: '<range>', jsonValues: '[["a","b"]]' } },
+      { description: 'Append more rows', tool: 'manage_sheets', example: { operation: 'append', email: '<email>', spreadsheetId: '<spreadsheetId>', jsonValues: '[["a","b"]]' } },
+    ],
+    getValues: [
+      { description: 'Write values to a range', tool: 'manage_sheets', example: { operation: 'updateValues', email: '<email>', spreadsheetId: '<spreadsheetId>', range: '<range>', jsonValues: '[["a","b"]]' } },
+    ],
+    append: [
+      { description: 'Read back what was written', tool: 'manage_sheets', example: { operation: 'read', email: '<email>', spreadsheetId: '<spreadsheetId>', range: '<Sheet1!A1:Z>' } },
+    ],
+    updateValues: [
+      { description: 'Read back what was written', tool: 'manage_sheets', example: { operation: 'read', email: '<email>', spreadsheetId: '<spreadsheetId>', range: '<range>' } },
+    ],
+  },
   scratchpad: {
     create: [
       { description: 'Add content', tool: 'manage_scratchpad', example: { operation: 'append_lines', scratchpadId: '<scratchpadId>', content: '<text>' } },

--- a/src/server/formatting/next-steps.ts
+++ b/src/server/formatting/next-steps.ts
@@ -149,6 +149,29 @@ const suggestions: Record<string, Record<string, NextStep[]>> = {
     updateValues: [
       { description: 'Read back what was written', tool: 'manage_sheets', example: { operation: 'read', email: '<email>', spreadsheetId: '<spreadsheetId>', range: '<range>' } },
     ],
+    addSheet: [
+      { description: 'Write to the new tab', tool: 'manage_sheets', example: { operation: 'updateValues', email: '<email>', spreadsheetId: '<spreadsheetId>', range: '<NewTab!A1>', jsonValues: '[["a","b"]]' } },
+      { description: 'Inspect all tabs', tool: 'manage_sheets', example: { operation: 'get', email: '<email>', spreadsheetId: '<spreadsheetId>' } },
+    ],
+    renameSheet: [
+      { description: 'Verify new tab name', tool: 'manage_sheets', example: { operation: 'get', email: '<email>', spreadsheetId: '<spreadsheetId>' } },
+    ],
+    deleteSheet: [
+      { description: 'Verify remaining tabs', tool: 'manage_sheets', example: { operation: 'get', email: '<email>', spreadsheetId: '<spreadsheetId>' } },
+    ],
+    duplicateSheet: [
+      { description: 'Read back copied data', tool: 'manage_sheets', example: { operation: 'read', email: '<email>', spreadsheetId: '<spreadsheetId>', range: '<NewTab!A1:Z>' } },
+    ],
+    renameSpreadsheet: [
+      { description: 'Verify the new title', tool: 'manage_sheets', example: { operation: 'get', email: '<email>', spreadsheetId: '<spreadsheetId>' } },
+    ],
+    clearValues: [
+      { description: 'Confirm range is empty', tool: 'manage_sheets', example: { operation: 'read', email: '<email>', spreadsheetId: '<spreadsheetId>', range: '<range>' } },
+      { description: 'Write new values', tool: 'manage_sheets', example: { operation: 'updateValues', email: '<email>', spreadsheetId: '<spreadsheetId>', range: '<range>', jsonValues: '[["a","b"]]' } },
+    ],
+    copySheetTo: [
+      { description: 'Open the destination spreadsheet', tool: 'manage_sheets', example: { operation: 'get', email: '<email>', spreadsheetId: '<destinationSpreadsheetId>' } },
+    ],
   },
   scratchpad: {
     create: [

--- a/src/server/tools.ts
+++ b/src/server/tools.ts
@@ -116,7 +116,7 @@ const handCodedSchemas: ToolSchema[] = [
             properties: {
               tool: {
                 type: 'string',
-                enum: ['manage_email', 'manage_calendar', 'manage_drive', 'manage_accounts', 'manage_scratchpad', 'manage_workspace'],
+                enum: ['manage_email', 'manage_calendar', 'manage_drive', 'manage_sheets', 'manage_docs', 'manage_tasks', 'manage_meet', 'manage_accounts', 'manage_scratchpad', 'manage_workspace'],
                 description: 'Tool to call',
               },
               args: {

--- a/src/services/sheets/patch.ts
+++ b/src/services/sheets/patch.ts
@@ -228,6 +228,194 @@ async function updateValuesHandler(
   };
 }
 
+/** Parse a sheetId param — Google assigns integers and `0` is valid. */
+function requireSheetId(params: Record<string, unknown>, field = 'sheetId'): number {
+  const raw = params[field];
+  if (raw === undefined || raw === null || raw === '') {
+    throw new Error(`${field} is required (integer, from manage_sheets get)`);
+  }
+  const n = Number(raw);
+  if (!Number.isInteger(n)) {
+    throw new Error(`${field} must be an integer, got: ${String(raw)}`);
+  }
+  return n;
+}
+
+/** Run a single-request batchUpdate and return the first reply. */
+async function runBatchUpdate(
+  spreadsheetId: string,
+  request: Record<string, unknown>,
+  account: string,
+): Promise<Record<string, unknown>> {
+  const result = await execute([
+    'sheets', 'spreadsheets', 'batchUpdate',
+    '--params', JSON.stringify({ spreadsheetId }),
+    '--json', JSON.stringify({ requests: [request] }),
+  ], { account });
+  const data = (result.data ?? {}) as Record<string, unknown>;
+  const replies = (data.replies as Array<Record<string, unknown>> | undefined) ?? [];
+  return replies[0] ?? {};
+}
+
+/**
+ * addSheet — append a new tab. Accepts `title`, optional `rowCount`/`columnCount`
+ * and `index` (position among tabs). Returns the new sheetId.
+ */
+async function addSheetHandler(
+  params: Record<string, unknown>,
+  account: string,
+): Promise<HandlerResponse> {
+  const spreadsheetId = requireString(params, 'spreadsheetId');
+  const title = requireString(params, 'title');
+  const properties: Record<string, unknown> = { title };
+
+  if (params.index !== undefined && params.index !== null && params.index !== '') {
+    const idx = Number(params.index);
+    if (!Number.isInteger(idx) || idx < 0) {
+      throw new Error('index must be a non-negative integer');
+    }
+    properties.index = idx;
+  }
+
+  const rowCount = params.rowCount !== undefined && params.rowCount !== '' ? Number(params.rowCount) : undefined;
+  const columnCount = params.columnCount !== undefined && params.columnCount !== '' ? Number(params.columnCount) : undefined;
+  if (rowCount !== undefined || columnCount !== undefined) {
+    properties.gridProperties = {
+      ...(rowCount !== undefined ? { rowCount } : {}),
+      ...(columnCount !== undefined ? { columnCount } : {}),
+    };
+  }
+
+  const reply = await runBatchUpdate(spreadsheetId, { addSheet: { properties } }, account);
+  const addedProps = ((reply.addSheet as Record<string, unknown>)?.properties ?? {}) as Record<string, unknown>;
+  const newSheetId = addedProps.sheetId;
+  const newTitle = addedProps.title ?? title;
+  const grid = (addedProps.gridProperties ?? {}) as Record<string, unknown>;
+
+  return {
+    text: `Sheet added: **${newTitle}**\n\n**Sheet ID:** ${newSheetId}\n**Rows:** ${grid.rowCount ?? '?'}\n**Columns:** ${grid.columnCount ?? '?'}`,
+    refs: { spreadsheetId, sheetId: newSheetId, title: newTitle },
+  };
+}
+
+/** renameSheet — update a tab's title. */
+async function renameSheetHandler(
+  params: Record<string, unknown>,
+  account: string,
+): Promise<HandlerResponse> {
+  const spreadsheetId = requireString(params, 'spreadsheetId');
+  const sheetId = requireSheetId(params);
+  const title = requireString(params, 'title');
+
+  await runBatchUpdate(spreadsheetId, {
+    updateSheetProperties: {
+      properties: { sheetId, title },
+      fields: 'title',
+    },
+  }, account);
+
+  return {
+    text: `Sheet renamed.\n\n**Sheet ID:** ${sheetId}\n**New title:** ${title}`,
+    refs: { spreadsheetId, sheetId, title },
+  };
+}
+
+/** deleteSheet — remove a tab. Irreversible. */
+async function deleteSheetHandler(
+  params: Record<string, unknown>,
+  account: string,
+): Promise<HandlerResponse> {
+  const spreadsheetId = requireString(params, 'spreadsheetId');
+  const sheetId = requireSheetId(params);
+
+  await runBatchUpdate(spreadsheetId, { deleteSheet: { sheetId } }, account);
+
+  return {
+    text: `Sheet deleted.\n\n**Sheet ID:** ${sheetId}`,
+    refs: { spreadsheetId, sheetId, deleted: true },
+  };
+}
+
+/** duplicateSheet — copy a tab within the same spreadsheet. */
+async function duplicateSheetHandler(
+  params: Record<string, unknown>,
+  account: string,
+): Promise<HandlerResponse> {
+  const spreadsheetId = requireString(params, 'spreadsheetId');
+  const sourceSheetId = requireSheetId(params, 'sheetId');
+  const newSheetName = params.title ? String(params.title) : undefined;
+
+  const request: Record<string, unknown> = { duplicateSheet: { sourceSheetId } };
+  if (newSheetName) (request.duplicateSheet as Record<string, unknown>).newSheetName = newSheetName;
+  if (params.index !== undefined && params.index !== '') {
+    const idx = Number(params.index);
+    if (!Number.isInteger(idx) || idx < 0) {
+      throw new Error('index must be a non-negative integer');
+    }
+    (request.duplicateSheet as Record<string, unknown>).insertSheetIndex = idx;
+  }
+
+  const reply = await runBatchUpdate(spreadsheetId, request, account);
+  const newProps = ((reply.duplicateSheet as Record<string, unknown>)?.properties ?? {}) as Record<string, unknown>;
+
+  return {
+    text: `Sheet duplicated.\n\n**Source sheet ID:** ${sourceSheetId}\n**New sheet ID:** ${newProps.sheetId ?? 'unknown'}\n**New title:** ${newProps.title ?? newSheetName ?? '?'}`,
+    refs: { spreadsheetId, sourceSheetId, sheetId: newProps.sheetId, title: newProps.title },
+  };
+}
+
+/** renameSpreadsheet — rename the spreadsheet (the doc title, not a tab). */
+async function renameSpreadsheetHandler(
+  params: Record<string, unknown>,
+  account: string,
+): Promise<HandlerResponse> {
+  const spreadsheetId = requireString(params, 'spreadsheetId');
+  const title = requireString(params, 'title');
+
+  await runBatchUpdate(spreadsheetId, {
+    updateSpreadsheetProperties: {
+      properties: { title },
+      fields: 'title',
+    },
+  }, account);
+
+  return {
+    text: `Spreadsheet renamed.\n\n**Spreadsheet ID:** ${spreadsheetId}\n**New title:** ${title}`,
+    refs: { spreadsheetId, title },
+  };
+}
+
+/**
+ * copySheetTo — copy a tab to another spreadsheet.
+ * spreadsheets.sheets.copyTo takes a --json body with destinationSpreadsheetId.
+ */
+async function copySheetToHandler(
+  params: Record<string, unknown>,
+  account: string,
+): Promise<HandlerResponse> {
+  const spreadsheetId = requireString(params, 'spreadsheetId');
+  const sheetId = requireSheetId(params);
+  const destinationSpreadsheetId = requireString(params, 'destinationSpreadsheetId');
+
+  const result = await execute([
+    'sheets', 'spreadsheets', 'sheets', 'copyTo',
+    '--params', JSON.stringify({ spreadsheetId, sheetId }),
+    '--json', JSON.stringify({ destinationSpreadsheetId }),
+  ], { account });
+
+  const data = (result.data ?? {}) as Record<string, unknown>;
+  return {
+    text: `Sheet copied.\n\n**Source:** ${spreadsheetId} (sheet ${sheetId})\n**Destination:** ${destinationSpreadsheetId}\n**New sheet ID:** ${data.sheetId ?? 'unknown'}\n**New title:** ${data.title ?? '?'}`,
+    refs: {
+      spreadsheetId,
+      sourceSheetId: sheetId,
+      destinationSpreadsheetId,
+      sheetId: data.sheetId,
+      title: data.title,
+    },
+  };
+}
+
 // --- Patch export ---
 
 export const sheetsPatch: ServicePatch = {
@@ -261,5 +449,11 @@ export const sheetsPatch: ServicePatch = {
 
   customHandlers: {
     updateValues: updateValuesHandler,
+    addSheet: addSheetHandler,
+    renameSheet: renameSheetHandler,
+    deleteSheet: deleteSheetHandler,
+    duplicateSheet: duplicateSheetHandler,
+    renameSpreadsheet: renameSpreadsheetHandler,
+    copySheetTo: copySheetToHandler,
   },
 };

--- a/src/services/sheets/patch.ts
+++ b/src/services/sheets/patch.ts
@@ -183,6 +183,30 @@ function formatAppendAction(data: unknown): HandlerResponse {
 // --- Custom handlers ---
 
 /**
+ * Parse user-friendly `values` (CSV for one row) or `jsonValues` (JSON 2D
+ * array) params into the shape the Sheets API body needs. Shared by
+ * updateValues and append since both take the same input shape.
+ */
+function parseValuesInput(params: Record<string, unknown>, opLabel: string): unknown[][] {
+  if (typeof params.jsonValues === 'string' && params.jsonValues.trim()) {
+    try {
+      const parsed = JSON.parse(params.jsonValues);
+      if (!Array.isArray(parsed) || !parsed.every(Array.isArray)) {
+        throw new Error('jsonValues must be a JSON 2D array, e.g. [["a","b"],["c","d"]]');
+      }
+      return parsed;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`Invalid jsonValues: ${message}`);
+    }
+  }
+  if (typeof params.values === 'string' && params.values.trim()) {
+    return [parseCsvLine(params.values)];
+  }
+  throw new Error(`${opLabel} requires either values (CSV row) or jsonValues (JSON 2D array)`);
+}
+
+/**
  * updateValues — write a 2D values array to a range.
  *
  * The manifest/factory can't express request bodies, so this handler
@@ -200,23 +224,7 @@ async function updateValuesHandler(
     ? String(params.valueInputOption)
     : 'USER_ENTERED';
 
-  let values: unknown[][];
-  if (typeof params.jsonValues === 'string' && params.jsonValues.trim()) {
-    try {
-      const parsed = JSON.parse(params.jsonValues);
-      if (!Array.isArray(parsed) || !parsed.every(Array.isArray)) {
-        throw new Error('jsonValues must be a JSON 2D array, e.g. [["a","b"],["c","d"]]');
-      }
-      values = parsed;
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      throw new Error(`Invalid jsonValues: ${message}`);
-    }
-  } else if (typeof params.values === 'string' && params.values.trim()) {
-    values = [parseCsvLine(params.values)];
-  } else {
-    throw new Error('updateValues requires either values (CSV row) or jsonValues (JSON 2D array)');
-  }
+  const values = parseValuesInput(params, 'updateValues');
 
   const result = await execute([
     'sheets', 'spreadsheets', 'values', 'update',
@@ -238,6 +246,35 @@ async function updateValuesHandler(
     text: parts.join(''),
     refs: { spreadsheetId, updatedRange, updatedRows, updatedCells, updatedColumns, valueInputOption },
   };
+}
+
+/**
+ * append — add rows after existing data in a range.
+ *
+ * The gws `+append` helper has no --range flag and always hits Sheet1.
+ * This handler uses the underlying spreadsheets.values.append resource
+ * so callers can target a specific tab. Accepts the same values /
+ * jsonValues / valueInputOption shape as updateValues.
+ */
+async function appendHandler(
+  params: Record<string, unknown>,
+  account: string,
+): Promise<HandlerResponse> {
+  const spreadsheetId = requireString(params, 'spreadsheetId');
+  const range = params.range ? String(params.range) : 'Sheet1';
+  const valueInputOption = params.valueInputOption
+    ? String(params.valueInputOption)
+    : 'USER_ENTERED';
+
+  const values = parseValuesInput(params, 'append');
+
+  const result = await execute([
+    'sheets', 'spreadsheets', 'values', 'append',
+    '--params', JSON.stringify({ spreadsheetId, range, valueInputOption }),
+    '--json', JSON.stringify({ range, majorDimension: 'ROWS', values }),
+  ], { account });
+
+  return formatAppendAction(result.data);
 }
 
 /** Parse a sheetId param — Google assigns integers and `0` is valid. */
@@ -463,6 +500,7 @@ export const sheetsPatch: ServicePatch = {
 
   customHandlers: {
     updateValues: updateValuesHandler,
+    append: appendHandler,
     addSheet: addSheetHandler,
     renameSheet: renameSheetHandler,
     deleteSheet: deleteSheetHandler,

--- a/src/services/sheets/patch.ts
+++ b/src/services/sheets/patch.ts
@@ -1,0 +1,265 @@
+/**
+ * Sheets patch — domain-specific hooks for the Sheets service.
+ *
+ * Key customizations:
+ * - formatDetail for `get` (spreadsheet metadata + sheet tabs) and
+ *   `read`/`getValues` (cell values rendered as a markdown table). The
+ *   generic detail formatter drops object/array fields, so the `values`
+ *   and `sheets` arrays are invisible without this patch.
+ * - formatAction for `create` and `append` so the spreadsheetId / update
+ *   summary make it back to the agent.
+ * - customHandlers.updateValues — `spreadsheets.values.update` needs a
+ *   request body containing `values`, which the manifest/factory path
+ *   can't express. This handler accepts `values` (CSV for a single row)
+ *   or `jsonValues` (JSON 2D array) and sends them via `--json`.
+ */
+
+import { execute } from '../../executor/gws.js';
+import { requireString } from '../../server/handlers/validate.js';
+import type { ServicePatch, PatchContext } from '../../factory/types.js';
+import type { HandlerResponse } from '../../server/formatting/markdown.js';
+
+// --- Helpers ---
+
+/** Escape a pipe so it doesn't break the markdown table. */
+function escapeCell(val: unknown): string {
+  if (val === null || val === undefined) return '';
+  const s = String(val);
+  return s.replace(/\|/g, '\\|').replace(/\n/g, ' ');
+}
+
+/** Render a 2D values array as a compact pipe-delimited markdown block. */
+function renderValuesTable(values: unknown[][]): string {
+  if (values.length === 0) return '_(empty range)_';
+  const rows = values.map(row =>
+    (row ?? []).map(escapeCell).join(' | '),
+  );
+  return rows.join('\n');
+}
+
+/** Parse a simple CSV line respecting quoted fields. */
+function parseCsvLine(line: string): string[] {
+  const fields: string[] = [];
+  let current = '';
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (ch === '"') {
+      if (inQuotes && line[i + 1] === '"') {
+        current += '"';
+        i++;
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if (ch === ',' && !inQuotes) {
+      fields.push(current);
+      current = '';
+    } else {
+      current += ch;
+    }
+  }
+  fields.push(current);
+  return fields;
+}
+
+// --- Detail formatters ---
+
+function formatValuesDetail(data: unknown): HandlerResponse {
+  const raw = (data ?? {}) as Record<string, unknown>;
+  const range = String(raw.range ?? '');
+  const majorDimension = String(raw.majorDimension ?? 'ROWS');
+  const values = (raw.values as unknown[][]) ?? [];
+  const rowCount = values.length;
+  const colCount = rowCount > 0 ? Math.max(...values.map(r => (r ?? []).length)) : 0;
+
+  const header = range ? `## ${range}` : '## Values';
+  const meta = `**Rows:** ${rowCount} | **Columns:** ${colCount} | **Major dimension:** ${majorDimension}`;
+  const table = renderValuesTable(values);
+
+  return {
+    text: `${header}\n\n${meta}\n\n${table}`,
+    refs: { range, majorDimension, rowCount, colCount, values },
+  };
+}
+
+function formatSpreadsheetDetail(data: unknown): HandlerResponse {
+  const raw = (data ?? {}) as Record<string, unknown>;
+  const spreadsheetId = String(raw.spreadsheetId ?? '');
+  const spreadsheetUrl = String(raw.spreadsheetUrl ?? '');
+  const props = (raw.properties ?? {}) as Record<string, unknown>;
+  const title = String(props.title ?? 'Untitled');
+  const locale = props.locale ? String(props.locale) : '';
+  const timeZone = props.timeZone ? String(props.timeZone) : '';
+  const sheets = ((raw.sheets ?? []) as Array<Record<string, unknown>>)
+    .map(s => (s.properties ?? {}) as Record<string, unknown>);
+
+  const parts: string[] = [`## ${title}`];
+  parts.push(`**Spreadsheet ID:** ${spreadsheetId}`);
+  if (spreadsheetUrl) parts.push(`**URL:** ${spreadsheetUrl}`);
+  if (locale) parts.push(`**Locale:** ${locale}`);
+  if (timeZone) parts.push(`**Time zone:** ${timeZone}`);
+
+  if (sheets.length > 0) {
+    parts.push('', `### Sheets (${sheets.length})`);
+    for (const sp of sheets) {
+      const name = String(sp.title ?? '');
+      const sheetId = String(sp.sheetId ?? '');
+      const gridProps = (sp.gridProperties ?? {}) as Record<string, unknown>;
+      const rows = gridProps.rowCount ?? '?';
+      const cols = gridProps.columnCount ?? '?';
+      parts.push(`- **${name}** (sheetId: ${sheetId}) — ${rows} rows × ${cols} cols`);
+    }
+  }
+
+  return {
+    text: parts.join('\n'),
+    refs: {
+      spreadsheetId,
+      spreadsheetUrl,
+      title,
+      sheets: sheets.map(sp => ({
+        sheetId: sp.sheetId,
+        title: sp.title,
+        rowCount: (sp.gridProperties as Record<string, unknown>)?.rowCount,
+        columnCount: (sp.gridProperties as Record<string, unknown>)?.columnCount,
+      })),
+    },
+  };
+}
+
+// --- Action formatters ---
+
+function formatCreateAction(data: unknown): HandlerResponse {
+  const raw = (data ?? {}) as Record<string, unknown>;
+  const spreadsheetId = String(raw.spreadsheetId ?? '');
+  const spreadsheetUrl = String(raw.spreadsheetUrl ?? '');
+  const title = String((raw.properties as Record<string, unknown>)?.title ?? 'Untitled');
+  const sheets = ((raw.sheets ?? []) as Array<Record<string, unknown>>)
+    .map(s => String((s.properties as Record<string, unknown>)?.title ?? ''));
+
+  const parts = [`Spreadsheet created: **${title}**`, `\n**Spreadsheet ID:** ${spreadsheetId}`];
+  if (spreadsheetUrl) parts.push(`\n**URL:** ${spreadsheetUrl}`);
+  if (sheets.length > 0) parts.push(`\n**Sheets:** ${sheets.join(', ')}`);
+
+  return {
+    text: parts.join(''),
+    refs: { spreadsheetId, spreadsheetUrl, title, sheets },
+  };
+}
+
+function formatAppendAction(data: unknown): HandlerResponse {
+  const raw = (data ?? {}) as Record<string, unknown>;
+  const spreadsheetId = String(raw.spreadsheetId ?? '');
+  const updates = (raw.updates ?? {}) as Record<string, unknown>;
+  const updatedRange = String(updates.updatedRange ?? '');
+  const updatedRows = Number(updates.updatedRows ?? 0);
+  const updatedCells = Number(updates.updatedCells ?? 0);
+  const updatedColumns = Number(updates.updatedColumns ?? 0);
+
+  const parts = [`Rows appended.`];
+  if (updatedRange) parts.push(`\n**Range:** ${updatedRange}`);
+  parts.push(`\n**Rows:** ${updatedRows}`);
+  if (updatedColumns) parts.push(`\n**Columns:** ${updatedColumns}`);
+  parts.push(`\n**Cells:** ${updatedCells}`);
+
+  return {
+    text: parts.join(''),
+    refs: { spreadsheetId, updatedRange, updatedRows, updatedCells, updatedColumns },
+  };
+}
+
+// --- Custom handlers ---
+
+/**
+ * updateValues — write a 2D values array to a range.
+ *
+ * The manifest/factory can't express request bodies, so this handler
+ * assembles the body from user-friendly params and calls the API
+ * directly via `--json`. Accepts either `values` (CSV for a single row)
+ * or `jsonValues` (JSON 2D array, e.g. '[["a","b"],["c","d"]]').
+ */
+async function updateValuesHandler(
+  params: Record<string, unknown>,
+  account: string,
+): Promise<HandlerResponse> {
+  const spreadsheetId = requireString(params, 'spreadsheetId');
+  const range = requireString(params, 'range');
+  const valueInputOption = params.valueInputOption
+    ? String(params.valueInputOption)
+    : 'USER_ENTERED';
+
+  let values: unknown[][];
+  if (typeof params.jsonValues === 'string' && params.jsonValues.trim()) {
+    try {
+      const parsed = JSON.parse(params.jsonValues);
+      if (!Array.isArray(parsed) || !parsed.every(Array.isArray)) {
+        throw new Error('jsonValues must be a JSON 2D array, e.g. [["a","b"],["c","d"]]');
+      }
+      values = parsed;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`Invalid jsonValues: ${message}`);
+    }
+  } else if (typeof params.values === 'string' && params.values.trim()) {
+    values = [parseCsvLine(params.values)];
+  } else {
+    throw new Error('updateValues requires either values (CSV row) or jsonValues (JSON 2D array)');
+  }
+
+  const result = await execute([
+    'sheets', 'spreadsheets', 'values', 'update',
+    '--params', JSON.stringify({ spreadsheetId, range, valueInputOption }),
+    '--json', JSON.stringify({ range, majorDimension: 'ROWS', values }),
+  ], { account });
+
+  const data = (result.data ?? {}) as Record<string, unknown>;
+  const updatedRange = String(data.updatedRange ?? range);
+  const updatedRows = Number(data.updatedRows ?? values.length);
+  const updatedCells = Number(data.updatedCells ?? values.reduce((n, r) => n + (r?.length ?? 0), 0));
+  const updatedColumns = Number(data.updatedColumns ?? 0);
+
+  const parts = [`Values written.`, `\n**Range:** ${updatedRange}`, `\n**Rows:** ${updatedRows}`];
+  if (updatedColumns) parts.push(`\n**Columns:** ${updatedColumns}`);
+  parts.push(`\n**Cells:** ${updatedCells}`, `\n**Value input:** ${valueInputOption}`);
+
+  return {
+    text: parts.join(''),
+    refs: { spreadsheetId, updatedRange, updatedRows, updatedCells, updatedColumns, valueInputOption },
+  };
+}
+
+// --- Patch export ---
+
+export const sheetsPatch: ServicePatch = {
+  formatDetail: (data: unknown, ctx: PatchContext): HandlerResponse => {
+    switch (ctx.operation) {
+      case 'read':
+      case 'getValues':
+        return formatValuesDetail(data);
+      case 'get':
+        return formatSpreadsheetDetail(data);
+      default:
+        return formatSpreadsheetDetail(data);
+    }
+  },
+
+  formatAction: (data: unknown, ctx: PatchContext): HandlerResponse => {
+    switch (ctx.operation) {
+      case 'create':
+        return formatCreateAction(data);
+      case 'append':
+        return formatAppendAction(data);
+      default: {
+        const raw = (data ?? {}) as Record<string, unknown>;
+        return {
+          text: 'Operation completed.',
+          refs: { ...raw },
+        };
+      }
+    }
+  },
+
+  customHandlers: {
+    updateValues: updateValuesHandler,
+  },
+};

--- a/src/services/sheets/patch.ts
+++ b/src/services/sheets/patch.ts
@@ -15,11 +15,26 @@
  */
 
 import { execute } from '../../executor/gws.js';
+import { nextSteps } from '../../server/formatting/next-steps.js';
 import { requireString } from '../../server/handlers/validate.js';
 import type { ServicePatch, PatchContext } from '../../factory/types.js';
 import type { HandlerResponse } from '../../server/formatting/markdown.js';
 
 // --- Helpers ---
+
+/**
+ * Build a string-only context map for next-steps placeholder resolution.
+ * The factory path builds an equivalent map internally; custom handlers
+ * skip that path, so we reconstruct it here to keep placeholders like
+ * `<spreadsheetId>` and `<range>` resolving in the guidance footer.
+ */
+function handlerContext(params: Record<string, unknown>, account: string): Record<string, string> {
+  const ctx: Record<string, string> = { email: account };
+  for (const [key, value] of Object.entries(params)) {
+    if (typeof value === 'string') ctx[key] = value;
+  }
+  return ctx;
+}
 
 /** Escape a pipe so it doesn't break the markdown table. */
 function escapeCell(val: unknown): string {
@@ -243,7 +258,7 @@ async function updateValuesHandler(
   parts.push(`\n**Cells:** ${updatedCells}`, `\n**Value input:** ${valueInputOption}`);
 
   return {
-    text: parts.join(''),
+    text: parts.join('') + nextSteps('sheets', 'updateValues', handlerContext(params, account)),
     refs: { spreadsheetId, updatedRange, updatedRows, updatedCells, updatedColumns, valueInputOption },
   };
 }
@@ -274,7 +289,11 @@ async function appendHandler(
     '--json', JSON.stringify({ range, majorDimension: 'ROWS', values }),
   ], { account });
 
-  return formatAppendAction(result.data);
+  const formatted = formatAppendAction(result.data);
+  return {
+    ...formatted,
+    text: formatted.text + nextSteps('sheets', 'append', handlerContext(params, account)),
+  };
 }
 
 /** Parse a sheetId param — Google assigns integers and `0` is valid. */
@@ -282,6 +301,9 @@ function requireSheetId(params: Record<string, unknown>, field = 'sheetId'): num
   const raw = params[field];
   if (raw === undefined || raw === null || raw === '') {
     throw new Error(`${field} is required (integer, from manage_sheets get)`);
+  }
+  if (typeof raw === 'boolean') {
+    throw new Error(`${field} must be an integer, got boolean`);
   }
   const n = Number(raw);
   if (!Number.isInteger(n)) {
@@ -342,7 +364,8 @@ async function addSheetHandler(
   const grid = (addedProps.gridProperties ?? {}) as Record<string, unknown>;
 
   return {
-    text: `Sheet added: **${newTitle}**\n\n**Sheet ID:** ${newSheetId}\n**Rows:** ${grid.rowCount ?? '?'}\n**Columns:** ${grid.columnCount ?? '?'}`,
+    text: `Sheet added: **${newTitle}**\n\n**Sheet ID:** ${newSheetId}\n**Rows:** ${grid.rowCount ?? '?'}\n**Columns:** ${grid.columnCount ?? '?'}` +
+      nextSteps('sheets', 'addSheet', handlerContext(params, account)),
     refs: { spreadsheetId, sheetId: newSheetId, title: newTitle },
   };
 }
@@ -364,7 +387,8 @@ async function renameSheetHandler(
   }, account);
 
   return {
-    text: `Sheet renamed.\n\n**Sheet ID:** ${sheetId}\n**New title:** ${title}`,
+    text: `Sheet renamed.\n\n**Sheet ID:** ${sheetId}\n**New title:** ${title}` +
+      nextSteps('sheets', 'renameSheet', handlerContext(params, account)),
     refs: { spreadsheetId, sheetId, title },
   };
 }
@@ -380,7 +404,8 @@ async function deleteSheetHandler(
   await runBatchUpdate(spreadsheetId, { deleteSheet: { sheetId } }, account);
 
   return {
-    text: `Sheet deleted.\n\n**Sheet ID:** ${sheetId}`,
+    text: `Sheet deleted.\n\n**Sheet ID:** ${sheetId}` +
+      nextSteps('sheets', 'deleteSheet', handlerContext(params, account)),
     refs: { spreadsheetId, sheetId, deleted: true },
   };
 }
@@ -396,7 +421,7 @@ async function duplicateSheetHandler(
 
   const request: Record<string, unknown> = { duplicateSheet: { sourceSheetId } };
   if (newSheetName) (request.duplicateSheet as Record<string, unknown>).newSheetName = newSheetName;
-  if (params.index !== undefined && params.index !== '') {
+  if (params.index !== undefined && params.index !== null && params.index !== '') {
     const idx = Number(params.index);
     if (!Number.isInteger(idx) || idx < 0) {
       throw new Error('index must be a non-negative integer');
@@ -408,7 +433,8 @@ async function duplicateSheetHandler(
   const newProps = ((reply.duplicateSheet as Record<string, unknown>)?.properties ?? {}) as Record<string, unknown>;
 
   return {
-    text: `Sheet duplicated.\n\n**Source sheet ID:** ${sourceSheetId}\n**New sheet ID:** ${newProps.sheetId ?? 'unknown'}\n**New title:** ${newProps.title ?? newSheetName ?? '?'}`,
+    text: `Sheet duplicated.\n\n**Source sheet ID:** ${sourceSheetId}\n**New sheet ID:** ${newProps.sheetId ?? 'unknown'}\n**New title:** ${newProps.title ?? newSheetName ?? '?'}` +
+      nextSteps('sheets', 'duplicateSheet', handlerContext(params, account)),
     refs: { spreadsheetId, sourceSheetId, sheetId: newProps.sheetId, title: newProps.title },
   };
 }
@@ -429,7 +455,8 @@ async function renameSpreadsheetHandler(
   }, account);
 
   return {
-    text: `Spreadsheet renamed.\n\n**Spreadsheet ID:** ${spreadsheetId}\n**New title:** ${title}`,
+    text: `Spreadsheet renamed.\n\n**Spreadsheet ID:** ${spreadsheetId}\n**New title:** ${title}` +
+      nextSteps('sheets', 'renameSpreadsheet', handlerContext(params, account)),
     refs: { spreadsheetId, title },
   };
 }
@@ -454,7 +481,8 @@ async function copySheetToHandler(
 
   const data = (result.data ?? {}) as Record<string, unknown>;
   return {
-    text: `Sheet copied.\n\n**Source:** ${spreadsheetId} (sheet ${sheetId})\n**Destination:** ${destinationSpreadsheetId}\n**New sheet ID:** ${data.sheetId ?? 'unknown'}\n**New title:** ${data.title ?? '?'}`,
+    text: `Sheet copied.\n\n**Source:** ${spreadsheetId} (sheet ${sheetId})\n**Destination:** ${destinationSpreadsheetId}\n**New sheet ID:** ${data.sheetId ?? 'unknown'}\n**New title:** ${data.title ?? '?'}` +
+      nextSteps('sheets', 'copySheetTo', handlerContext(params, account)),
     refs: {
       spreadsheetId,
       sourceSheetId: sheetId,
@@ -475,8 +503,17 @@ export const sheetsPatch: ServicePatch = {
         return formatValuesDetail(data);
       case 'get':
         return formatSpreadsheetDetail(data);
-      default:
-        return formatSpreadsheetDetail(data);
+      default: {
+        // Unknown detail op — render generic key/value rather than silently
+        // routing through formatSpreadsheetDetail and misformatting the response.
+        const raw = (data ?? {}) as Record<string, unknown>;
+        const parts: string[] = [`## ${ctx.operation}`];
+        for (const [key, val] of Object.entries(raw)) {
+          if (val === null || val === undefined || typeof val === 'object') continue;
+          parts.push(`**${key}:** ${val}`);
+        }
+        return { text: parts.join('\n'), refs: raw };
+      }
     }
   },
 

--- a/src/services/sheets/patch.ts
+++ b/src/services/sheets/patch.ts
@@ -147,6 +147,18 @@ function formatCreateAction(data: unknown): HandlerResponse {
   };
 }
 
+function formatClearAction(data: unknown): HandlerResponse {
+  const raw = (data ?? {}) as Record<string, unknown>;
+  const spreadsheetId = String(raw.spreadsheetId ?? '');
+  const clearedRange = String(raw.clearedRange ?? '');
+  return {
+    text: clearedRange
+      ? `Range cleared.\n\n**Range:** ${clearedRange}`
+      : 'Range cleared.',
+    refs: { spreadsheetId, clearedRange },
+  };
+}
+
 function formatAppendAction(data: unknown): HandlerResponse {
   const raw = (data ?? {}) as Record<string, unknown>;
   const spreadsheetId = String(raw.spreadsheetId ?? '');
@@ -437,6 +449,8 @@ export const sheetsPatch: ServicePatch = {
         return formatCreateAction(data);
       case 'append':
         return formatAppendAction(data);
+      case 'clearValues':
+        return formatClearAction(data);
       default: {
         const raw = (data ?? {}) as Record<string, unknown>;
         return {


### PR DESCRIPTION
## Summary

Fixes #90 and expands `manage_sheets` from 6 to 13 agent-facing operations. Sheets tool coverage on the gws surface moves from **32% → 47%** (6/19 → 9/19 unique resources; the 5 batchUpdate-based tab ops share one endpoint). Also fixes two latent bugs discovered during the live-test session.

## What changed

### #90 — read/write bug fix (`19b5303`)
The generic detail formatter in `src/factory/defaults.ts` skipped any object/array field, so `read`/`getValues` dropped the `values` 2D array and `get` dropped the `sheets` list. `updateValues` declared only `spreadsheetId`/`range` with no body wiring, so writes never sent data. New `src/services/sheets/patch.ts`:
- `formatDetail` renders `values` as a pipe-delimited markdown table and shows sheet tabs with dimensions for `get`
- `formatAction` surfaces `create`/`append`/`clearValues` response fields
- `customHandlers.updateValues` assembles the `{values}` body via `--json`, accepts `values` (CSV) or `jsonValues` (JSON 2D array) plus `valueInputOption`

### Tab management (`b0ee618`)
Five new operations, all via `spreadsheets.batchUpdate` with a single-request body:
- `addSheet` — add a tab (optional `title`/`index`/`rowCount`/`columnCount`)
- `renameSheet` — rename a tab by `sheetId`
- `deleteSheet` — remove a tab by `sheetId`
- `duplicateSheet` — clone a tab within the same spreadsheet
- `renameSpreadsheet` — rename the document itself

Plus two more that fit the factory path directly:
- `clearValues` — clear a range (`spreadsheets.values.clear`)
- `copySheetTo` — copy a tab into another spreadsheet (`spreadsheets.sheets.copyTo`)

### `clearValues` formatter polish (`2ee9ff7`)
Surfaces `clearedRange` instead of a generic "Operation completed."

### Append range bug (`1eac654`)
The gws `+append` helper has no `--range` flag and always writes to `Sheet1`. Switched `append` off the helper onto `spreadsheets.values.append` (custom handler) so callers can target a specific tab. Default range remains `Sheet1` for backward compatibility. Extracted a shared `parseValuesInput` helper since `updateValues` and `append` take the same input shape.

### Queue enum gap (`cfa6c1d`)
The `queue_operations` schema enum listed only the four pre-factory tools (email/calendar/drive/accounts + scratchpad/workspace) — so agents couldn't queue operations against the factory-generated tools even though dispatch already handled them. Added `manage_sheets`, `manage_docs`, `manage_tasks`, `manage_meet` to the enum.

## Test plan

- [x] Unit tests — 26 new tests in `src/__tests__/factory/sheets-patch.test.ts` covering all formatters, all custom handlers, body shapes, param validation, and error paths
- [x] `patch-coverage.test.ts` snapshot — sheets now reports 13/13 custom formatted
- [x] `make check` — full CI gate green (383 tests)
- [x] `make coverage` — sheets gws coverage 32% → 47%
- [x] Live verified against a real Google account, each operation individually and then all together via `queue_operations`:
  - `create`, `get`, `read`, `getValues`, `updateValues`, `append`, `clearValues`
  - `addSheet`, `renameSheet`, `deleteSheet`, `duplicateSheet`, `renameSpreadsheet`, `copySheetTo`
  - Formula evaluation under `USER_ENTERED` (cascade through dependent cells confirmed)
  - `queue_operations` with 10 chained sheets operations on factory-generated tools
  - Bonus live test: built a working D&D 5e character sheet (Half-Elf Bard, L6) with reactive formulas — every save/skill/weapon attack/spell DC derived from ability scores and level

## Out of scope

- `manifest.yaml` crossed 1300 lines in this change — the quality hook flagged it. Worth a follow-up ADR to split per-service YAML files with the loader concatenating them.
- Remaining sheets gaps (10 operations): `*ByDataFilter` variants, multi-range batch reads/writes, `developerMetadata.*`. These are esoteric enough to defer.

Closes #90.