### PR TITLE
fix(drive): listPermissions returns the permission list, not "No files found" (#114)

### DIFF
--- a/src/__tests__/factory/drive-patch.test.ts
+++ b/src/__tests__/factory/drive-patch.test.ts
@@ -232,6 +232,69 @@ describe('drivePatch custom handlers', () => {
     });
   });
 
+  describe('listPermissions', () => {
+    it('hits permissions.list and requests the fields the API omits by default', async () => {
+      mockExecute.mockResolvedValueOnce({
+        success: true,
+        data: {
+          permissions: [
+            { id: 'owner-perm', type: 'user', role: 'owner', emailAddress: 'me@test.com' },
+            { id: 'reader-perm', type: 'user', role: 'reader', emailAddress: 'bob@test.com' },
+          ],
+        },
+        stderr: '',
+      });
+
+      const handler = drivePatch.customHandlers!.listPermissions!;
+      const result = await handler({ fileId: 'file-1' }, 'me@test.com');
+
+      const args = mockExecute.mock.calls[0][0];
+      expect(args.slice(0, 3)).toEqual(['drive', 'permissions', 'list']);
+      const queryParams = JSON.parse(args[args.indexOf('--params') + 1]);
+      expect(queryParams.fileId).toBe('file-1');
+      // Without an explicit fields mask the Drive API returns only id/type — not
+      // role or emailAddress — which made the listing useless.
+      expect(queryParams.fields).toContain('role');
+      expect(queryParams.fields).toContain('emailAddress');
+
+      expect(result.text).toContain('Permissions on file-1 (2)');
+      expect(result.text).toContain('owner-perm | owner | user | me@test.com');
+      expect(result.text).toContain('reader-perm | reader | user | bob@test.com');
+      expect(result.refs.count).toBe(2);
+      expect(result.refs.permissionId).toBe('owner-perm');
+    });
+
+    it('reports an empty permission list without claiming "No files found"', async () => {
+      mockExecute.mockResolvedValueOnce({ success: true, data: { permissions: [] }, stderr: '' });
+
+      const handler = drivePatch.customHandlers!.listPermissions!;
+      const result = await handler({ fileId: 'file-2' }, 'me@test.com');
+
+      expect(result.text).toContain('No sharing permissions on file file-2');
+      expect(result.text).not.toContain('No files found');
+      expect(result.refs.count).toBe(0);
+    });
+
+    it("labels anyone-with-link and pending-owner permissions", async () => {
+      mockExecute.mockResolvedValueOnce({
+        success: true,
+        data: {
+          permissions: [
+            { id: 'anyone-perm', type: 'anyone', role: 'reader' },
+            { id: 'pending-perm', type: 'user', role: 'writer', emailAddress: 'new@test.com', pendingOwner: true },
+          ],
+        },
+        stderr: '',
+      });
+
+      const handler = drivePatch.customHandlers!.listPermissions!;
+      const result = await handler({ fileId: 'file-3' }, 'me@test.com');
+
+      expect(result.text).toContain('anyone-perm | reader | anyone | anyone with the link');
+      expect(result.text).toContain('[pending owner]');
+    });
+  });
+
   describe('download', () => {
     it('creates parent directories before calling gws', async () => {
       const outputPath = path.join(tmpWorkspace, 'images', 'photo.png');

--- a/src/__tests__/factory/drive-patch.test.ts
+++ b/src/__tests__/factory/drive-patch.test.ts
@@ -261,7 +261,12 @@ describe('drivePatch custom handlers', () => {
       expect(result.text).toContain('owner-perm | owner | user | me@test.com');
       expect(result.text).toContain('reader-perm | reader | user | bob@test.com');
       expect(result.refs.count).toBe(2);
-      expect(result.refs.permissionId).toBe('owner-perm');
+      // A list has no canonical "the" permission — no singular permissionId ref.
+      expect(result.refs.permissionId).toBeUndefined();
+      expect(result.refs.permissions).toEqual([
+        { permissionId: 'owner-perm', type: 'user', role: 'owner', target: 'me@test.com' },
+        { permissionId: 'reader-perm', type: 'user', role: 'reader', target: 'bob@test.com' },
+      ]);
     });
 
     it('reports an empty permission list without claiming "No files found"', async () => {
@@ -273,15 +278,19 @@ describe('drivePatch custom handlers', () => {
       expect(result.text).toContain('No sharing permissions on file file-2');
       expect(result.text).not.toContain('No files found');
       expect(result.refs.count).toBe(0);
+      expect(result.refs.permissions).toEqual([]);
     });
 
-    it("labels anyone-with-link and pending-owner permissions", async () => {
+    it('labels anyone-with-link, pending-owner, deleted, and domain/displayName targets', async () => {
       mockExecute.mockResolvedValueOnce({
         success: true,
         data: {
           permissions: [
             { id: 'anyone-perm', type: 'anyone', role: 'reader' },
             { id: 'pending-perm', type: 'user', role: 'writer', emailAddress: 'new@test.com', pendingOwner: true },
+            { id: 'domain-perm', type: 'domain', role: 'reader', domain: 'acme.com' },
+            { id: 'group-perm', type: 'group', role: 'commenter', displayName: 'Eng Team' },
+            { id: 'gone-perm', type: 'user', role: 'reader', emailAddress: 'old@test.com', deleted: true },
           ],
         },
         stderr: '',
@@ -292,6 +301,9 @@ describe('drivePatch custom handlers', () => {
 
       expect(result.text).toContain('anyone-perm | reader | anyone | anyone with the link');
       expect(result.text).toContain('[pending owner]');
+      expect(result.text).toContain('domain-perm | reader | domain | acme.com');
+      expect(result.text).toContain('group-perm | commenter | group | Eng Team');
+      expect(result.text).toContain('gone-perm | reader | user | old@test.com [deleted account]');
     });
   });
 

--- a/src/services/drive/patch.ts
+++ b/src/services/drive/patch.ts
@@ -341,6 +341,56 @@ export const drivePatch: ServicePatch = {
       };
     },
 
+    listPermissions: async (params, account): Promise<HandlerResponse> => {
+      // permissions.list returns `{ permissions: [...] }`, not `{ files: [...] }`,
+      // so the generic drive list formatter (formatFileList) reported "No files
+      // found" for every call. This handler fetches the permission fields the
+      // default response omits (role, emailAddress, domain) and renders them.
+      const fileId = requireString(params, 'fileId');
+
+      const result = await execute([
+        'drive', 'permissions', 'list',
+        '--params', JSON.stringify({
+          fileId,
+          fields: 'permissions(id, type, role, emailAddress, domain, displayName, deleted, pendingOwner)',
+          supportsAllDrives: true,
+        }),
+      ], { account });
+      const data = result.data as Record<string, unknown>;
+      const permissions = (data.permissions || []) as Array<Record<string, unknown>>;
+
+      if (permissions.length === 0) {
+        return {
+          text: `No sharing permissions on file ${fileId}.`,
+          refs: { fileId, count: 0 },
+        };
+      }
+
+      const lines = permissions.map((p) => {
+        const id = String(p.id ?? '');
+        const type = String(p.type ?? '');
+        const role = String(p.role ?? '');
+        const target =
+          p.emailAddress ? String(p.emailAddress)
+            : p.domain ? String(p.domain)
+              : type === 'anyone' ? 'anyone with the link'
+                : p.displayName ? String(p.displayName)
+                  : '';
+        const flags = `${p.pendingOwner ? ' [pending owner]' : ''}${p.deleted ? ' [deleted account]' : ''}`;
+        return `${id} | ${role} | ${type}${target ? ' | ' + target : ''}${flags}`;
+      });
+
+      return {
+        text: `## Permissions on ${fileId} (${permissions.length})\n\n${lines.join('\n')}`,
+        refs: {
+          fileId,
+          count: permissions.length,
+          permissionId: String(permissions[0]?.id ?? ''),
+          permissions: permissions.map((p) => String(p.id ?? '')),
+        },
+      };
+    },
+
     share: async (params, account): Promise<HandlerResponse> => {
       // Drive v3 permissions.create requires the permission body (type, role,
       // emailAddress|domain) to be POSTed as the request body, not passed

--- a/src/services/drive/patch.ts
+++ b/src/services/drive/patch.ts
@@ -362,31 +362,38 @@ export const drivePatch: ServicePatch = {
       if (permissions.length === 0) {
         return {
           text: `No sharing permissions on file ${fileId}.`,
-          refs: { fileId, count: 0 },
+          refs: { fileId, count: 0, permissions: [] },
         };
       }
 
-      const lines = permissions.map((p) => {
-        const id = String(p.id ?? '');
-        const type = String(p.type ?? '');
-        const role = String(p.role ?? '');
-        const target =
-          p.emailAddress ? String(p.emailAddress)
-            : p.domain ? String(p.domain)
-              : type === 'anyone' ? 'anyone with the link'
-                : p.displayName ? String(p.displayName)
-                  : '';
+      const targetOf = (p: Record<string, unknown>): string =>
+        p.emailAddress ? String(p.emailAddress)
+          : p.domain ? String(p.domain)
+            : String(p.type) === 'anyone' ? 'anyone with the link'
+              : p.displayName ? String(p.displayName)
+                : '';
+
+      const rows = permissions.map((p) => ({
+        permissionId: String(p.id ?? ''),
+        type: String(p.type ?? ''),
+        role: String(p.role ?? ''),
+        target: targetOf(p),
+      }));
+
+      const lines = permissions.map((p, i) => {
+        const { permissionId, type, role, target } = rows[i];
         const flags = `${p.pendingOwner ? ' [pending owner]' : ''}${p.deleted ? ' [deleted account]' : ''}`;
-        return `${id} | ${role} | ${type}${target ? ' | ' + target : ''}${flags}`;
+        return `${permissionId} | ${role} | ${type}${target ? ' | ' + target : ''}${flags}`;
       });
 
       return {
         text: `## Permissions on ${fileId} (${permissions.length})\n\n${lines.join('\n')}`,
+        // No singular permissionId here — a list has no canonical "the" permission;
+        // unshare callers must pick a specific row's permissionId from `permissions`.
         refs: {
           fileId,
           count: permissions.length,
-          permissionId: String(permissions[0]?.id ?? ''),
-          permissions: permissions.map((p) => String(p.id ?? '')),
+          permissions: rows,
         },
       };
     },


### PR DESCRIPTION
## Problem

`manage_drive` `listPermissions` returned the error text `No files found` for any valid `fileId`, even one just uploaded in the same session. Reported in #114.

## Root cause

`listPermissions` is declared `type: list` in the manifest, and the drive patch's `formatList` is `formatFileList`, which reads `data.files`. But `permissions.list` returns `data.permissions` — so `formatFileList` saw an empty `files` array and emitted its "No files found." message. (Same structural family as the `share` body-vs-query bug already fixed: an operation whose response/request shape the generic path can't express.)

## Fix

Add a dedicated `listPermissions` custom handler (mirrors `share`):

- Requests an explicit `fields` mask — the Drive API's default `permissions.list` response omits `role`, `emailAddress`, and `domain`, which would have made the listing useless even once it rendered.
- Renders `permId | role | type | target` rows.
- Reports an empty permission list plainly instead of claiming "No files found".
- Labels `anyone`-with-link, pending-owner, and deleted-account permissions.

The manifest entry is unchanged (`type: list`, `resource: permissions.list`) — the custom handler takes precedence in `generateHandler`, so the generic `formatList` is no longer reached for this op.

## Verification

- `make build` + `make test` — all 609 tests pass (3 new for this handler).
- Live: `listPermissions` on an owned Google Doc now returns:
  ```
  ## Permissions on <id> (2)
  anyoneWithLink | writer | anyone | anyone with the link
  <id> | owner | user | owner@example.com
  ```

Closes #114.