### PR TITLE
fix(mcpb): anchor .mcpbignore, add post-pack bundle verification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,7 @@ mcpb: build ## Build .mcpb for current platform (PLATFORM=linux-x64 etc.)
 	rm -f mcpb/server/package.json mcpb/server/package-lock.json
 	./scripts/download-gws-binary.sh $(PLATFORM) $(GWS_VERSION)
 	mcpb pack mcpb google-workspace-mcp-$(PLATFORM).mcpb
+	node scripts/verify-mcpb.cjs google-workspace-mcp-$(PLATFORM).mcpb
 	@echo ""
 	@echo "Built: google-workspace-mcp-$(PLATFORM).mcpb ($$(du -h google-workspace-mcp-$(PLATFORM).mcpb | cut -f1))"
 

--- a/mcpb/.mcpbignore
+++ b/mcpb/.mcpbignore
@@ -1,16 +1,20 @@
-# Exclude dev artifacts from .mcpb bundle
+# Exclude dev artifacts from .mcpb bundle.
+# Leading `/` anchors patterns to the bundle root so they do NOT match
+# nested paths. Unanchored `docs/` in v2.6.0 matched server/services/docs/
+# and dropped the compiled Docs service handler from the bundle,
+# crashing the server at import time. Anchor everything directory-shaped.
 *.map
 *.test.js
 *.test.d.ts
-__tests__/
-.github/
-docs/
-scripts/
-src/
-*.md
-.eslintrc*
-tsconfig.json
-jest.config*
-Makefile
-discovered-manifest.yaml
-.claude/
+/__tests__/
+/.github/
+/docs/
+/scripts/
+/src/
+/.claude/
+/.eslintrc*
+/tsconfig.json
+/jest.config*
+/Makefile
+/discovered-manifest.yaml
+/*.md

--- a/scripts/verify-mcpb.cjs
+++ b/scripts/verify-mcpb.cjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+/**
+ * Post-pack sanity check — inspects a packed .mcpb bundle and fails
+ * if any file imported from build/factory/patches.js is absent.
+ *
+ * History: v2.6.0 shipped with `docs/` as an unanchored entry in
+ * .mcpbignore, which silently matched server/services/docs/ and
+ * dropped the compiled Docs patch. The server crashed at import
+ * time with ERR_MODULE_NOT_FOUND. This script catches that class
+ * of regression before release.
+ *
+ * Usage: node scripts/verify-mcpb.cjs <bundle.mcpb>
+ */
+
+const fs = require('node:fs');
+const { execSync } = require('node:child_process');
+const path = require('node:path');
+
+const bundle = process.argv[2];
+if (!bundle) {
+  console.error('usage: verify-mcpb.cjs <path-to-mcpb>');
+  process.exit(2);
+}
+if (!fs.existsSync(bundle)) {
+  console.error(`bundle not found: ${bundle}`);
+  process.exit(2);
+}
+
+// Read every file that build/factory/patches.js imports. Expected shape:
+//   import { gmailPatch } from '../services/gmail/patch.js';
+const patchesSource = fs.readFileSync(
+  path.join(__dirname, '..', 'build', 'factory', 'patches.js'),
+  'utf-8',
+);
+const importRe = /from\s+['"](\.\.\/services\/[^'"]+)['"]/g;
+const expected = new Set();
+let m;
+while ((m = importRe.exec(patchesSource)) !== null) {
+  // "../services/docs/patch.js" → "server/services/docs/patch.js"
+  expected.add('server/' + m[1].replace(/^\.\.\//, ''));
+}
+
+if (expected.size === 0) {
+  console.error('verify-mcpb: no services found in build/factory/patches.js — refusing to silently pass');
+  process.exit(2);
+}
+
+const listing = execSync(`unzip -l "${bundle}"`, { encoding: 'utf-8' });
+const missing = [];
+for (const file of expected) {
+  if (!listing.includes(file)) missing.push(file);
+}
+
+if (missing.length > 0) {
+  console.error(`verify-mcpb: bundle is missing ${missing.length} required file(s):`);
+  for (const f of missing) console.error(`  - ${f}`);
+  console.error(`\nCheck mcpb/.mcpbignore for patterns that may be filtering nested paths.`);
+  process.exit(1);
+}
+
+console.log(`verify-mcpb: ok (${expected.size} service patches present in ${path.basename(bundle)})`);


### PR DESCRIPTION
## Summary

v2.6.0 shipped with a broken mcpb bundle — the server crashed at startup with \`ERR_MODULE_NOT_FOUND\` because \`server/services/docs/patch.js\` was missing.

Root cause: \`mcpb/.mcpbignore\` had \`docs/\` unanchored. Gitignore-style matching treated it as \"any directory named docs anywhere,\" which silently filtered \`server/services/docs/\` along with the intended repo-root \`docs/\` (the ADRs).

## Changes

- **\`mcpb/.mcpbignore\`** — anchor directory-shaped patterns with \`/\` so they match only the bundle root: \`docs/\`, \`src/\`, \`scripts/\`, \`__tests__/\`, \`.github/\`, \`.claude/\`, config files.
- **\`scripts/verify-mcpb.cjs\`** — post-pack sanity check. Reads \`build/factory/patches.js\`, extracts every \`../services/*/patch.js\` import, and asserts each is present in the packed \`.mcpb\`. Fails with a clear error listing anything missing.
- **\`Makefile\`** — runs \`verify-mcpb.cjs\` after \`mcpb pack\`.

## Test plan

- [x] Local bundle rebuild with fix — all 6 service patches present
- [x] \`node server/index.js\` on the rebuilt bundle starts cleanly, loads 11 tools, token warmup completes
- [x] \`verify-mcpb.cjs\` fails cleanly on the original (broken) v2.6.0 linux-x64 download
- [x] \`make check\` — 390 tests pass

## Follow-up

User raised a deeper question: the patches registry statically lists every service import, so the manifest and \`factory/patches.ts\` can drift silently. Worth an ADR — either derive the registry from the manifest (compile-time check) or move to runtime discovery. Tracking separately.