### PR TITLE
fix(drive): copy honors `name`; add `update` op for rename/move (#105)

### DIFF
--- a/src/__tests__/factory/drive-patch.test.ts
+++ b/src/__tests__/factory/drive-patch.test.ts
@@ -307,6 +307,92 @@ describe('drivePatch custom handlers', () => {
     });
   });
 
+  describe('copy', () => {
+    it('sends name as the request body, not via --params, so the copy is renamed', async () => {
+      mockExecute.mockResolvedValueOnce({
+        success: true,
+        data: { id: 'copy-1', name: 'My New Name', mimeType: 'application/vnd.google-apps.spreadsheet' },
+        stderr: '',
+      });
+
+      const handler = drivePatch.customHandlers!.copy!;
+      const result = await handler({ fileId: 'src-1', name: 'My New Name' }, 'user@test.com');
+
+      const args = mockExecute.mock.calls[0][0];
+      expect(args.slice(0, 3)).toEqual(['drive', 'files', 'copy']);
+      const body = JSON.parse(args[args.indexOf('--json') + 1]);
+      expect(body.name).toBe('My New Name');
+      const queryParams = JSON.parse(args[args.indexOf('--params') + 1]);
+      expect(queryParams.fileId).toBe('src-1');
+      // name must NOT leak into the query — that's the bug being fixed.
+      expect(queryParams.name).toBeUndefined();
+
+      expect(result.text).toContain('File copied: **My New Name**');
+      expect(result.text).toContain('**File ID:** copy-1');
+      expect(result.refs.fileId).toBe('copy-1');
+      expect(result.refs.sourceFileId).toBe('src-1');
+    });
+
+    it('forwards parentFolderId as body.parents', async () => {
+      mockExecute.mockResolvedValueOnce({ success: true, data: { id: 'copy-2', name: 'Copy of X', parents: ['folder-9'] }, stderr: '' });
+
+      const handler = drivePatch.customHandlers!.copy!;
+      await handler({ fileId: 'src-2', parentFolderId: 'folder-9' }, 'user@test.com');
+
+      const args = mockExecute.mock.calls[0][0];
+      const body = JSON.parse(args[args.indexOf('--json') + 1]);
+      expect(body.parents).toEqual(['folder-9']);
+    });
+
+    it('omits --json entirely when neither name nor parentFolderId is given', async () => {
+      mockExecute.mockResolvedValueOnce({ success: true, data: { id: 'copy-3', name: 'Copy of X' }, stderr: '' });
+
+      const handler = drivePatch.customHandlers!.copy!;
+      await handler({ fileId: 'src-3' }, 'user@test.com');
+
+      const args = mockExecute.mock.calls[0][0];
+      expect(args).not.toContain('--json');
+    });
+  });
+
+  describe('update', () => {
+    it('renames via the request body and surfaces the new name', async () => {
+      mockExecute.mockResolvedValueOnce({ success: true, data: { id: 'file-1', name: 'Renamed.pdf', parents: ['root'] }, stderr: '' });
+
+      const handler = drivePatch.customHandlers!.update!;
+      const result = await handler({ fileId: 'file-1', name: 'Renamed.pdf' }, 'user@test.com');
+
+      const args = mockExecute.mock.calls[0][0];
+      expect(args.slice(0, 3)).toEqual(['drive', 'files', 'update']);
+      const body = JSON.parse(args[args.indexOf('--json') + 1]);
+      expect(body.name).toBe('Renamed.pdf');
+      const queryParams = JSON.parse(args[args.indexOf('--params') + 1]);
+      expect(queryParams.name).toBeUndefined();
+
+      expect(result.text).toContain('File updated: **Renamed.pdf**');
+      expect(result.refs.name).toBe('Renamed.pdf');
+    });
+
+    it('moves between folders via addParents/removeParents query params (no body)', async () => {
+      mockExecute.mockResolvedValueOnce({ success: true, data: { id: 'file-2', name: 'doc', parents: ['new-folder'] }, stderr: '' });
+
+      const handler = drivePatch.customHandlers!.update!;
+      await handler({ fileId: 'file-2', addParents: 'new-folder', removeParents: 'old-folder' }, 'user@test.com');
+
+      const args = mockExecute.mock.calls[0][0];
+      expect(args).not.toContain('--json'); // nothing to put in the body
+      const queryParams = JSON.parse(args[args.indexOf('--params') + 1]);
+      expect(queryParams.addParents).toBe('new-folder');
+      expect(queryParams.removeParents).toBe('old-folder');
+    });
+
+    it('rejects a no-op update (none of name/addParents/removeParents)', async () => {
+      const handler = drivePatch.customHandlers!.update!;
+      await expect(handler({ fileId: 'file-3' }, 'user@test.com')).rejects.toThrow(/name.*addParents.*removeParents/);
+      expect(mockExecute).not.toHaveBeenCalled();
+    });
+  });
+
   describe('download', () => {
     it('creates parent directories before calling gws', async () => {
       const outputPath = path.join(tmpWorkspace, 'images', 'photo.png');

--- a/src/__tests__/factory/drive-patch.test.ts
+++ b/src/__tests__/factory/drive-patch.test.ts
@@ -386,6 +386,35 @@ describe('drivePatch custom handlers', () => {
       expect(queryParams.removeParents).toBe('old-folder');
     });
 
+    it('rename + move in one call populates both --json (name) and --params (parents)', async () => {
+      mockExecute.mockResolvedValueOnce({ success: true, data: { id: 'file-4', name: 'Moved.pdf', parents: ['dest'] }, stderr: '' });
+
+      const handler = drivePatch.customHandlers!.update!;
+      const result = await handler(
+        { fileId: 'file-4', name: 'Moved.pdf', addParents: 'dest', removeParents: 'src' },
+        'user@test.com',
+      );
+
+      const args = mockExecute.mock.calls[0][0];
+      const body = JSON.parse(args[args.indexOf('--json') + 1]);
+      expect(body.name).toBe('Moved.pdf');
+      const queryParams = JSON.parse(args[args.indexOf('--params') + 1]);
+      expect(queryParams.addParents).toBe('dest');
+      expect(queryParams.removeParents).toBe('src');
+      expect(result.text).toContain('File updated: **Moved.pdf**');
+      expect(result.text).toContain('**Parents:** dest');
+      expect(result.refs.parents).toEqual(['dest']);
+    });
+
+    it('omits refs.parents when the API response has none', async () => {
+      mockExecute.mockResolvedValueOnce({ success: true, data: { id: 'file-5', name: 'R.pdf' }, stderr: '' });
+
+      const handler = drivePatch.customHandlers!.update!;
+      const result = await handler({ fileId: 'file-5', name: 'R.pdf' }, 'user@test.com');
+
+      expect('parents' in result.refs).toBe(false);
+    });
+
     it('rejects a no-op update (none of name/addParents/removeParents)', async () => {
       const handler = drivePatch.customHandlers!.update!;
       await expect(handler({ fileId: 'file-3' }, 'user@test.com')).rejects.toThrow(/name.*addParents.*removeParents/);

--- a/src/factory/manifest.yaml
+++ b/src/factory/manifest.yaml
@@ -575,7 +575,7 @@ services:
 
       copy:
         type: action
-        description: "create a copy of a file"
+        description: "create a copy of a file (set name to rename the copy; parentFolderId to place it in a folder)"
         resource: files.copy
         params:
           fileId:
@@ -584,7 +584,31 @@ services:
             required: true
           name:
             type: string
-            description: "Name for the copy"
+            description: "Name for the copy (without it, Drive names it 'Copy of <original>')"
+          parentFolderId:
+            type: string
+            description: "Folder ID to place the copy in (defaults to the source's folder)"
+        defaults:
+          supportsAllDrives: true
+
+      update:
+        type: action
+        description: "rename a file (set name) and/or move it between folders (addParents / removeParents — to move, set both)"
+        resource: files.update
+        params:
+          fileId:
+            type: string
+            description: "File ID to update"
+            required: true
+          name:
+            type: string
+            description: "New file name (rename)"
+          addParents:
+            type: string
+            description: "Comma-separated folder ID(s) to add as parents (move into a folder)"
+          removeParents:
+            type: string
+            description: "Comma-separated folder ID(s) to remove as parents (move out of a folder)"
         defaults:
           supportsAllDrives: true
 

--- a/src/services/drive/patch.ts
+++ b/src/services/drive/patch.ts
@@ -55,6 +55,75 @@ export const drivePatch: ServicePatch = {
       };
     },
 
+    copy: async (params, account): Promise<HandlerResponse> => {
+      // files.copy takes the new file's metadata (name, parents) as the
+      // request body, not query --params. The generator's generic path
+      // collapses everything into --params, so a passed `name` was silently
+      // dropped and copies kept Drive's "Copy of <original>" default name.
+      const fileId = requireString(params, 'fileId');
+
+      const body: Record<string, unknown> = {};
+      if (params.name) body.name = String(params.name);
+      if (params.parentFolderId) body.parents = [String(params.parentFolderId)];
+
+      const args = [
+        'drive', 'files', 'copy',
+        '--params', JSON.stringify({
+          fileId,
+          fields: 'id, name, mimeType, parents, webViewLink',
+          supportsAllDrives: true,
+        }),
+      ];
+      if (Object.keys(body).length > 0) {
+        args.push('--json', JSON.stringify(body));
+      }
+
+      const result = await execute(args, { account });
+      const data = result.data as Record<string, unknown>;
+      return {
+        text: `File copied: **${data.name ?? 'copy'}**\n\n**File ID:** ${data.id ?? 'unknown'}` +
+          (data.webViewLink ? `\n**Link:** ${data.webViewLink}` : ''),
+        refs: { fileId: data.id, id: data.id, name: data.name, sourceFileId: fileId },
+      };
+    },
+
+    update: async (params, account): Promise<HandlerResponse> => {
+      // Rename a file (body: name) and/or move it between folders (query:
+      // addParents/removeParents). files.update needs renamable metadata in
+      // the request body and parent changes in query params — the generic
+      // path can't split one request across both.
+      const fileId = requireString(params, 'fileId');
+
+      const body: Record<string, unknown> = {};
+      if (params.name) body.name = String(params.name);
+
+      const queryParams: Record<string, unknown> = {
+        fileId,
+        fields: 'id, name, mimeType, parents, webViewLink',
+        supportsAllDrives: true,
+      };
+      if (params.addParents) queryParams.addParents = String(params.addParents);
+      if (params.removeParents) queryParams.removeParents = String(params.removeParents);
+
+      if (Object.keys(body).length === 0 && !queryParams.addParents && !queryParams.removeParents) {
+        throw new Error('update requires at least one of: name, addParents, removeParents');
+      }
+
+      const args = ['drive', 'files', 'update', '--params', JSON.stringify(queryParams)];
+      if (Object.keys(body).length > 0) {
+        args.push('--json', JSON.stringify(body));
+      }
+
+      const result = await execute(args, { account });
+      const data = result.data as Record<string, unknown>;
+      const parents = Array.isArray(data.parents) ? (data.parents as string[]) : undefined;
+      return {
+        text: `File updated: **${data.name ?? fileId}**\n\n**File ID:** ${data.id ?? fileId}` +
+          (parents ? `\n**Parents:** ${parents.join(', ')}` : ''),
+        refs: { fileId: data.id ?? fileId, id: data.id ?? fileId, name: data.name, parents },
+      };
+    },
+
     download: async (params, account): Promise<HandlerResponse> => {
       const fileId = requireString(params, 'fileId');
 

--- a/src/services/drive/patch.ts
+++ b/src/services/drive/patch.ts
@@ -120,7 +120,12 @@ export const drivePatch: ServicePatch = {
       return {
         text: `File updated: **${data.name ?? fileId}**\n\n**File ID:** ${data.id ?? fileId}` +
           (parents ? `\n**Parents:** ${parents.join(', ')}` : ''),
-        refs: { fileId: data.id ?? fileId, id: data.id ?? fileId, name: data.name, parents },
+        refs: {
+          fileId: data.id ?? fileId,
+          id: data.id ?? fileId,
+          name: data.name,
+          ...(parents ? { parents } : {}),
+        },
       };
     },
 


### PR DESCRIPTION
## Problem (#105)

1. `manage_drive` `copy` accepted a `name` param but silently dropped it — copies kept Drive's `"Copy of <original>"` default name.
2. After the toolkit refactor there was no way to rename a file in place or move it between folders.

## Root cause

Same body-vs-query split that `share` already hit: the generic factory path (`buildResourceArgs`) puts every declared param into the query `--params`, but Drive's `files.copy` and `files.update` take renamable metadata (`name`, `parents`) in the **request body**.

## Fix

- **`copy`** — new custom handler: `name` → `body.name`, `parentFolderId` → `body.parents`, sent via `--json`; requests `id, name, parents, webViewLink` back. Omits `--json` entirely when neither is given (plain copy still works).
- **`update`** — new operation (manifest entry + custom handler): `name` renames (request body); `addParents` / `removeParents` move between folders (query params — `files.update` keeps parent changes in the query, renamable metadata in the body). Rejects a no-op call where none of `name` / `addParents` / `removeParents` is set.

Both `copy` and the new `update` op are surfaced in `manage_drive`'s operation enum with descriptions that explain the rename/move semantics.

## Verification

- `make build` + `make test` — all 615 tests pass (6 new for `copy` / `update`).
- `make manifest-lint` — passes (`manage_drive` now 17 operations).
- Live, against a real Google account:
  - `copy` on a Google Doc with `name: "MCP copy/update repro — DELETE ME"` → new file titled exactly that (not "Copy of …").
  - `update` with `name: "… RENAMED …"` → file renamed.
  - test file deleted afterward.

Closes #105.