### PR TITLE
docs(adr): ADR-303 + ADR-304 for factory follow-ups

### DIFF
--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -38,3 +38,5 @@ _MCP tools, schemas, progressive disclosure_
 | [ADR-300](./api/ADR-300-service-tool-factory-with-manifest-driven-generation.md) | Service tool factory with manifest-driven generation | Draft |
 | [ADR-301](./api/ADR-301-scratchpad-buffer-for-service-agnostic-content-authoring.md) | Scratchpad Buffer — Service-Agnostic Content Authoring | Draft |
 | [ADR-302](./api/ADR-302-scratchpad-html-format-and-format-aware-validation.md) | Scratchpad HTML Format and Format-Aware Validation | Draft |
+| [ADR-303](./api/ADR-303-auto-append-next-steps-in-factory-generator.md) | Auto-append next-steps in factory generator | Draft |
+| [ADR-304](./api/ADR-304-split-manifest-yaml-into-per-service-files.md) | Split manifest.yaml into per-service files | Draft |

--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -38,5 +38,5 @@ _MCP tools, schemas, progressive disclosure_
 | [ADR-300](./api/ADR-300-service-tool-factory-with-manifest-driven-generation.md) | Service tool factory with manifest-driven generation | Draft |
 | [ADR-301](./api/ADR-301-scratchpad-buffer-for-service-agnostic-content-authoring.md) | Scratchpad Buffer — Service-Agnostic Content Authoring | Draft |
 | [ADR-302](./api/ADR-302-scratchpad-html-format-and-format-aware-validation.md) | Scratchpad HTML Format and Format-Aware Validation | Draft |
-| [ADR-303](./api/ADR-303-auto-append-next-steps-in-factory-generator.md) | Auto-append next-steps in factory generator | Draft |
-| [ADR-304](./api/ADR-304-split-manifest-yaml-into-per-service-files.md) | Split manifest.yaml into per-service files | Draft |
+| [ADR-303](./api/ADR-303-auto-append-next-steps-in-factory-generator.md) | Auto-append next-steps in factory generator | Accepted |
+| [ADR-304](./api/ADR-304-split-manifest-yaml-into-per-service-files.md) | Split manifest.yaml into per-service files | Accepted |

--- a/docs/architecture/api/ADR-303-auto-append-next-steps-in-factory-generator.md
+++ b/docs/architecture/api/ADR-303-auto-append-next-steps-in-factory-generator.md
@@ -1,5 +1,5 @@
 ---
-status: Draft
+status: Accepted
 date: 2026-04-15
 deciders:
   - aaronsb

--- a/docs/architecture/api/ADR-303-auto-append-next-steps-in-factory-generator.md
+++ b/docs/architecture/api/ADR-303-auto-append-next-steps-in-factory-generator.md
@@ -1,0 +1,106 @@
+---
+status: Draft
+date: 2026-04-15
+deciders:
+  - aaronsb
+related:
+  - ADR-300
+---
+
+# ADR-303: Auto-append next-steps in factory generator
+
+## Context
+
+The factory generator in `src/factory/generator.ts` appends `nextSteps()` guidance footers only on the resource/helper path (lines 224–230). Custom handlers — registered via `patch.customHandlers[op]` — short-circuit at line 181–183 and return their response directly, bypassing the append step.
+
+Every existing patch works around this by calling `nextSteps('domain', 'op', { email: account })` inline in each handler's return statement:
+
+```ts
+// src/services/docs/patch.ts
+return {
+  text: `Text inserted at index ${index}.\n\n**Document:** ${documentId}...` +
+    nextSteps('docs', 'insertText', { email: account }),
+  refs: { documentId, index, length: text.length },
+};
+```
+
+The convention isn't enforced anywhere — it's a norm the author has to know. PR #103 (sheets expansion, 8 new custom handlers) shipped with the footer calls omitted from every handler. The bug was caught in review, but every future service with custom handlers is one forgotten call away from the same regression.
+
+Every patch that needed context richer than `{email}` also reinvented the same helper:
+
+```ts
+// Introduced in PR #103 review fix — reconstructs what the generator already builds internally
+function handlerContext(params: Record<string, unknown>, account: string): Record<string, string> {
+  const ctx: Record<string, string> = { email: account };
+  for (const [key, value] of Object.entries(params)) {
+    if (typeof value === 'string') ctx[key] = value;
+  }
+  return ctx;
+}
+```
+
+That code duplicates lines 205–209 of the generator. Two copies of the same context-building logic, in different files, maintained independently.
+
+Framing concerns (next-steps, session context injection) are the factory's job. Handlers should produce the response; the factory should frame it.
+
+## Decision
+
+Move `nextSteps()` application out of individual custom handlers and into the factory generator. After a custom handler returns, the generator appends next-steps the same way it does for the resource/helper path.
+
+In `src/factory/generator.ts`, replace:
+
+```ts
+if (patch?.customHandlers?.[operation]) {
+  return patch.customHandlers[operation](params, account);
+}
+```
+
+with an equivalent block that runs after the custom handler resolves, applies the same `contextMap` built from params + account, and uses `patch.nextSteps` override if present or the default `nextSteps(domain, operation, contextMap)` otherwise. The resource/helper path's append becomes the single source of truth for both paths.
+
+Custom handlers return `{ text, refs }` describing just their work — no framing. The generator owns framing.
+
+### Migration
+
+1. Update `src/factory/generator.ts` to append next-steps on the custom-handler path.
+2. Remove inline `nextSteps()` calls from every custom handler in:
+   - `src/services/gmail/patch.ts`
+   - `src/services/calendar/patch.ts`
+   - `src/services/drive/patch.ts`
+   - `src/services/docs/patch.ts`
+   - `src/services/meet/patch.ts`
+   - `src/services/sheets/patch.ts`
+3. Delete the `handlerContext()` helper from `sheets/patch.ts` — the generator's context map subsumes it.
+4. Strip `nextSteps` imports from patch files that no longer need them.
+5. Keep `patch.nextSteps` override hook for services that want per-operation control — it continues to work unchanged.
+
+Both phases land in one commit so no interim state ships a double-append.
+
+## Consequences
+
+### Positive
+
+- Custom handlers can no longer ship dead guidance by forgetting one function call. The failure mode that surfaced in PR #103 review becomes structurally impossible.
+- Single source of truth for the context map that resolves `<email>`, `<spreadsheetId>`, etc. in next-steps placeholders. No more two-copy drift.
+- Custom handlers shrink. Every inline `+ nextSteps(...)` on a return expression goes away.
+- Framing stays where framing lives — the factory already handles session context injection, blocked-policy messages, and afterExecute hooks. Next-steps joins the same lifecycle.
+
+### Negative
+
+- Custom handlers lose per-response control over the footer. A handler can no longer conditionally omit next-steps or craft a response-shape-specific footer.
+  - Mitigation: `patch.nextSteps` override hook still exists and runs per-operation with the same context. A service that needs conditional logic can implement it there.
+  - No existing handler uses conditional next-steps — every current call site is unconditional.
+
+### Neutral
+
+- The migration touches every service patch file. Mechanical change (delete one `+ nextSteps(...)` per return) but broad. Lands as one commit since partial application would cause double-append.
+- Does not change the `nextSteps()` function itself, the `src/server/formatting/next-steps.ts` entries, or the placeholder resolution logic.
+
+## Alternatives Considered
+
+**Keep the convention, add a lint rule.** Write a test or ESLint rule that fails if a custom handler's return doesn't include a `nextSteps(` call. Rejected: enforces the right pattern but doesn't eliminate the duplication, and a lint rule is easy to silence inadvertently. The factory owning the concern is the deeper fix.
+
+**Add a "bring your own next-steps" flag on `HandlerResponse`.** Let handlers opt out of auto-append via a response field. Rejected: solves a problem no existing handler has. Adds API surface for a hypothetical need. If the need arises, it can be added later without breaking callers.
+
+**Wrap custom handlers with a decorator at registration time.** Transform each `customHandlers[op]` function when the patch is imported so every return gets the footer appended. Rejected: hides the behavior one level further (the wrapping happens outside the generator) and makes testing harder — the generator is where the lifecycle is visible and documented.
+
+**Leave it as a convention and document harder.** Add a comment to the `customHandlers` field in `src/factory/types.ts` reminding authors to call `nextSteps()`. Rejected: this is the current state. It failed in PR #103 despite every other patch already doing it. Conventions that only work when you remember them aren't conventions; they're footguns.

--- a/docs/architecture/api/ADR-304-split-manifest-yaml-into-per-service-files.md
+++ b/docs/architecture/api/ADR-304-split-manifest-yaml-into-per-service-files.md
@@ -1,5 +1,5 @@
 ---
-status: Draft
+status: Accepted
 date: 2026-04-15
 deciders:
   - aaronsb

--- a/docs/architecture/api/ADR-304-split-manifest-yaml-into-per-service-files.md
+++ b/docs/architecture/api/ADR-304-split-manifest-yaml-into-per-service-files.md
@@ -1,0 +1,122 @@
+---
+status: Draft
+date: 2026-04-15
+deciders:
+  - aaronsb
+related:
+  - ADR-300
+---
+
+# ADR-304: Split manifest.yaml into per-service files
+
+## Context
+
+`src/factory/manifest.yaml` is now 1383 lines and covers seven services. The quality-check hook has flagged it twice in the last two PRs (sheets fix, sheets expansion) with the 800-line priority threshold. Each new service adds another 100–300 lines; the growth is mechanical, not problematic per service, but the aggregate is.
+
+The per-service breakdown today:
+
+```
+  gmail:    lines 11–278  (268 lines)
+  calendar: lines 279–478 (200 lines)
+  drive:    lines 479–767 (289 lines)
+  sheets:   lines 768–994 (227 lines)
+  docs:     lines 995–1077 (83 lines)
+  tasks:    lines 1078–1220 (143 lines)
+  meet:     lines 1221–1383 (163 lines)
+```
+
+Each service's block is self-contained. Cross-service references do not exist — every operation's params, resource, helper, and defaults live entirely within its service block. The file is a concatenation of independent sections that happen to share a YAML root.
+
+Editing one service means scrolling past all the others. A merge conflict in gmail's operations routinely touches the same file as an unrelated sheets change. `git blame` on a single service's operation loses context quickly because line numbers shift when neighbors grow. The coverage linter's output and the `manifest-lint` Makefile target both operate on the whole file; neither benefits from the bundling.
+
+The other side of the codebase — service-specific handler logic — is already split per service: `src/services/gmail/patch.ts`, `src/services/calendar/patch.ts`, etc. The manifest is the last single-file concession to historical organization, from when the factory was strictly manifest-driven with no patches.
+
+## Decision
+
+Replace the single `src/factory/manifest.yaml` with a directory of per-service files at `src/factory/manifest/`:
+
+```
+src/factory/manifest/
+  gmail.yaml
+  calendar.yaml
+  drive.yaml
+  sheets.yaml
+  docs.yaml
+  tasks.yaml
+  meet.yaml
+```
+
+Each file contains just that service's definition as the YAML root — no enclosing `services:` key. The filename (minus `.yaml`) is the service key:
+
+```yaml
+# src/factory/manifest/sheets.yaml
+tool_name: manage_sheets
+description: "Read, write, and manage Google Sheets spreadsheets."
+requires_email: true
+gws_service: sheets
+operations:
+  get:
+    type: detail
+    ...
+```
+
+`loadManifest()` enumerates the directory, parses each file, and assembles a `Manifest` with the same shape it returns today:
+
+```ts
+// pseudo-code
+const files = readdirSync(manifestDir).filter(f => f.endsWith('.yaml'));
+const services: Record<string, ServiceDef> = {};
+for (const file of files) {
+  const name = basename(file, '.yaml');
+  services[name] = parseYaml(readFileSync(resolve(manifestDir, file), 'utf-8'));
+}
+return { services };
+```
+
+The loader's search strategy (module-relative → cwd fallback, for Jest + mcpb compatibility) gets reused — just pointing at the directory instead of the file.
+
+### Migration
+
+1. Create `src/factory/manifest/` with one file per service, content taken verbatim from the current sections.
+2. Update `src/factory/generator.ts` `loadManifest()` to enumerate the directory.
+3. Update `Makefile`:
+   - `build:` copies `src/factory/manifest/` recursively to `build/factory/manifest/` instead of the single file.
+   - `manifest-lint:` walks the directory (trivial adapt).
+   - `mcpb:` ships the directory in the bundle.
+4. Update `scripts/gen-manifest.sh` references if any (used only for discovery output, not the runtime manifest).
+5. Delete `src/factory/manifest.yaml`.
+
+The split is mechanical — cut each service's YAML section into its own file, adjust indentation to bring the service's body up one level (strip the leading two-space indent from the children of `  gmail:`, etc.).
+
+## Consequences
+
+### Positive
+
+- No file above ~300 lines. The quality-check hook's recurring flag on this file goes away.
+- Adding a service is now one new file, not an edit to a growing shared file. Zero merge contention between services.
+- `git blame` on a service's operations stays stable over time — line numbers don't drift because of unrelated neighbors.
+- Editing context is focused. You open the file for the service you're changing, and only that service's content is on screen.
+- Symmetrical with the patch organization already in `src/services/*/patch.ts` — both layers are now per-service.
+
+### Negative
+
+- One-time migration touches every service block. Large diff, but mechanical; `git log --follow` preserves history per file after the split.
+- `loadManifest()` now does filesystem enumeration instead of a single `readFileSync`. Negligible cost at startup (a handful of small files) but worth noting.
+- Bundling for mcpb is now a directory copy instead of a file copy. One-line Makefile change.
+- A service with a malformed YAML file now loads *everyone else* successfully while dropping the malformed one. Decision: fail hard on any malformed file to preserve current whole-or-nothing behavior.
+
+### Neutral
+
+- The `Manifest` type and `generateTools()` API stay identical. Only `loadManifest()` changes.
+- The `manifest-discover` / `manifest-diff` tooling (which produces a single `discovered-manifest.yaml`) is unaffected; it was always independent of the curated manifest's file layout.
+- ADR-303 (auto-append next-steps) is orthogonal to this split and can land before or after.
+
+## Alternatives Considered
+
+**Co-locate manifest files with service patches under `src/services/<name>/manifest.yaml`.** More cohesive — everything for a service lives in one directory. Rejected for this ADR because it's a larger migration (the build pipeline's tsc output tree would need to include non-TS assets from `src/services/`, and the loader would need to know about both locations during the transition). Worth a follow-up if it becomes compelling; the primary goal here is breaking up the single file, which `src/factory/manifest/` accomplishes with minimal surface area change.
+
+**Keep `manifest.yaml`, introduce YAML anchors or `$include` references.** Some YAML parsers support file includes via custom tags. Rejected: our parser (`src/factory/yaml.ts`) is a simple subset that doesn't support includes, and adding that capability means maintaining it. The filesystem already does "include" semantics for free.
+
+**Split by domain instead of service** (e.g., `communication.yaml` for gmail+meet+chat, `storage.yaml` for drive+docs+sheets+tasks). Rejected: domains are fuzzier than services, adding judgment calls about which bucket a new service goes in. Service-per-file is the natural grain of the existing structure.
+
+**Leave it as one file and raise the quality-check threshold for YAML.** The hook's 800-line rule targets code files where cognitive load scales with length. YAML data files are arguably different. Rejected: the file-size pain is real (scrolling, merge conflicts, noisy blame) independent of what the linter says. Splitting solves the underlying ergonomics problem, not just the linter complaint.


### PR DESCRIPTION
Two ADRs capturing follow-ups flagged during the sheets expansion (PR #103):

**ADR-303 — Auto-append next-steps in factory generator**
Moves the `nextSteps()` footer append out of every custom handler and into the generator. PR #103 shipped 8 new custom handlers that all forgot the inline `nextSteps()` call — blocker caught in review, fixed in `8ee3c8a`. This ADR prevents the class of bug by making the generator own framing.

**ADR-304 — Split manifest.yaml into per-service files**
`src/factory/manifest.yaml` is 1383 lines and has been flagged by the quality-check hook on two consecutive PRs. Each service's block is self-contained, so a directory of per-service files (`src/factory/manifest/`) is the natural shape. Loader enumerates the directory.

Orthogonal — can land in either order.

## Test plan
- [x] `docs/scripts/adr lint` clean
- [x] Index regenerated (`docs/scripts/adr index -y`)
- [ ] Decide status (Draft vs promote to Accepted)