### PR TITLE
feat(factory): implement ADR-303 — auto-append next-steps in generator

### DIFF
--- a/src/__tests__/factory/generator.test.ts
+++ b/src/__tests__/factory/generator.test.ts
@@ -215,3 +215,75 @@ describe('generateHandler', () => {
     expect(result.refs).toHaveProperty('count', 2);
   });
 });
+
+// ADR-303: the generator appends next-steps for custom handlers, so patches
+// no longer need to call nextSteps() inline. This is the architectural
+// guarantee that replaces the per-handler regression tests.
+describe('generateHandler — custom-handler next-steps wrapping', () => {
+  const manifest = loadManifest();
+
+  beforeEach(() => mockExecute.mockReset());
+
+  it('appends next-steps to a custom handler response', async () => {
+    // sheets.addSheet is a customHandler — its handler return has no footer,
+    // but the factory should wrap with one from the next-steps registry.
+    mockExecute.mockResolvedValueOnce({
+      success: true,
+      data: { replies: [{ addSheet: { properties: { sheetId: 42, title: 'T', gridProperties: {} } } }] },
+      stderr: '',
+    });
+
+    const handler = generateHandler(manifest.services.sheets, patches.sheets);
+    const result = await handler({
+      operation: 'addSheet',
+      email: 'u@t.com',
+      spreadsheetId: 'sheet-123',
+      title: 'T',
+    });
+
+    expect(result.text).toContain('Sheet added');
+    expect(result.text).toContain('Next steps:');
+  });
+
+  it('resolves placeholder values from the input params on custom handlers', async () => {
+    mockExecute.mockResolvedValueOnce({
+      success: true,
+      data: { replies: [{}] },
+      stderr: '',
+    });
+
+    const handler = generateHandler(manifest.services.sheets, patches.sheets);
+    const result = await handler({
+      operation: 'renameSheet',
+      email: 'u@t.com',
+      spreadsheetId: 'sheet-xyz',
+      sheetId: 0,
+      title: 'Main',
+    });
+
+    // The sheets.renameSheet next-steps entry references <spreadsheetId> —
+    // the generator's contextMap should have resolved it.
+    expect(result.text).toContain('sheet-xyz');
+    expect(result.text).not.toContain('<spreadsheetId>');
+  });
+
+  it('does not double-append next-steps (regression for ADR-303 migration)', async () => {
+    mockExecute.mockResolvedValueOnce({
+      success: true,
+      data: { replies: [{ addSheet: { properties: { sheetId: 99, title: 'Q', gridProperties: {} } } }] },
+      stderr: '',
+    });
+
+    const handler = generateHandler(manifest.services.sheets, patches.sheets);
+    const result = await handler({
+      operation: 'addSheet',
+      email: 'u@t.com',
+      spreadsheetId: 'sheet-123',
+      title: 'Q',
+    });
+
+    // Exactly one footer marker in the response
+    const matches = result.text.match(/---\n\*\*Next steps:\*\*/g) ?? [];
+    expect(matches.length).toBe(1);
+  });
+});

--- a/src/__tests__/factory/sheets-patch.test.ts
+++ b/src/__tests__/factory/sheets-patch.test.ts
@@ -617,47 +617,6 @@ describe('sheetsPatch customHandlers.copySheetTo', () => {
   });
 });
 
-describe('sheetsPatch — nextSteps guidance (regression for PR #103 review)', () => {
-  beforeEach(() => mockExecute.mockReset());
-
-  it('updateValues appends next-steps footer to response text', async () => {
-    mockExecute.mockResolvedValueOnce({
-      success: true,
-      data: { spreadsheetId: 'sheet123', updatedRange: 'Sheet1!A1:B1', updatedRows: 1, updatedColumns: 2, updatedCells: 2 },
-      stderr: '',
-    });
-    const handler = sheetsPatch.customHandlers!.updateValues!;
-    const res = await handler(
-      { spreadsheetId: 'sheet123', range: 'Sheet1!A1', jsonValues: '[["a","b"]]' },
-      'user@test.com',
-    );
-    expect(res.text).toContain('Next steps:');
-    expect(res.text).toContain('manage_sheets');
-  });
-
-  it('addSheet appends next-steps footer', async () => {
-    mockExecute.mockResolvedValueOnce({
-      success: true,
-      data: { replies: [{ addSheet: { properties: { sheetId: 42, title: 'T', gridProperties: {} } } }] },
-      stderr: '',
-    });
-    const handler = sheetsPatch.customHandlers!.addSheet!;
-    const res = await handler(
-      { spreadsheetId: 'sheet123', title: 'T' },
-      'user@test.com',
-    );
-    expect(res.text).toContain('Next steps:');
-  });
-
-  it('resolves spreadsheetId placeholder from handler context', async () => {
-    mockExecute.mockResolvedValueOnce({ success: true, data: { replies: [{}] }, stderr: '' });
-    const handler = sheetsPatch.customHandlers!.renameSheet!;
-    const res = await handler(
-      { spreadsheetId: 'sheet-xyz', sheetId: 0, title: 'Main' },
-      'user@test.com',
-    );
-    // Next-steps entry for renameSheet references <spreadsheetId> — verify resolution
-    expect(res.text).toContain('sheet-xyz');
-    expect(res.text).not.toContain('<spreadsheetId>');
-  });
-});
+// Next-steps framing is now handled by the factory generator (ADR-303)
+// rather than each custom handler. See generator.test.ts for the regression
+// test that custom-handler responses receive the footer via the wrapper.

--- a/src/factory/generator.ts
+++ b/src/factory/generator.ts
@@ -177,9 +177,28 @@ export function generateHandler(
       };
     }
 
-    // Check for a fully custom handler first
+    // Context map for next-steps placeholder resolution — built once,
+    // used whether the request goes through a custom handler or the
+    // factory path.
+    const contextMap: Record<string, string> = { email: account };
+    for (const [key, value] of Object.entries(params)) {
+      if (typeof value === 'string') contextMap[key] = value;
+    }
+
+    const framingFooter = (): string =>
+      patch?.nextSteps
+        ? patch.nextSteps(operation, contextMap)
+        : nextSteps(domain, operation, contextMap);
+
+    // Check for a fully custom handler first. The generator still owns
+    // framing (next-steps append) — handlers produce the response text;
+    // the factory frames it. See ADR-303.
     if (patch?.customHandlers?.[operation]) {
-      return patch.customHandlers[operation](params, account);
+      const response = await patch.customHandlers[operation](params, account);
+      return {
+        ...response,
+        text: response.text + framingFooter(),
+      };
     }
 
     // Build gws args
@@ -201,13 +220,6 @@ export function generateHandler(
       data = await patch.afterExecute[operation](data, ctx);
     }
 
-    // Format response
-    const contextMap: Record<string, string> = { email: account };
-    // Add relevant param values to context for next-steps placeholder resolution
-    for (const [key, value] of Object.entries(params)) {
-      if (typeof value === 'string') contextMap[key] = value;
-    }
-
     let formatted: HandlerResponse;
 
     // Check for patch formatters by operation type
@@ -221,14 +233,9 @@ export function generateHandler(
       formatted = formatDefault(data, opDef);
     }
 
-    // Append next-steps
-    const stepsText = patch?.nextSteps
-      ? patch.nextSteps(operation, contextMap)
-      : nextSteps(domain, operation, contextMap);
-
     return {
-      text: formatted.text + stepsText,
-      refs: formatted.refs,
+      ...formatted,
+      text: formatted.text + framingFooter(),
     };
   };
 }

--- a/src/services/calendar/patch.ts
+++ b/src/services/calendar/patch.ts
@@ -11,7 +11,6 @@
 
 import { execute } from '../../executor/gws.js';
 import { formatEventList, formatEventDetail } from '../../server/formatting/markdown.js';
-import { nextSteps } from '../../server/formatting/next-steps.js';
 import { requireString } from '../../server/handlers/validate.js';
 import type { ServicePatch, PatchContext } from '../../factory/types.js';
 import type { HandlerResponse } from '../../server/formatting/markdown.js';
@@ -92,7 +91,7 @@ function formatFreeBusy(data: unknown, ctx: PatchContext): HandlerResponse {
   }
 
   return {
-    text: parts.join('\n') + nextSteps('calendar', 'freebusy', { email: ctx.account }),
+    text: parts.join('\n'),
     refs: {
       calendars: Object.keys(calendars),
       busyBlocks: allBusy,
@@ -109,7 +108,7 @@ function formatAgenda(data: unknown, account: string): HandlerResponse {
   const text = typeof data === 'string' ? data : JSON.stringify(data, null, 2);
 
   return {
-    text: text + nextSteps('calendar', 'agenda', { email: account }),
+    text,
     refs: {
       count: events.length,
       eventId: events[0]?.id as string | undefined,
@@ -213,8 +212,7 @@ export const calendarPatch: ServicePatch = {
           `**When:** ${start} – ${end}\n` +
           (params.location ? `**Where:** ${params.location}\n` : '') +
           `**Calendar:** ${calendarId}\n` +
-          `**Event ID:** ${data.id ?? 'unknown'}` +
-          nextSteps('calendar', 'create', { email: account }),
+          `**Event ID:** ${data.id ?? 'unknown'}`,
         refs: { id: data.id, eventId: data.id, calendarId, summary, start, end },
       };
     },
@@ -227,7 +225,7 @@ export const calendarPatch: ServicePatch = {
         '--params', JSON.stringify({ calendarId, eventId }),
       ], { account });
       return {
-        text: `Event deleted: ${eventId}` + nextSteps('calendar', 'delete', { email: account }),
+        text: `Event deleted: ${eventId}`,
         refs: { eventId, status: 'deleted' },
       };
     },

--- a/src/services/docs/patch.ts
+++ b/src/services/docs/patch.ts
@@ -6,7 +6,6 @@
  */
 
 import { execute } from '../../executor/gws.js';
-import { nextSteps } from '../../server/formatting/next-steps.js';
 import { requireString } from '../../server/handlers/validate.js';
 import type { ServicePatch } from '../../factory/types.js';
 import type { HandlerResponse } from '../../server/formatting/markdown.js';
@@ -37,8 +36,7 @@ export const docsPatch: ServicePatch = {
       ], { account });
 
       return {
-        text: `Text inserted at index ${index}.\n\n**Document:** ${documentId}\n**Inserted:** ${text.length} characters` +
-          nextSteps('docs', 'insertText', { email: account }),
+        text: `Text inserted at index ${index}.\n\n**Document:** ${documentId}\n**Inserted:** ${text.length} characters`,
         refs: { documentId, index, length: text.length },
       };
     },
@@ -74,8 +72,7 @@ export const docsPatch: ServicePatch = {
       const occurrences = replaceReply?.occurrencesChanged || 0;
 
       return {
-        text: `Text replaced.\n\n**Document:** ${documentId}\n**Found:** "${findText}"\n**Replaced with:** "${replaceWith}"\n**Occurrences:** ${occurrences}` +
-          nextSteps('docs', 'replaceText', { email: account }),
+        text: `Text replaced.\n\n**Document:** ${documentId}\n**Found:** "${findText}"\n**Replaced with:** "${replaceWith}"\n**Occurrences:** ${occurrences}`,
         refs: { documentId, occurrences },
       };
     },

--- a/src/services/drive/patch.ts
+++ b/src/services/drive/patch.ts
@@ -12,7 +12,6 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { execute } from '../../executor/gws.js';
 import { formatFileList, formatFileDetail } from '../../server/formatting/markdown.js';
-import { nextSteps } from '../../server/formatting/next-steps.js';
 import { requireString } from '../../server/handlers/validate.js';
 import { ensureWorkspaceDir, getWorkspaceDir, resolveWorkspacePath, verifyPathSafety } from '../../executor/workspace.js';
 import { isTextFile, formatFileOutput, buildImageBlock, buildImageBlockFromFile, isImageFile, type FileOutputResult } from '../../executor/file-output.js';
@@ -51,8 +50,7 @@ export const drivePatch: ServicePatch = {
       const result = await execute(args, { account });
       const data = result.data as Record<string, unknown>;
       return {
-        text: `File uploaded: **${data.name ?? filePath}**\n\n**File ID:** ${data.id ?? 'unknown'}` +
-          nextSteps('drive', 'upload', { email: account }),
+        text: `File uploaded: **${data.name ?? filePath}**\n\n**File ID:** ${data.id ?? 'unknown'}`,
         refs: { id: data.id, fileId: data.id, name: data.name },
       };
     },
@@ -89,7 +87,7 @@ export const drivePatch: ServicePatch = {
       const output = await readWorkspaceFile(outputPath, filename, mimeType);
 
       return {
-        text: formatFileOutput(output) + nextSteps('drive', 'download', { email: account }),
+        text: formatFileOutput(output),
         refs: {
           fileId,
           filename: output.filename,
@@ -188,7 +186,7 @@ export const drivePatch: ServicePatch = {
       const output = await readWorkspaceFile(outputPath, filename, mimeType);
 
       return {
-        text: formatFileOutput(output) + nextSteps('drive', 'export', { email: account }),
+        text: formatFileOutput(output),
         refs: {
           fileId,
           filename: output.filename,
@@ -219,8 +217,7 @@ export const drivePatch: ServicePatch = {
 
       if (comments.length === 0) {
         return {
-          text: 'No comments on this file.' +
-            nextSteps('drive', 'listComments', { email: account }),
+          text: 'No comments on this file.',
           refs: { fileId, count: 0 },
         };
       }
@@ -243,8 +240,7 @@ export const drivePatch: ServicePatch = {
       });
 
       return {
-        text: `## Comments (${comments.length})\n\n${lines.join('\n\n')}` +
-          nextSteps('drive', 'listComments', { email: account }),
+        text: `## Comments (${comments.length})\n\n${lines.join('\n\n')}`,
         refs: { fileId, count: comments.length },
       };
     },
@@ -276,8 +272,7 @@ export const drivePatch: ServicePatch = {
 
       return {
         text: `## Comment by ${author}${resolved}\n\n${c.content}${quoted}\n\n**Created:** ${c.createdTime}\n**Modified:** ${c.modifiedTime}` +
-          (replyLines ? `\n\n### Replies\n\n${replyLines}` : '') +
-          nextSteps('drive', 'getComment', { email: account }),
+          (replyLines ? `\n\n### Replies\n\n${replyLines}` : ''),
         refs: { commentId: c.id, fileId, resolved: c.resolved },
       };
     },
@@ -304,8 +299,7 @@ export const drivePatch: ServicePatch = {
       const data = result.data as Record<string, unknown>;
       return {
         text: `Comment added.\n\n**ID:** ${data.id}\n**Content:** ${data.content}` +
-          (quotedText ? `\n**Anchored to:** "${quotedText}"` : '') +
-          nextSteps('drive', 'addComment', { email: account }),
+          (quotedText ? `\n**Anchored to:** "${quotedText}"` : ''),
         refs: { commentId: data.id, fileId },
       };
     },
@@ -342,8 +336,7 @@ export const drivePatch: ServicePatch = {
       ], { account });
       const data = result.data as Record<string, unknown>;
       return {
-        text: `Comment ${resolved ? 'resolved' : 'reopened'}.\n\n**ID:** ${data.id}\n**Resolved:** ${resolved}` +
-          nextSteps('drive', 'resolveComment', { email: account }),
+        text: `Comment ${resolved ? 'resolved' : 'reopened'}.\n\n**ID:** ${data.id}\n**Resolved:** ${resolved}`,
         refs: { commentId: data.id, fileId, resolved },
       };
     },
@@ -365,8 +358,7 @@ export const drivePatch: ServicePatch = {
       ], { account });
       const data = result.data as Record<string, unknown>;
       return {
-        text: `Reply added.\n\n**ID:** ${data.id}\n**Content:** ${data.content}` +
-          nextSteps('drive', 'replyToComment', { email: account }),
+        text: `Reply added.\n\n**ID:** ${data.id}\n**Content:** ${data.content}`,
         refs: { replyId: data.id, commentId, fileId },
       };
     },

--- a/src/services/gmail/patch.ts
+++ b/src/services/gmail/patch.ts
@@ -11,7 +11,6 @@ import * as path from 'node:path';
 import { execute } from '../../executor/gws.js';
 import { resolveWorkspacePath, verifyPathSafety, getWorkspaceDir } from '../../executor/workspace.js';
 import { formatEmailList, formatEmailDetail, extractBodyFromPayload } from '../../server/formatting/markdown.js';
-import { nextSteps } from '../../server/formatting/next-steps.js';
 import { requireString } from '../../server/handlers/validate.js';
 import { handleGetAttachment, handleViewAttachment } from './attachments.js';
 import type { ServicePatch, PatchContext } from '../../factory/types.js';
@@ -247,15 +246,13 @@ export const gmailPatch: ServicePatch = {
 
       if (draft || attachmentNames.length > 0) {
         return {
-          text: `Draft created for ${to}.\n\n**Subject:** ${subject}${attachNote}\n**Draft ID:** ${data.id ?? 'unknown'}` +
-            nextSteps('email', 'draft', { email: account }),
+          text: `Draft created for ${to}.\n\n**Subject:** ${subject}${attachNote}\n**Draft ID:** ${data.id ?? 'unknown'}`,
           refs: { id: data.id, draftId: data.id, to, subject, attachments: attachmentNames, isDraft: true },
         };
       }
 
       return {
-        text: `Email sent to ${to}.\n\n**Subject:** ${subject}\n**Message ID:** ${data.id ?? 'unknown'}` +
-          nextSteps('email', 'send', { email: account }),
+        text: `Email sent to ${to}.\n\n**Subject:** ${subject}\n**Message ID:** ${data.id ?? 'unknown'}`,
         refs: { id: data.id, threadId: data.threadId, to, subject },
       };
     },
@@ -285,8 +282,7 @@ export const gmailPatch: ServicePatch = {
       const data = result.data as Record<string, unknown>;
       const labels = (data.labelIds ?? []) as string[];
       return {
-        text: `Labels updated on ${messageId}.\n\n**Current labels:** ${labels.join(', ') || '(none)'}` +
-          nextSteps('email', 'modify', { email: account }),
+        text: `Labels updated on ${messageId}.\n\n**Current labels:** ${labels.join(', ') || '(none)'}`,
         refs: { messageId, labelIds: labels },
       };
     },
@@ -302,8 +298,7 @@ export const gmailPatch: ServicePatch = {
       ], { account });
       const data = result.data as Record<string, unknown>;
       return {
-        text: `Reply sent.\n\n**Message ID:** ${data.id ?? 'unknown'}` +
-          nextSteps('email', 'reply', { email: account }),
+        text: `Reply sent.\n\n**Message ID:** ${data.id ?? 'unknown'}`,
         refs: { id: data.id, threadId: data.threadId, messageId },
       };
     },

--- a/src/services/meet/patch.ts
+++ b/src/services/meet/patch.ts
@@ -10,7 +10,6 @@
  */
 
 import { execute } from '../../executor/gws.js';
-import { nextSteps } from '../../server/formatting/next-steps.js';
 import type { ServicePatch, PatchContext } from '../../factory/types.js';
 import type { HandlerResponse } from '../../server/formatting/markdown.js';
 
@@ -416,8 +415,7 @@ async function getFullTranscript(
   }
 
   return {
-    text: `## Transcript (${entries.length} entries)\n\n${blocks.join('\n\n')}${footer.join('')}` +
-      nextSteps('meet', 'getFullTranscript', { email: account, conferenceId: confId }),
+    text: `## Transcript (${entries.length} entries)\n\n${blocks.join('\n\n')}${footer.join('')}`,
     refs: {
       conferenceId: confId,
       transcriptName,

--- a/src/services/sheets/patch.ts
+++ b/src/services/sheets/patch.ts
@@ -15,26 +15,11 @@
  */
 
 import { execute } from '../../executor/gws.js';
-import { nextSteps } from '../../server/formatting/next-steps.js';
 import { requireString } from '../../server/handlers/validate.js';
 import type { ServicePatch, PatchContext } from '../../factory/types.js';
 import type { HandlerResponse } from '../../server/formatting/markdown.js';
 
 // --- Helpers ---
-
-/**
- * Build a string-only context map for next-steps placeholder resolution.
- * The factory path builds an equivalent map internally; custom handlers
- * skip that path, so we reconstruct it here to keep placeholders like
- * `<spreadsheetId>` and `<range>` resolving in the guidance footer.
- */
-function handlerContext(params: Record<string, unknown>, account: string): Record<string, string> {
-  const ctx: Record<string, string> = { email: account };
-  for (const [key, value] of Object.entries(params)) {
-    if (typeof value === 'string') ctx[key] = value;
-  }
-  return ctx;
-}
 
 /** Escape a pipe so it doesn't break the markdown table. */
 function escapeCell(val: unknown): string {
@@ -258,7 +243,7 @@ async function updateValuesHandler(
   parts.push(`\n**Cells:** ${updatedCells}`, `\n**Value input:** ${valueInputOption}`);
 
   return {
-    text: parts.join('') + nextSteps('sheets', 'updateValues', handlerContext(params, account)),
+    text: parts.join(''),
     refs: { spreadsheetId, updatedRange, updatedRows, updatedCells, updatedColumns, valueInputOption },
   };
 }
@@ -289,11 +274,7 @@ async function appendHandler(
     '--json', JSON.stringify({ range, majorDimension: 'ROWS', values }),
   ], { account });
 
-  const formatted = formatAppendAction(result.data);
-  return {
-    ...formatted,
-    text: formatted.text + nextSteps('sheets', 'append', handlerContext(params, account)),
-  };
+  return formatAppendAction(result.data);
 }
 
 /** Parse a sheetId param — Google assigns integers and `0` is valid. */
@@ -364,8 +345,7 @@ async function addSheetHandler(
   const grid = (addedProps.gridProperties ?? {}) as Record<string, unknown>;
 
   return {
-    text: `Sheet added: **${newTitle}**\n\n**Sheet ID:** ${newSheetId}\n**Rows:** ${grid.rowCount ?? '?'}\n**Columns:** ${grid.columnCount ?? '?'}` +
-      nextSteps('sheets', 'addSheet', handlerContext(params, account)),
+    text: `Sheet added: **${newTitle}**\n\n**Sheet ID:** ${newSheetId}\n**Rows:** ${grid.rowCount ?? '?'}\n**Columns:** ${grid.columnCount ?? '?'}`,
     refs: { spreadsheetId, sheetId: newSheetId, title: newTitle },
   };
 }
@@ -387,8 +367,7 @@ async function renameSheetHandler(
   }, account);
 
   return {
-    text: `Sheet renamed.\n\n**Sheet ID:** ${sheetId}\n**New title:** ${title}` +
-      nextSteps('sheets', 'renameSheet', handlerContext(params, account)),
+    text: `Sheet renamed.\n\n**Sheet ID:** ${sheetId}\n**New title:** ${title}`,
     refs: { spreadsheetId, sheetId, title },
   };
 }
@@ -404,8 +383,7 @@ async function deleteSheetHandler(
   await runBatchUpdate(spreadsheetId, { deleteSheet: { sheetId } }, account);
 
   return {
-    text: `Sheet deleted.\n\n**Sheet ID:** ${sheetId}` +
-      nextSteps('sheets', 'deleteSheet', handlerContext(params, account)),
+    text: `Sheet deleted.\n\n**Sheet ID:** ${sheetId}`,
     refs: { spreadsheetId, sheetId, deleted: true },
   };
 }
@@ -433,8 +411,7 @@ async function duplicateSheetHandler(
   const newProps = ((reply.duplicateSheet as Record<string, unknown>)?.properties ?? {}) as Record<string, unknown>;
 
   return {
-    text: `Sheet duplicated.\n\n**Source sheet ID:** ${sourceSheetId}\n**New sheet ID:** ${newProps.sheetId ?? 'unknown'}\n**New title:** ${newProps.title ?? newSheetName ?? '?'}` +
-      nextSteps('sheets', 'duplicateSheet', handlerContext(params, account)),
+    text: `Sheet duplicated.\n\n**Source sheet ID:** ${sourceSheetId}\n**New sheet ID:** ${newProps.sheetId ?? 'unknown'}\n**New title:** ${newProps.title ?? newSheetName ?? '?'}`,
     refs: { spreadsheetId, sourceSheetId, sheetId: newProps.sheetId, title: newProps.title },
   };
 }
@@ -455,8 +432,7 @@ async function renameSpreadsheetHandler(
   }, account);
 
   return {
-    text: `Spreadsheet renamed.\n\n**Spreadsheet ID:** ${spreadsheetId}\n**New title:** ${title}` +
-      nextSteps('sheets', 'renameSpreadsheet', handlerContext(params, account)),
+    text: `Spreadsheet renamed.\n\n**Spreadsheet ID:** ${spreadsheetId}\n**New title:** ${title}`,
     refs: { spreadsheetId, title },
   };
 }
@@ -481,8 +457,7 @@ async function copySheetToHandler(
 
   const data = (result.data ?? {}) as Record<string, unknown>;
   return {
-    text: `Sheet copied.\n\n**Source:** ${spreadsheetId} (sheet ${sheetId})\n**Destination:** ${destinationSpreadsheetId}\n**New sheet ID:** ${data.sheetId ?? 'unknown'}\n**New title:** ${data.title ?? '?'}` +
-      nextSteps('sheets', 'copySheetTo', handlerContext(params, account)),
+    text: `Sheet copied.\n\n**Source:** ${spreadsheetId} (sheet ${sheetId})\n**Destination:** ${destinationSpreadsheetId}\n**New sheet ID:** ${data.sheetId ?? 'unknown'}\n**New title:** ${data.title ?? '?'}`,
     refs: {
       spreadsheetId,
       sourceSheetId: sheetId,


### PR DESCRIPTION
Implements [ADR-303](../blob/main/docs/architecture/api/ADR-303-auto-append-next-steps-in-factory-generator.md) (accepted in #104).

## Summary

The factory generator now wraps **both** the custom-handler path and the resource/helper path with `nextSteps()` framing. Custom handlers can no longer ship dead guidance by forgetting an inline call — the failure mode that surfaced in PR #103 review becomes structurally impossible.

## What changed

**Generator** (`src/factory/generator.ts`)
- Build `contextMap` once before branching instead of inside the resource/helper path only
- Extract `framingFooter()` closure used by both paths
- Wrap the custom-handler return with the same next-steps append

**Patches** — removed 26 inline `nextSteps()` calls + imports:
| file | calls removed |
|---|---|
| calendar/patch.ts | 4 |
| drive/patch.ts | 9 |
| gmail/patch.ts | 4 |
| docs/patch.ts | 2 |
| meet/patch.ts | 1 |
| sheets/patch.ts | 8 |

Also deleted the `handlerContext()` helper from `sheets/patch.ts` (added in the PR #103 review fix) — it reconstructed what the generator's `contextMap` already builds.

**Tests**
- Removed per-handler regression tests in `sheets-patch.test.ts` (obsolete — handlers no longer add the footer themselves)
- Added generator-level tests in `generator.test.ts`:
  - custom handlers get the footer appended
  - placeholders like `<spreadsheetId>` resolve from handler context
  - no double-append (regression during the migration)

## Test plan

- [x] `make check` — 390 tests pass
- [x] Single-commit migration (both generator wrap + handler cleanup ship together to avoid interim double-append)