### PR TITLE
fix(calendar,drive): integrate PR #115 + scratchpad follow-up from #117

### DIFF
--- a/src/__tests__/factory/calendar-patch.test.ts
+++ b/src/__tests__/factory/calendar-patch.test.ts
@@ -282,5 +282,133 @@ describe('calendarPatch', () => {
 
       expect(result.refs.calendarId).toBe('primary');
     });
+
+    it('passes attendees via --attendee (singular) — gws rejects the plural form', async () => {
+      mockExecute.mockResolvedValue(mockGwsResponse(calendarInsertResponse));
+      await calendarPatch.customHandlers!.create(
+        { summary: 'X', start: 'Y', end: 'Z', attendees: 'a@b.com,c@d.com' },
+        'user@test.com',
+      );
+
+      const args = mockExecute.mock.calls[0][0];
+      expect(args).toContain('--attendee');
+      expect(args).not.toContain('--attendees');
+      const idx = args.indexOf('--attendee');
+      expect(args[idx + 1]).toBe('a@b.com,c@d.com');
+    });
+  });
+
+  describe('update custom handler', () => {
+    it('requires eventId', async () => {
+      await expect(
+        calendarPatch.customHandlers!.update({ summary: 'X' }, 'user@test.com'),
+      ).rejects.toThrow('eventId');
+    });
+
+    it('rejects updates with no fields to change', async () => {
+      await expect(
+        calendarPatch.customHandlers!.update({ eventId: 'evt-1' }, 'user@test.com'),
+      ).rejects.toThrow('at least one field');
+    });
+
+    it('routes via events.patch with --params and --json', async () => {
+      mockExecute.mockResolvedValue(mockGwsResponse({ id: 'evt-1', summary: 'New title' }));
+      await calendarPatch.customHandlers!.update(
+        { eventId: 'evt-1', summary: 'New title' },
+        'user@test.com',
+      );
+
+      const args = mockExecute.mock.calls[0][0];
+      expect(args.slice(0, 3)).toEqual(['calendar', 'events', 'patch']);
+      expect(args).toContain('--params');
+      expect(args).toContain('--json');
+
+      const queryParams = JSON.parse(args[args.indexOf('--params') + 1]);
+      expect(queryParams).toEqual({ calendarId: 'primary', eventId: 'evt-1' });
+
+      const body = JSON.parse(args[args.indexOf('--json') + 1]);
+      expect(body).toEqual({ summary: 'New title' });
+    });
+
+    it('maps start and end to dateTime objects', async () => {
+      mockExecute.mockResolvedValue(mockGwsResponse({ id: 'evt-1' }));
+      await calendarPatch.customHandlers!.update(
+        { eventId: 'evt-1', start: '2026-05-01T10:00:00Z', end: '2026-05-01T11:00:00Z' },
+        'user@test.com',
+      );
+
+      const args = mockExecute.mock.calls[0][0];
+      const body = JSON.parse(args[args.indexOf('--json') + 1]);
+      expect(body.start).toEqual({ dateTime: '2026-05-01T10:00:00Z' });
+      expect(body.end).toEqual({ dateTime: '2026-05-01T11:00:00Z' });
+    });
+
+    it('converts comma-separated attendees string into array of {email}', async () => {
+      mockExecute.mockResolvedValue(mockGwsResponse({ id: 'evt-1' }));
+      await calendarPatch.customHandlers!.update(
+        { eventId: 'evt-1', attendees: 'a@b.com, c@d.com , e@f.com' },
+        'user@test.com',
+      );
+
+      const args = mockExecute.mock.calls[0][0];
+      const body = JSON.parse(args[args.indexOf('--json') + 1]);
+      expect(body.attendees).toEqual([
+        { email: 'a@b.com' },
+        { email: 'c@d.com' },
+        { email: 'e@f.com' },
+      ]);
+    });
+
+    it('clears attendees when attendees is an empty string', async () => {
+      mockExecute.mockResolvedValue(mockGwsResponse({ id: 'evt-1' }));
+      await calendarPatch.customHandlers!.update(
+        { eventId: 'evt-1', attendees: '' },
+        'user@test.com',
+      );
+
+      const args = mockExecute.mock.calls[0][0];
+      const body = JSON.parse(args[args.indexOf('--json') + 1]);
+      expect(body.attendees).toEqual([]);
+    });
+
+    it('adds conferenceData + conferenceDataVersion=1 when meet: true', async () => {
+      mockExecute.mockResolvedValue(mockGwsResponse({ id: 'evt-1', hangoutLink: 'https://meet.google.com/abc' }));
+      await calendarPatch.customHandlers!.update(
+        { eventId: 'evt-1', meet: true },
+        'user@test.com',
+      );
+
+      const args = mockExecute.mock.calls[0][0];
+      const queryParams = JSON.parse(args[args.indexOf('--params') + 1]);
+      const body = JSON.parse(args[args.indexOf('--json') + 1]);
+
+      expect(queryParams.conferenceDataVersion).toBe(1);
+      expect(body.conferenceData).toBeDefined();
+      expect(body.conferenceData.createRequest.conferenceSolutionKey.type).toBe('hangoutsMeet');
+    });
+
+    it('honors explicit calendarId', async () => {
+      mockExecute.mockResolvedValue(mockGwsResponse({ id: 'evt-1' }));
+      await calendarPatch.customHandlers!.update(
+        { eventId: 'evt-1', summary: 'X', calendarId: 'shared@test.com' },
+        'user@test.com',
+      );
+
+      const args = mockExecute.mock.calls[0][0];
+      const queryParams = JSON.parse(args[args.indexOf('--params') + 1]);
+      expect(queryParams.calendarId).toBe('shared@test.com');
+    });
+
+    it('lists changed fields in response text and refs', async () => {
+      mockExecute.mockResolvedValue(mockGwsResponse({ id: 'evt-1', summary: 'New' }));
+      const result = await calendarPatch.customHandlers!.update(
+        { eventId: 'evt-1', summary: 'New', location: 'Room B' },
+        'user@test.com',
+      );
+
+      expect(result.text).toContain('summary');
+      expect(result.text).toContain('location');
+      expect(result.refs.changed).toEqual(['summary', 'location']);
+    });
   });
 });

--- a/src/__tests__/factory/drive-patch.test.ts
+++ b/src/__tests__/factory/drive-patch.test.ts
@@ -125,6 +125,113 @@ describe('drivePatch custom handlers', () => {
     });
   });
 
+  describe('share', () => {
+    it('sends type + role + emailAddress as JSON body, not via --params', async () => {
+      mockExecute.mockResolvedValueOnce({
+        success: true,
+        data: { id: 'perm-1', emailAddress: 'bob@test.com', role: 'reader', type: 'user' },
+        stderr: '',
+      });
+
+      const handler = drivePatch.customHandlers!.share!;
+      await handler(
+        { fileId: 'file-1', shareEmail: 'bob@test.com', role: 'reader' },
+        'user@test.com',
+      );
+
+      const args = mockExecute.mock.calls[0][0];
+      expect(args.slice(0, 3)).toEqual(['drive', 'permissions', 'create']);
+      expect(args).toContain('--json');
+
+      const body = JSON.parse(args[args.indexOf('--json') + 1]);
+      // type MUST be in the body — omitting it caused
+      // "The permission type field is required." on every share call.
+      expect(body.type).toBe('user');
+      expect(body.role).toBe('reader');
+      expect(body.emailAddress).toBe('bob@test.com');
+
+      // --params should only carry query params, not the permission body.
+      const queryParams = JSON.parse(args[args.indexOf('--params') + 1]);
+      expect(queryParams.fileId).toBe('file-1');
+      expect(queryParams.type).toBeUndefined();
+      expect(queryParams.role).toBeUndefined();
+    });
+
+    it("defaults type to 'user' when not provided", async () => {
+      mockExecute.mockResolvedValueOnce({ success: true, data: { id: 'perm-1' }, stderr: '' });
+
+      const handler = drivePatch.customHandlers!.share!;
+      await handler(
+        { fileId: 'file-1', shareEmail: 'bob@test.com' },
+        'user@test.com',
+      );
+
+      const args = mockExecute.mock.calls[0][0];
+      const body = JSON.parse(args[args.indexOf('--json') + 1]);
+      expect(body.type).toBe('user');
+      expect(body.role).toBe('reader'); // default from manifest flows through
+    });
+
+    it('rejects user/group share without shareEmail', async () => {
+      const handler = drivePatch.customHandlers!.share!;
+      await expect(handler({ fileId: 'file-1' }, 'user@test.com')).rejects.toThrow('shareEmail');
+      await expect(handler({ fileId: 'file-1', type: 'group' }, 'user@test.com')).rejects.toThrow('shareEmail');
+    });
+
+    it("uses domain field when type is 'domain'", async () => {
+      mockExecute.mockResolvedValueOnce({ success: true, data: { id: 'perm-1' }, stderr: '' });
+
+      const handler = drivePatch.customHandlers!.share!;
+      await handler(
+        { fileId: 'file-1', type: 'domain', domain: 'acme.com', role: 'writer' },
+        'user@test.com',
+      );
+
+      const args = mockExecute.mock.calls[0][0];
+      const body = JSON.parse(args[args.indexOf('--json') + 1]);
+      expect(body.type).toBe('domain');
+      expect(body.domain).toBe('acme.com');
+      expect(body.emailAddress).toBeUndefined();
+    });
+
+    it("requires domain when type is 'domain'", async () => {
+      const handler = drivePatch.customHandlers!.share!;
+      await expect(
+        handler({ fileId: 'file-1', type: 'domain' }, 'user@test.com'),
+      ).rejects.toThrow('domain');
+    });
+
+    it("accepts type 'anyone' with no target", async () => {
+      mockExecute.mockResolvedValueOnce({ success: true, data: { id: 'perm-1' }, stderr: '' });
+
+      const handler = drivePatch.customHandlers!.share!;
+      await handler(
+        { fileId: 'file-1', type: 'anyone', role: 'reader' },
+        'user@test.com',
+      );
+
+      const args = mockExecute.mock.calls[0][0];
+      const body = JSON.parse(args[args.indexOf('--json') + 1]);
+      expect(body.type).toBe('anyone');
+      expect(body.emailAddress).toBeUndefined();
+      expect(body.domain).toBeUndefined();
+    });
+
+    it('suppresses email notifications by default for user/group shares', async () => {
+      mockExecute.mockResolvedValueOnce({ success: true, data: { id: 'perm-1' }, stderr: '' });
+
+      const handler = drivePatch.customHandlers!.share!;
+      await handler(
+        { fileId: 'file-1', shareEmail: 'bob@test.com' },
+        'user@test.com',
+      );
+
+      const args = mockExecute.mock.calls[0][0];
+      const queryParams = JSON.parse(args[args.indexOf('--params') + 1]);
+      expect(queryParams.sendNotificationEmail).toBe(false);
+    });
+  });
+
   describe('download', () => {
     it('creates parent directories before calling gws', async () => {
       const outputPath = path.join(tmpWorkspace, 'images', 'photo.png');

--- a/src/__tests__/server/handlers/calendar.test.ts
+++ b/src/__tests__/server/handlers/calendar.test.ts
@@ -68,7 +68,8 @@ describe('handleCalendar', () => {
 
       const args = mockExecute.mock.calls[0][0];
       expect(args).toContain('--location');
-      expect(args).toContain('--attendees');
+      // gws expects the singular form --attendee (the plural --attendees is rejected by the CLI).
+      expect(args).toContain('--attendee');
     });
 
     it('returns markdown with event details', async () => {

--- a/src/factory/manifest.yaml
+++ b/src/factory/manifest.yaml
@@ -387,7 +387,7 @@ services:
           end: "--end"
           description: "--description"
           location: "--location"
-          attendees: "--attendees"
+          attendees: "--attendee"
 
       quickAdd:
         type: action
@@ -431,6 +431,12 @@ services:
           location:
             type: string
             description: "Updated location"
+          attendees:
+            type: string
+            description: "Comma-separated attendee emails. REPLACES the existing attendee list entirely (Google events.patch overwrites arrays). Pass an empty string to clear all attendees."
+          meet:
+            type: boolean
+            description: "Add a Google Meet video conference link. Note: Google Calendar does not allow removing an existing Meet link via patch; omit or set false to leave the link untouched."
         defaults:
           calendarId: primary
 
@@ -629,7 +635,7 @@ services:
 
       share:
         type: action
-        description: "share a file with a user or group"
+        description: "share a file with a user, group, domain, or anyone"
         resource: permissions.create
         params:
           fileId:
@@ -638,13 +644,20 @@ services:
             required: true
           shareEmail:
             type: string
-            description: "Email address to share with"
-            required: true
+            description: "Email address (required when type is 'user' or 'group'). Omit for 'domain' (use 'domain' param) or 'anyone'."
           role:
             type: string
             description: "Permission level"
             enum: [reader, commenter, writer, organizer]
             default: reader
+          type:
+            type: string
+            description: "Permission type (default: 'user'). Use 'group' for Google Groups, 'domain' to share with an entire G Suite domain, 'anyone' for public links."
+            enum: [user, group, domain, anyone]
+            default: user
+          domain:
+            type: string
+            description: "Domain name (required when type is 'domain')."
         defaults:
           supportsAllDrives: true
 

--- a/src/server/handlers/calendar.ts
+++ b/src/server/handlers/calendar.ts
@@ -55,7 +55,7 @@ export async function handleCalendar(params: Record<string, unknown>): Promise<H
       const args = ['calendar', '+insert', '--calendar', calendarId, '--summary', summary, '--start', start, '--end', end];
       if (params.description) args.push('--description', String(params.description));
       if (params.location) args.push('--location', String(params.location));
-      if (params.attendees) args.push('--attendees', String(params.attendees));
+      if (params.attendees) args.push('--attendee', String(params.attendees));
       const result = await execute(args, { account: email });
       const data = result.data as Record<string, unknown>;
       return {

--- a/src/server/scratchpad/adapters/send-calendar.ts
+++ b/src/server/scratchpad/adapters/send-calendar.ts
@@ -42,7 +42,7 @@ export async function sendCalendarEvent(
     '--description', content,
   ];
   if (location) args.push('--location', location);
-  if (attendees) args.push('--attendees', attendees);
+  if (attendees) args.push('--attendee', attendees);
 
   try {
     const result = await execute(args, { account: email });

--- a/src/services/calendar/patch.ts
+++ b/src/services/calendar/patch.ts
@@ -202,7 +202,10 @@ export const calendarPatch: ServicePatch = {
       const args = ['calendar', '+insert', '--calendar', calendarId, '--summary', summary, '--start', start, '--end', end];
       if (params.description) args.push('--description', String(params.description));
       if (params.location) args.push('--location', String(params.location));
-      if (params.attendees) args.push('--attendees', String(params.attendees));
+      // `gws calendar +insert` expects `--attendee` (singular) — the CLI accepts the flag repeatedly,
+      // but a single comma-separated value also works. Using `--attendees` (plural) errors out at the
+      // CLI layer with "unexpected argument '--attendees' found; tip: a similar argument exists: '--attendee'".
+      if (params.attendees) args.push('--attendee', String(params.attendees));
       if (params.meet) args.push('--meet');
       const result = await execute(args, { account });
       const data = result.data as Record<string, unknown>;
@@ -227,6 +230,79 @@ export const calendarPatch: ServicePatch = {
       return {
         text: `Event deleted: ${eventId}`,
         refs: { eventId, status: 'deleted' },
+      };
+    },
+
+    update: async (params, account): Promise<HandlerResponse> => {
+      // events.patch takes `calendarId` + `eventId` via --params (path/query)
+      // and the changed fields as a JSON body via --json. The manifest-driven
+      // generator only emits --params, so without this handler the body is
+      // empty and Google returns 200 without applying anything — silently.
+      const eventId = requireString(params, 'eventId');
+      const calendarId = (params.calendarId as string) || 'primary';
+
+      const body: Record<string, unknown> = {};
+      if (params.summary !== undefined) body.summary = String(params.summary);
+      if (params.description !== undefined) body.description = String(params.description);
+      if (params.location !== undefined) body.location = String(params.location);
+      if (params.start !== undefined) body.start = { dateTime: String(params.start) };
+      if (params.end !== undefined) body.end = { dateTime: String(params.end) };
+
+      // attendees: comma-separated string → array of {email} objects.
+      // Google events.patch replaces the attendees array wholesale (no diff semantics),
+      // so the caller must re-supply every guest they want kept.
+      if (params.attendees !== undefined) {
+        const attendeeList = String(params.attendees)
+          .split(',')
+          .map(e => e.trim())
+          .filter(Boolean);
+        body.attendees = attendeeList.map(email => ({ email }));
+      }
+
+      // Build --params: note the conferenceDataVersion=1 requirement when creating a Meet link.
+      const queryParams: Record<string, unknown> = { calendarId, eventId };
+
+      // Optional Meet link attach. Google Calendar does not allow removing a Meet link
+      // via events.patch, so we only handle the "add" case.
+      if (params.meet) {
+        const requestId = `meet-${eventId}-${Date.now()}`;
+        body.conferenceData = {
+          createRequest: {
+            requestId,
+            conferenceSolutionKey: { type: 'hangoutsMeet' },
+          },
+        };
+        queryParams.conferenceDataVersion = 1;
+      }
+
+      if (Object.keys(body).length === 0) {
+        throw new Error(
+          'update requires at least one field to change: summary, start, end, description, location, attendees, or meet',
+        );
+      }
+
+      const result = await execute([
+        'calendar', 'events', 'patch',
+        '--params', JSON.stringify(queryParams),
+        '--json', JSON.stringify(body),
+      ], { account });
+      const data = result.data as Record<string, unknown>;
+
+      const changed = Object.keys(body);
+      const meetLink = data.hangoutLink ? `\n**Meet:** ${data.hangoutLink}` : '';
+      return {
+        text: `Event updated: **${data.summary ?? eventId}**\n\n` +
+          `**Event ID:** ${data.id ?? eventId}\n` +
+          `**Calendar:** ${calendarId}\n` +
+          `**Fields changed:** ${changed.join(', ')}` +
+          meetLink,
+        refs: {
+          id: data.id,
+          eventId: data.id ?? eventId,
+          calendarId,
+          changed,
+          ...(data.hangoutLink ? { meetLink: data.hangoutLink } : {}),
+        },
       };
     },
   },

--- a/src/services/drive/patch.ts
+++ b/src/services/drive/patch.ts
@@ -341,6 +341,65 @@ export const drivePatch: ServicePatch = {
       };
     },
 
+    share: async (params, account): Promise<HandlerResponse> => {
+      // Drive v3 permissions.create requires the permission body (type, role,
+      // emailAddress|domain) to be POSTed as the request body, not passed
+      // through query --params. The generator's default buildResourceArgs
+      // collapses everything into --params, which makes the API reject the
+      // call with "The permission type field is required." This handler sends
+      // the body via --json.
+      const fileId = requireString(params, 'fileId');
+      const role = (params.role as string) || 'reader';
+      const type = (params.type as string) || 'user';
+
+      const body: Record<string, unknown> = { role, type };
+
+      if (type === 'user' || type === 'group') {
+        const email = (params.shareEmail as string) || '';
+        if (!email) {
+          throw new Error(`share requires shareEmail when type is '${type}'`);
+        }
+        body.emailAddress = email;
+      } else if (type === 'domain') {
+        const domain = (params.domain as string) || '';
+        if (!domain) {
+          throw new Error("share requires the 'domain' param when type is 'domain'");
+        }
+        body.domain = domain;
+      }
+      // type === 'anyone' needs no additional fields.
+
+      const queryParams: Record<string, unknown> = {
+        fileId,
+        supportsAllDrives: true,
+      };
+      // Skip the noisy "notify by email" default — the caller didn't ask for it.
+      if (type === 'user' || type === 'group') {
+        queryParams.sendNotificationEmail = false;
+      }
+
+      const result = await execute([
+        'drive', 'permissions', 'create',
+        '--params', JSON.stringify(queryParams),
+        '--json', JSON.stringify(body),
+      ], { account });
+      const data = result.data as Record<string, unknown>;
+
+      const target =
+        type === 'user' || type === 'group'
+          ? (body.emailAddress as string)
+          : type === 'domain'
+            ? (body.domain as string)
+            : 'anyone with the link';
+
+      return {
+        text: `File shared with **${target}** as ${role} (${type}).\n\n` +
+          `**File ID:** ${fileId}\n` +
+          `**Permission ID:** ${data.id ?? 'unknown'}`,
+        refs: { fileId, permissionId: data.id, role, type, target },
+      };
+    },
+
     replyToComment: async (params, account): Promise<HandlerResponse> => {
       const fileId = requireString(params, 'fileId');
       const commentId = requireString(params, 'commentId');


### PR DESCRIPTION
Integration branch bundling two contributor fixes for the same family of bugs (gws CLI flag mismatch + body-field routing). Validated end-to-end against a real Google account before opening this PR.

## What's bundled

### From #115 (DirectCash-Personal)

Three related fixes, all rooted in how the manifest-driven generator routes args via `--params` (URL/query) vs `--json` (request body):

- **Bug 1 — `calendar.create` rejected every guest list.** Manifest emitted `--attendees` (plural); gws CLI expects `--attendee` (singular). Fixed in manifest, handler, and patch.
- **Bug 2 — `calendar.update` silently swallowed body fields.** Generator pushed everything via `--params`, but `events.patch` requires the change body via `--json`. Adds an `update` custom handler on `calendarPatch` that splits them, converts comma-separated attendees → `[{email}]`, and attaches `conferenceData.createRequest` + `conferenceDataVersion=1` when `meet: true`. Includes the "no fields" guard.
- **Bug 3 — `drive.share` 400'd on missing permission type.** Same root cause class. Adds a `share` custom handler on `drivePatch` that sends `{type, role, emailAddress|domain}` via `--json`, with `type` defaulting to `user` and the manifest extended to accept `type` (user|group|domain|anyone) and `domain`. User/group shares no longer spam notification emails by default.

17 new tests across `calendar-patch.test.ts` and `drive-patch.test.ts`.

### From #117 (adwitiyasingh11)

- **Scratchpad adapter `--attendees` fix.** PR #115 missed `src/server/scratchpad/adapters/send-calendar.ts`, which still had the broken plural flag. Picked up as a one-line follow-up commit on this branch (`fix(scratchpad): correct --attendees flag in send-calendar adapter`), with credit in the commit body.

## Live verification

Tested against a real Google account on the integrated branch:

| Test | Pre-fix | Result |
|---|---|---|
| `calendar.create` with attendees | CLI errors `unexpected argument '--attendees'` | ✅ event created, attendee attached |
| `calendar.update` summary/location/attendees | 200 OK, event unchanged | ✅ all three fields persisted |
| `drive.share` type=anyone | 400 "permission type field required" | ✅ anyone-with-link permission created |
| `drive.share` type=user (Google account) | 400 "permission type field required" | ✅ user permission created |

`npm run type-check`, `npm run build`, `npm test` (35 suites / 606 tests) all green on the integrated branch.

## Closes

- Closes #116 — calendar.create attendees flag

## Not addressed (intentional)

- #114 — `manage_drive.listPermissions` returns "No files found" for valid `fileId`. Reproduced live during integration testing; needs a separate root-cause investigation. Out of scope here.

## Credits

- @DirectCash-Personal (PR #115) — the three-bug fix and 17 new tests
- @adwitiyasingh11 (PR #117) — caught the scratchpad adapter file #115 missed

Both source PRs will be closed with thank-you notes pointing at this merge.