### PR TITLE
feat(scratchpad): live Docs batchUpdate sync for JSON mode (#79)

### DIFF
--- a/src/server/scratchpad/__tests__/docs-sync-integration.test.ts
+++ b/src/server/scratchpad/__tests__/docs-sync-integration.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Integration-ish tests for the docs-bound mutation path through the
+ * scratchpad handler. Mocks `execute` from the gws executor; everything
+ * else is real (ScratchpadManager, the docs-sync translator).
+ *
+ * Covers the two test cases that the pure-translator tests can't:
+ *  - API rejects → local buffer preserved, error response returned.
+ *  - API succeeds → reloadDocsBuffer fires, sp.lines replaced from the
+ *    fresh response, binding revisionId updated.
+ */
+
+jest.mock('../../../executor/gws.js');
+jest.mock('../../handler.js', () => ({ getEpoch: () => 0 }));
+
+import { execute } from '../../../executor/gws.js';
+import { handleScratchpad } from '../handler.js';
+import { getScratchpadManager } from '../handler.js';
+
+const mockExecute = execute as jest.MockedFunction<typeof execute>;
+
+/** Seed a docs-bound JSON scratchpad with a one-paragraph doc and return its id. */
+function seedDocsBoundScratchpad(opts?: { revisionId?: string }): string {
+  const manager = getScratchpadManager();
+  const id = manager.create({ format: 'json' });
+  const doc = {
+    documentId: 'doc-1',
+    revisionId: opts?.revisionId ?? 'rev-1',
+    body: {
+      content: [
+        {
+          startIndex: 1,
+          endIndex: 13,
+          paragraph: {
+            elements: [
+              { startIndex: 1, endIndex: 13, textRun: { content: 'Hello world\n' } },
+            ],
+            paragraphStyle: { namedStyleType: 'NORMAL_TEXT' },
+          },
+        },
+      ],
+    },
+  };
+  const sp = manager.get(id)!;
+  sp.lines = JSON.stringify(doc, null, 2).split('\n');
+  manager.setBinding(id, {
+    service: 'docs', resourceId: 'doc-1', account: 'me@test.com',
+    revisionId: opts?.revisionId ?? 'rev-1',
+  });
+  return id;
+}
+
+describe('docs-bound json_set', () => {
+  beforeEach(() => {
+    mockExecute.mockReset();
+  });
+
+  it('rejects an unsupported path WITHOUT mutating the local buffer (pre-validation)', async () => {
+    const id = seedDocsBoundScratchpad();
+    const manager = getScratchpadManager();
+    const linesBefore = [...manager.get(id)!.lines];
+
+    const result = await handleScratchpad({
+      operation: 'json_set',
+      scratchpadId: id,
+      // textStyle.bold is structural in the supported-path sense — not in the allowlist.
+      path: '$.body.content[0].paragraph.elements[0].textStyle.bold',
+      value: true,
+    });
+
+    expect(result.text).toMatch(/rejected/);
+    expect(result.text).toMatch(/not supported/);
+    // Pre-validation contract: the buffer is untouched on rejection.
+    expect(manager.get(id)!.lines).toEqual(linesBefore);
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it('on API success, pushes batchUpdate and reloads the buffer from documents.get', async () => {
+    const id = seedDocsBoundScratchpad({ revisionId: 'rev-1' });
+    const manager = getScratchpadManager();
+
+    // First call: batchUpdate succeeds.
+    // Second call: documents.get returns the fresh doc (with bumped revisionId).
+    mockExecute
+      .mockResolvedValueOnce({ success: true, data: {}, stderr: '' })
+      .mockResolvedValueOnce({
+        success: true,
+        data: {
+          documentId: 'doc-1',
+          revisionId: 'rev-2',
+          body: {
+            content: [{
+              startIndex: 1,
+              endIndex: 9,
+              paragraph: {
+                elements: [{ startIndex: 1, endIndex: 9, textRun: { content: 'Goodbye\n' } }],
+                paragraphStyle: { namedStyleType: 'NORMAL_TEXT' },
+              },
+            }],
+          },
+        },
+        stderr: '',
+      });
+
+    const result = await handleScratchpad({
+      operation: 'json_set',
+      scratchpadId: id,
+      path: '$.body.content[0].paragraph.elements[0].textRun.content',
+      value: 'Goodbye',
+    });
+
+    expect(result.refs.synced).toBe(true);
+    expect(mockExecute).toHaveBeenCalledTimes(2);
+
+    // First call: batchUpdate with the translated request + writeControl.
+    const batchArgs = mockExecute.mock.calls[0][0];
+    expect(batchArgs.slice(0, 3)).toEqual(['docs', 'documents', 'batchUpdate']);
+    const body = JSON.parse(batchArgs[batchArgs.indexOf('--json') + 1]);
+    expect(body.requests[0]).toEqual({ deleteContentRange: { range: { startIndex: 1, endIndex: 12 } } });
+    expect(body.requests[1]).toEqual({ insertText: { text: 'Goodbye', location: { index: 1 } } });
+    expect(body.writeControl).toEqual({ requiredRevisionId: 'rev-1' });
+
+    // Second call: documents.get for the reload.
+    expect(mockExecute.mock.calls[1][0].slice(0, 3)).toEqual(['docs', 'documents', 'get']);
+
+    // Buffer reloaded from fresh response.
+    const reloaded = JSON.parse(manager.get(id)!.lines.join('\n'));
+    expect(reloaded.revisionId).toBe('rev-2');
+    expect(reloaded.body.content[0].paragraph.elements[0].textRun.content).toBe('Goodbye\n');
+    // Binding revisionId advanced for the NEXT sync.
+    expect(manager.getBinding(id)?.revisionId).toBe('rev-2');
+  });
+
+  it('on API rejection, preserves the local buffer change and returns an error', async () => {
+    const id = seedDocsBoundScratchpad({ revisionId: 'rev-1' });
+    const manager = getScratchpadManager();
+
+    // Simulate the API rejecting (e.g., stale requiredRevisionId).
+    mockExecute.mockRejectedValueOnce(new Error('precondition failed: revisionId mismatch'));
+
+    const result = await handleScratchpad({
+      operation: 'json_set',
+      scratchpadId: id,
+      path: '$.body.content[0].paragraph.elements[0].textRun.content',
+      value: 'Goodbye',
+    });
+
+    expect(result.refs.error).toBe(true);
+    expect(result.text).toMatch(/Sync failed/);
+    expect(result.text).toMatch(/Retry or use scratchpad reset to discard/);
+
+    // The batchUpdate was attempted; the reload (second call) was NOT.
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+
+    // Local buffer holds the would-have-synced change — agent retries or discards.
+    const buffer = JSON.parse(manager.get(id)!.lines.join('\n'));
+    expect(buffer.body.content[0].paragraph.elements[0].textRun.content).toBe('Goodbye');
+    // Binding revisionId did NOT advance — still the original.
+    expect(manager.getBinding(id)?.revisionId).toBe('rev-1');
+  });
+
+  it('json_delete on a docs-bound scratchpad is rejected (structural)', async () => {
+    const id = seedDocsBoundScratchpad();
+    const manager = getScratchpadManager();
+    const linesBefore = [...manager.get(id)!.lines];
+
+    const result = await handleScratchpad({
+      operation: 'json_delete',
+      scratchpadId: id,
+      path: '$.body.content[0]',
+    });
+
+    expect(result.text).toMatch(/rejected/);
+    expect(result.text).toMatch(/structural/);
+    expect(manager.get(id)!.lines).toEqual(linesBefore);
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it('omits writeControl when the binding has no revisionId (legacy import)', async () => {
+    const id = seedDocsBoundScratchpad({ revisionId: undefined });
+    // Need to clear it explicitly — the seed helper defaults to 'rev-1'.
+    const manager = getScratchpadManager();
+    manager.setBinding(id, { service: 'docs', resourceId: 'doc-1', account: 'me@test.com' });
+
+    mockExecute
+      .mockResolvedValueOnce({ success: true, data: {}, stderr: '' })
+      .mockResolvedValueOnce({
+        success: true,
+        data: {
+          documentId: 'doc-1',
+          revisionId: 'rev-9',
+          body: { content: [{
+            startIndex: 1, endIndex: 13,
+            paragraph: {
+              elements: [{ startIndex: 1, endIndex: 13, textRun: { content: 'Hello world\n' } }],
+              paragraphStyle: {},
+            },
+          }] },
+        },
+        stderr: '',
+      });
+
+    await handleScratchpad({
+      operation: 'json_set',
+      scratchpadId: id,
+      path: '$.body.content[0].paragraph.elements[0].textRun.content',
+      value: 'X',
+    });
+
+    const body = JSON.parse(mockExecute.mock.calls[0][0][mockExecute.mock.calls[0][0].indexOf('--json') + 1]);
+    expect(body.writeControl).toBeUndefined();
+    // But the reload picks up a fresh revisionId for the next sync.
+    expect(manager.getBinding(id)?.revisionId).toBe('rev-9');
+  });
+});

--- a/src/server/scratchpad/__tests__/docs-sync.test.ts
+++ b/src/server/scratchpad/__tests__/docs-sync.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Tests for docs-sync — translating a scratchpad JSON-mode mutation into
+ * a Docs batchUpdate request. Pure translator; no API calls (mocked or
+ * otherwise) in this file. See issue #79.
+ */
+
+import { translateMutation, isRejection } from '../docs-sync.js';
+import type { DocsSyncIntent } from '../docs-sync.js';
+
+/** Minimal Docs-API-shaped JSON with one body content element. */
+function docWith(element: Record<string, unknown>, revisionId = 'rev-1'): string {
+  return JSON.stringify({
+    documentId: 'doc-1',
+    revisionId,
+    body: { content: [element] },
+  });
+}
+
+/** Helper — a textRun element. content/startIndex/endIndex configurable. */
+function textRunElement(content: string, startIndex: number): Record<string, unknown> {
+  return {
+    startIndex,
+    endIndex: startIndex + content.length,
+    paragraph: {
+      elements: [
+        { startIndex, endIndex: startIndex + content.length, textRun: { content } },
+      ],
+      paragraphStyle: { namedStyleType: 'NORMAL_TEXT' },
+    },
+  };
+}
+
+const TEXT_PATH = '$.body.content[0].paragraph.elements[0].textRun.content';
+const STYLE_PATH = '$.body.content[0].paragraph.paragraphStyle.namedStyleType';
+
+describe('translateMutation — textRun.content path', () => {
+  it('builds deleteContentRange(start, end-1) + insertText when old content ends with \\n', () => {
+    // Trailing newline is the paragraph break — must not delete through it,
+    // or the paragraph itself disappears.
+    const beforeJson = docWith(textRunElement('Hello world\n', 1)); // endIndex = 13
+    const result = translateMutation(
+      { op: 'set', path: TEXT_PATH, value: 'Goodbye', beforeJson },
+      'rev-1',
+    );
+    if (isRejection(result)) throw new Error(`unexpected rejection: ${result.reason}`);
+    expect(result.body.requests).toEqual([
+      { deleteContentRange: { range: { startIndex: 1, endIndex: 12 } } }, // end - 1 = 13 - 1
+      { insertText: { text: 'Goodbye', location: { index: 1 } } },
+    ]);
+    expect(result.body.writeControl).toEqual({ requiredRevisionId: 'rev-1' });
+  });
+
+  it('builds deleteContentRange(start, end) when old content has no trailing newline', () => {
+    const beforeJson = docWith(textRunElement('inline', 5));            // endIndex = 11, no trailing \n
+    const result = translateMutation(
+      { op: 'set', path: TEXT_PATH, value: 'inlined', beforeJson },
+      'rev-1',
+    );
+    if (isRejection(result)) throw new Error(`unexpected rejection: ${result.reason}`);
+    expect(result.body.requests).toEqual([
+      { deleteContentRange: { range: { startIndex: 5, endIndex: 11 } } },
+      { insertText: { text: 'inlined', location: { index: 5 } } },
+    ]);
+  });
+
+  it('omits deleteContentRange when the run is just a paragraph-break newline', () => {
+    // oldContent='\n' → deleteEnd = endIndex - 1 = startIndex; nothing to delete.
+    const beforeJson = docWith(textRunElement('\n', 7));
+    const result = translateMutation(
+      { op: 'set', path: TEXT_PATH, value: 'X', beforeJson },
+      'rev-1',
+    );
+    if (isRejection(result)) throw new Error(`unexpected rejection: ${result.reason}`);
+    expect(result.body.requests).toEqual([
+      { insertText: { text: 'X', location: { index: 7 } } },
+    ]);
+  });
+
+  it('rejects a newline in the new value (structural edit disguised as text)', () => {
+    const beforeJson = docWith(textRunElement('Hello\n', 1));
+    const result = translateMutation(
+      { op: 'set', path: TEXT_PATH, value: 'line1\nline2', beforeJson },
+      'rev-1',
+    );
+    expect(isRejection(result)).toBe(true);
+    if (isRejection(result)) expect(result.reason).toMatch(/newline/);
+  });
+
+  it('rejects a non-string value', () => {
+    const beforeJson = docWith(textRunElement('x', 1));
+    const result = translateMutation(
+      { op: 'set', path: TEXT_PATH, value: 42, beforeJson },
+      'rev-1',
+    );
+    expect(isRejection(result)).toBe(true);
+    if (isRejection(result)) expect(result.reason).toMatch(/string/);
+  });
+
+  it('rejects when the element has no textRun (e.g. an inline image)', () => {
+    const beforeJson = docWith({
+      startIndex: 1,
+      endIndex: 2,
+      paragraph: {
+        elements: [{ startIndex: 1, endIndex: 2, inlineObjectElement: { objectId: 'img-1' } }],
+      },
+    });
+    const result = translateMutation(
+      { op: 'set', path: TEXT_PATH, value: 'x', beforeJson },
+      'rev-1',
+    );
+    expect(isRejection(result)).toBe(true);
+    if (isRejection(result)) expect(result.reason).toMatch(/textRun/);
+  });
+});
+
+describe('translateMutation — paragraphStyle path', () => {
+  it('builds updateParagraphStyle with the element range and the leaf field mask', () => {
+    const beforeJson = docWith(textRunElement('Heading text\n', 1));
+    const result = translateMutation(
+      { op: 'set', path: STYLE_PATH, value: 'HEADING_1', beforeJson },
+      'rev-1',
+    );
+    if (isRejection(result)) throw new Error(`unexpected rejection: ${result.reason}`);
+    expect(result.body.requests).toEqual([{
+      updateParagraphStyle: {
+        range: { startIndex: 1, endIndex: 14 }, // 'Heading text\n'.length = 13
+        paragraphStyle: { namedStyleType: 'HEADING_1' },
+        fields: 'namedStyleType',
+      },
+    }]);
+    expect(result.body.writeControl).toEqual({ requiredRevisionId: 'rev-1' });
+  });
+
+  it('passes the leaf field name through unchanged (alignment, direction, etc.)', () => {
+    const beforeJson = docWith(textRunElement('x\n', 1));
+    const result = translateMutation(
+      { op: 'set', path: '$.body.content[0].paragraph.paragraphStyle.alignment', value: 'CENTER', beforeJson },
+      'rev-1',
+    );
+    if (isRejection(result)) throw new Error(`unexpected rejection: ${result.reason}`);
+    const r = result.body.requests[0] as Record<string, Record<string, unknown>>;
+    expect(r.updateParagraphStyle.fields).toBe('alignment');
+    expect(r.updateParagraphStyle.paragraphStyle).toEqual({ alignment: 'CENTER' });
+  });
+
+  it('rejects when the element is not a paragraph', () => {
+    const beforeJson = docWith({
+      startIndex: 1, endIndex: 5,
+      table: { rows: 1, columns: 1 },
+    });
+    const result = translateMutation(
+      { op: 'set', path: STYLE_PATH, value: 'HEADING_1', beforeJson },
+      'rev-1',
+    );
+    expect(isRejection(result)).toBe(true);
+    if (isRejection(result)) expect(result.reason).toMatch(/paragraph/);
+  });
+});
+
+describe('translateMutation — rejected paths and ops', () => {
+  it('rejects an unsupported path with a guidance message', () => {
+    const beforeJson = docWith(textRunElement('x\n', 1));
+    const result = translateMutation(
+      { op: 'set', path: '$.body.content[0].paragraph.elements[0].textStyle.bold', value: true, beforeJson },
+      'rev-1',
+    );
+    expect(isRejection(result)).toBe(true);
+    if (isRejection(result)) {
+      expect(result.reason).toMatch(/not supported/);
+      expect(result.reason).toMatch(/markdown mode/);
+    }
+  });
+
+  it('rejects json_delete on a docs-bound scratchpad (structural)', () => {
+    const beforeJson = docWith(textRunElement('x\n', 1));
+    const result = translateMutation(
+      { op: 'delete', path: TEXT_PATH, beforeJson },
+      'rev-1',
+    );
+    expect(isRejection(result)).toBe(true);
+    if (isRejection(result)) expect(result.reason).toMatch(/structural/);
+  });
+
+  it('rejects json_insert on a docs-bound scratchpad (structural)', () => {
+    const beforeJson = docWith(textRunElement('x\n', 1));
+    const result = translateMutation(
+      { op: 'insert', path: '$.body.content', value: { paragraph: {} }, beforeJson },
+      'rev-1',
+    );
+    expect(isRejection(result)).toBe(true);
+    if (isRejection(result)) expect(result.reason).toMatch(/structural/);
+  });
+
+  it('rejects when the element index is out of range', () => {
+    const beforeJson = docWith(textRunElement('x\n', 1));
+    const result = translateMutation(
+      { op: 'set', path: '$.body.content[5].paragraph.elements[0].textRun.content', value: 'y', beforeJson },
+      'rev-1',
+    );
+    expect(isRejection(result)).toBe(true);
+    if (isRejection(result)) expect(result.reason).toMatch(/not found/);
+  });
+
+  it('rejects on a malformed buffer JSON (caller surfaces "fix syntax first")', () => {
+    const result = translateMutation(
+      { op: 'set', path: TEXT_PATH, value: 'x', beforeJson: '{ this is not valid JSON' },
+      'rev-1',
+    );
+    expect(isRejection(result)).toBe(true);
+    if (isRejection(result)) expect(result.reason).toMatch(/JSON/);
+  });
+});
+
+describe('translateMutation — writeControl.requiredRevisionId', () => {
+  it('omits writeControl when no revisionId is provided', () => {
+    // E.g. an older import that didn't capture a revisionId. The API still
+    // accepts the request, just without optimistic-concurrency protection.
+    const beforeJson = docWith(textRunElement('x\n', 1));
+    const result = translateMutation(
+      { op: 'set', path: TEXT_PATH, value: 'y', beforeJson },
+      undefined,
+    );
+    if (isRejection(result)) throw new Error('unexpected rejection');
+    expect(result.body.writeControl).toBeUndefined();
+  });
+
+  it('includes writeControl for paragraphStyle changes as well as text', () => {
+    const beforeJson = docWith(textRunElement('x\n', 1));
+    const text = translateMutation({ op: 'set', path: TEXT_PATH, value: 'y', beforeJson }, 'rev-42');
+    const style = translateMutation({ op: 'set', path: STYLE_PATH, value: 'HEADING_2', beforeJson }, 'rev-42');
+    if (isRejection(text) || isRejection(style)) throw new Error('unexpected rejection');
+    expect(text.body.writeControl).toEqual({ requiredRevisionId: 'rev-42' });
+    expect(style.body.writeControl).toEqual({ requiredRevisionId: 'rev-42' });
+  });
+});
+
+describe('translateMutation — summary', () => {
+  it('summary names the path and (for text) the length delta', () => {
+    const beforeJson = docWith(textRunElement('Hello\n', 1));
+    const result = translateMutation(
+      { op: 'set', path: TEXT_PATH, value: 'Goodbye', beforeJson },
+      'rev-1',
+    );
+    if (isRejection(result)) throw new Error('unexpected rejection');
+    expect(result.summary).toMatch(/content\[0\].elements\[0\]/);
+    // 'Hello\n'.length = 6, 'Goodbye'.length = 7
+    expect(result.summary).toMatch(/6 → 7/);
+  });
+
+  it('summary names the paragraphStyle field for style changes', () => {
+    const beforeJson = docWith(textRunElement('x\n', 1));
+    const result = translateMutation(
+      { op: 'set', path: STYLE_PATH, value: 'HEADING_1', beforeJson },
+      'rev-1',
+    );
+    if (isRejection(result)) throw new Error('unexpected rejection');
+    expect(result.summary).toMatch(/paragraphStyle\.namedStyleType/);
+  });
+});
+
+/**
+ * Suggested next pass — handler-level integration tests that mock `execute`
+ * to cover the API-error-preserves-buffer and success-reloads-buffer cases.
+ * Co-located with this file would be reasonable; a separate file under the
+ * same dir keeps the unit-vs-integration split clear.
+ *
+ *  - API rejects (stale revisionId, structural error) → buffer preserved.
+ *  - API succeeds → reloadDocsBuffer fires, sp.lines replaced, binding
+ *    revisionId updated from the fresh response.
+ */

--- a/src/server/scratchpad/adapters/import-doc.ts
+++ b/src/server/scratchpad/adapters/import-doc.ts
@@ -84,7 +84,9 @@ async function importDocJson(
       '--params', JSON.stringify({ documentId }),
     ], { account: email });
 
-    const json = JSON.stringify(result.data, null, 2);
+    const doc = result.data as Record<string, unknown>;
+    const revisionId = typeof doc.revisionId === 'string' ? doc.revisionId : undefined;
+    const json = JSON.stringify(doc, null, 2);
     const lines = json.split('\n');
 
     scratchpads.appendRawLines(scratchpadId, lines);
@@ -93,11 +95,12 @@ async function importDocJson(
       service: 'docs',
       resourceId: documentId,
       account: email,
+      revisionId,  // optimistic-concurrency seed for batchUpdate (#79)
     });
 
     return {
-      text: `Imported doc as JSON (${lines.length} lines) into scratchpad ${scratchpadId}.\nLive-bound to docs/${documentId} — json_set mutations will apply directly.`,
-      refs: { scratchpadId, documentId, format: 'json', linesImported: lines.length, bound: true },
+      text: `Imported doc as JSON (${lines.length} lines) into scratchpad ${scratchpadId}.\nLive-bound to docs/${documentId} — json_set mutations push back via batchUpdate.`,
+      refs: { scratchpadId, documentId, format: 'json', linesImported: lines.length, bound: true, revisionId },
     };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/src/server/scratchpad/docs-sync.ts
+++ b/src/server/scratchpad/docs-sync.ts
@@ -1,0 +1,250 @@
+/**
+ * docs-sync — translate a single JSON-mode mutation into a Google Docs
+ * `batchUpdate` request, or reject it.
+ *
+ * Issue #79 / deferred portion of ADR-301. The scratchpad JSON-mode buffer
+ * for a Doc lets agents do `json_set` on a typed path; this module turns
+ * those intents into the discrete operations the Docs API requires
+ * (`insertText`, `deleteContentRange`, `updateParagraphStyle`) — no full
+ * JSON replace endpoint exists.
+ *
+ * Two supported path shapes:
+ *
+ *  1. `$.body.content[N].paragraph.elements[M].textRun.content`
+ *     Text content change → `deleteContentRange(startIndex, endIndex)` +
+ *     `insertText(text=newValue, location.index=startIndex)`. Watch the
+ *     trailing-newline trap: a textRun whose content ends with `\n` includes
+ *     the paragraph break in its range; deleting through it removes the
+ *     paragraph. We delete `endIndex - 1` in that case to preserve the break.
+ *     A `\n` in the new value is rejected — that's a structural edit dressed
+ *     as a text change.
+ *
+ *  2. `$.body.content[N].paragraph.paragraphStyle.<field>`
+ *     Paragraph style change → `updateParagraphStyle` over the element's
+ *     range with `fields: <field>`. We don't pre-validate the field name —
+ *     the API rejects unknown fields cleanly and we surface its message.
+ *
+ * Anything else (structural edits, table cells, list items, image
+ * properties, root-level changes) is rejected with guidance to use markdown
+ * mode + doc_create / doc_write for structural authoring.
+ *
+ * Optimistic concurrency: every translation includes
+ * `writeControl.requiredRevisionId` = the revisionId captured at import time
+ * (or after the previous successful sync). The Docs API rejects stale
+ * writes — the agent gets a clean error rather than silently corrupting a
+ * doc that's been edited by a collaborator since import.
+ */
+
+import { parsePath } from './json-path.js';
+
+export type DocsSyncOp = 'set' | 'delete' | 'insert';
+
+export interface DocsSyncIntent {
+  op: DocsSyncOp;
+  path: string;
+  /** New value for `set` / `insert`; undefined for `delete`. */
+  value?: unknown;
+  /** Pre-mutation buffer JSON text (for looking up startIndex/endIndex/oldContent). */
+  beforeJson: string;
+}
+
+/** Successful translation — body to POST to documents.batchUpdate. */
+export interface DocsSyncRequest {
+  body: {
+    requests: Array<Record<string, unknown>>;
+    writeControl?: { requiredRevisionId: string };
+  };
+  /** A human-readable summary of what was translated, for the response text. */
+  summary: string;
+}
+
+/** Rejection — caller surfaces `reason` to the agent. */
+export interface DocsSyncRejection {
+  reason: string;
+}
+
+export type DocsSyncResult = DocsSyncRequest | DocsSyncRejection;
+
+/** Translate a mutation intent into a batchUpdate request, or reject it. */
+export function translateMutation(
+  intent: DocsSyncIntent,
+  revisionId: string | undefined,
+): DocsSyncResult {
+  // `json_delete` and `json_insert` only ever shape up as structural edits in
+  // a Docs document (removing a paragraph, inserting into the content array).
+  // The Docs API has no JSON-replace primitive; structural changes need
+  // distinct operations per element type. Out of scope for #79 — reject so
+  // the agent uses markdown mode (re-author + doc_create / doc_write).
+  if (intent.op === 'delete' || intent.op === 'insert') {
+    return {
+      reason: `json_${intent.op} on a docs-bound scratchpad is structural — use markdown mode (export the doc, edit, doc_create or doc_write).`,
+    };
+  }
+
+  const segments = parsePath(intent.path);
+
+  if (isTextRunContentPath(segments)) {
+    return translateTextContent(intent, segments, revisionId);
+  }
+
+  if (isParagraphStylePath(segments)) {
+    return translateParagraphStyle(intent, segments, revisionId);
+  }
+
+  return {
+    reason: `path ${intent.path} is not supported for live Docs sync. Supported: '$.body.content[N].paragraph.elements[M].textRun.content' (text) and '$.body.content[N].paragraph.paragraphStyle.<field>' (paragraph style). For structural edits use markdown mode.`,
+  };
+}
+
+// ── Path-shape matchers ──────────────────────────────────────
+
+function isTextRunContentPath(segments: (string | number)[]): boolean {
+  return segments.length === 8
+    && segments[0] === 'body'
+    && segments[1] === 'content'
+    && typeof segments[2] === 'number'
+    && segments[3] === 'paragraph'
+    && segments[4] === 'elements'
+    && typeof segments[5] === 'number'
+    && segments[6] === 'textRun'
+    && segments[7] === 'content';
+}
+
+function isParagraphStylePath(segments: (string | number)[]): boolean {
+  return segments.length === 6
+    && segments[0] === 'body'
+    && segments[1] === 'content'
+    && typeof segments[2] === 'number'
+    && segments[3] === 'paragraph'
+    && segments[4] === 'paragraphStyle'
+    && typeof segments[5] === 'string';
+}
+
+// ── Translators ──────────────────────────────────────────────
+
+function translateTextContent(
+  intent: DocsSyncIntent,
+  segments: (string | number)[],
+  revisionId: string | undefined,
+): DocsSyncResult {
+  if (typeof intent.value !== 'string') {
+    return { reason: `textRun.content value must be a string, got ${typeof intent.value}` };
+  }
+  // A newline in the new value adds a paragraph break — that's a structural
+  // edit, not a text-content edit. Rejecting keeps the supported surface
+  // narrow and predictable; structural authoring belongs in markdown mode.
+  if (intent.value.includes('\n')) {
+    return { reason: 'newline in new value is a structural edit (adds a paragraph break) — use markdown mode for multi-paragraph content.' };
+  }
+
+  const contentIdx = segments[2] as number;
+  const elementIdx = segments[5] as number;
+
+  let doc: unknown;
+  try {
+    doc = JSON.parse(intent.beforeJson);
+  } catch {
+    return { reason: 'buffer JSON parse failed — fix syntax errors before sync.' };
+  }
+
+  const element = navigate(doc, ['body', 'content', contentIdx, 'paragraph', 'elements', elementIdx]);
+  if (!element || typeof element !== 'object') {
+    return { reason: `element at body.content[${contentIdx}].paragraph.elements[${elementIdx}] not found in buffer.` };
+  }
+  const e = element as Record<string, unknown>;
+  const startIndex = e.startIndex;
+  const endIndex = e.endIndex;
+  const textRun = e.textRun as Record<string, unknown> | undefined;
+  const oldContent = textRun?.content;
+
+  if (typeof startIndex !== 'number' || typeof endIndex !== 'number') {
+    return { reason: `element at content[${contentIdx}].elements[${elementIdx}] is missing startIndex/endIndex.` };
+  }
+  if (typeof oldContent !== 'string') {
+    return { reason: `element at content[${contentIdx}].elements[${elementIdx}] is not a textRun (or has no content).` };
+  }
+
+  // Trailing-newline trap: if the run's content ends with `\n`, that newline
+  // IS the paragraph break. Deleting through endIndex removes the paragraph;
+  // delete through endIndex-1 instead and the paragraph survives.
+  const deleteEnd = oldContent.endsWith('\n') ? endIndex - 1 : endIndex;
+  // Defensive: if the element is a bare-newline run (oldContent === '\n'),
+  // there's nothing to delete; just insert.
+  const requests: Array<Record<string, unknown>> = [];
+  if (deleteEnd > startIndex) {
+    requests.push({
+      deleteContentRange: { range: { startIndex, endIndex: deleteEnd } },
+    });
+  }
+  requests.push({
+    insertText: { text: intent.value, location: { index: startIndex } },
+  });
+
+  return {
+    body: {
+      requests,
+      ...(revisionId ? { writeControl: { requiredRevisionId: revisionId } } : {}),
+    },
+    summary: `text content @ content[${contentIdx}].elements[${elementIdx}] (${oldContent.length} → ${intent.value.length} chars)`,
+  };
+}
+
+function translateParagraphStyle(
+  intent: DocsSyncIntent,
+  segments: (string | number)[],
+  revisionId: string | undefined,
+): DocsSyncResult {
+  const contentIdx = segments[2] as number;
+  const field = segments[5] as string;
+
+  let doc: unknown;
+  try {
+    doc = JSON.parse(intent.beforeJson);
+  } catch {
+    return { reason: 'buffer JSON parse failed — fix syntax errors before sync.' };
+  }
+
+  const structural = navigate(doc, ['body', 'content', contentIdx]);
+  if (!structural || typeof structural !== 'object') {
+    return { reason: `content[${contentIdx}] not found in buffer.` };
+  }
+  const s = structural as Record<string, unknown>;
+  const startIndex = s.startIndex;
+  const endIndex = s.endIndex;
+  if (typeof startIndex !== 'number' || typeof endIndex !== 'number') {
+    return { reason: `content[${contentIdx}] is missing startIndex/endIndex.` };
+  }
+  if (!s.paragraph) {
+    return { reason: `content[${contentIdx}] is not a paragraph (paragraphStyle only applies to paragraphs).` };
+  }
+
+  return {
+    body: {
+      requests: [{
+        updateParagraphStyle: {
+          range: { startIndex, endIndex },
+          paragraphStyle: { [field]: intent.value },
+          fields: field,
+        },
+      }],
+      ...(revisionId ? { writeControl: { requiredRevisionId: revisionId } } : {}),
+    },
+    summary: `paragraphStyle.${field} @ content[${contentIdx}]`,
+  };
+}
+
+// ── Helpers ──────────────────────────────────────────────────
+
+function navigate(obj: unknown, segments: (string | number)[]): unknown {
+  let current = obj;
+  for (const seg of segments) {
+    if (current === null || current === undefined || typeof current !== 'object') return undefined;
+    current = (current as Record<string, unknown>)[String(seg)];
+  }
+  return current;
+}
+
+/** Type guard — narrows DocsSyncResult to the rejection arm. */
+export function isRejection(result: DocsSyncResult): result is DocsSyncRejection {
+  return 'reason' in result;
+}

--- a/src/server/scratchpad/handler.ts
+++ b/src/server/scratchpad/handler.ts
@@ -3,7 +3,8 @@
  * See ADR-301: Scratchpad Buffer — Service-Agnostic Content Authoring.
  */
 
-import { ScratchpadManager } from './manager.js';
+import { ScratchpadManager, type LiveBinding } from './manager.js';
+import { translateMutation, isRejection, type DocsSyncIntent } from './docs-sync.js';
 import * as fs from 'node:fs/promises';
 import {
   sendEmail, sendEmailDraft, sendDocCreate, sendDocWrite, sendWorkspace,
@@ -253,14 +254,18 @@ async function handleJsonSet(params: Record<string, unknown>): Promise<HandlerRe
   if (!jsonPath) return error('path is required for json_set.');
   if (!('value' in params)) return error('value is required for json_set.');
 
-  // Local mutation first
+  // For docs-bound scratchpads, pre-validate the mutation before applying
+  // locally — unsupported paths shouldn't strand the buffer divergent.
+  const docsResult = await maybeHandleDocsBoundMutation(id, {
+    op: 'set', path: jsonPath, value: params.value,
+  });
+  if (docsResult) return docsResult;
+
+  // Non-docs flow: mutate, then sync (sheets pushes; unbound is a no-op).
   const result = scratchpads.jsonSet(id, jsonPath, params.value);
   if (!result) return scratchpadNotFound(id);
-
-  // If live-bound, push to API and reload
   const syncResult = await syncIfBound(id);
   if (syncResult) return syncResult;
-
   return { text: formatMutation(result), refs: { scratchpadId: id } };
 }
 
@@ -271,12 +276,13 @@ async function handleJsonDelete(params: Record<string, unknown>): Promise<Handle
   const jsonPath = params.path as string | undefined;
   if (!jsonPath) return error('path is required for json_delete.');
 
+  const docsResult = await maybeHandleDocsBoundMutation(id, { op: 'delete', path: jsonPath });
+  if (docsResult) return docsResult;
+
   const result = scratchpads.jsonDelete(id, jsonPath);
   if (!result) return scratchpadNotFound(id);
-
   const syncResult = await syncIfBound(id);
   if (syncResult) return syncResult;
-
   return { text: formatMutation(result), refs: { scratchpadId: id } };
 }
 
@@ -288,13 +294,98 @@ async function handleJsonInsert(params: Record<string, unknown>): Promise<Handle
   if (!jsonPath) return error('path is required for json_insert.');
   if (!('value' in params)) return error('value is required for json_insert.');
 
+  const docsResult = await maybeHandleDocsBoundMutation(id, {
+    op: 'insert', path: jsonPath, value: params.value,
+  });
+  if (docsResult) return docsResult;
+
   const result = scratchpads.jsonInsert(id, jsonPath, params.value);
   if (!result) return scratchpadNotFound(id);
-
   const syncResult = await syncIfBound(id);
   if (syncResult) return syncResult;
-
   return { text: formatMutation(result), refs: { scratchpadId: id } };
+}
+
+/**
+ * For docs-bound scratchpads, translate the intent, push via batchUpdate,
+ * reload, and return the response. Returns null when the scratchpad isn't
+ * docs-bound (caller falls through to the existing non-docs flow).
+ *
+ * The mutation is pre-validated against the BEFORE buffer so unsupported
+ * paths reject without mutating local state (#79).
+ */
+async function maybeHandleDocsBoundMutation(
+  id: string,
+  intent: Omit<DocsSyncIntent, 'beforeJson'>,
+): Promise<HandlerResponse | null> {
+  const binding = scratchpads.getBinding(id);
+  if (binding?.service !== 'docs') return null;
+
+  const before = scratchpads.getContent(id);
+  if (before === null) return scratchpadNotFound(id);
+
+  const translated = translateMutation({ ...intent, beforeJson: before }, binding.revisionId);
+  if (isRejection(translated)) {
+    return error(`json_${intent.op} rejected: ${translated.reason}`);
+  }
+
+  // Apply the mutation locally now that we know it's translatable.
+  const result = applyMutation(id, intent);
+  if (!result) return scratchpadNotFound(id);
+
+  // Push to the Docs API.
+  try {
+    await execute([
+      'docs', 'documents', 'batchUpdate',
+      '--params', JSON.stringify({ documentId: binding.resourceId }),
+      '--json', JSON.stringify(translated.body),
+    ], { account: binding.account });
+  } catch (err) {
+    // The buffer has the local change; the doc doesn't. Match the sheets
+    // error contract — agent retries or discards.
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      text: `Sync failed: ${message}\nLocal buffer still has your changes. Retry or use scratchpad reset to discard.`,
+      refs: { error: true, scratchpadId: id },
+    };
+  }
+
+  // Reload the buffer from the doc — the doc is the source of truth.
+  // This also picks up the new revisionId for the next sync.
+  await reloadDocsBuffer(id, binding);
+
+  return {
+    text: `${formatMutation(result)}\n_Synced: ${translated.summary}_`,
+    refs: { scratchpadId: id, synced: true, summary: translated.summary },
+  };
+}
+
+/** Dispatch the local mutation matching the intent's op. */
+function applyMutation(
+  id: string,
+  intent: Omit<DocsSyncIntent, 'beforeJson'>,
+): ReturnType<ScratchpadManager['jsonSet']> {
+  switch (intent.op) {
+    case 'set':    return scratchpads.jsonSet(id, intent.path, intent.value);
+    case 'delete': return scratchpads.jsonDelete(id, intent.path);
+    case 'insert': return scratchpads.jsonInsert(id, intent.path, intent.value);
+  }
+}
+
+/** Re-fetch the doc, replace the buffer, and update the binding's revisionId. */
+async function reloadDocsBuffer(id: string, binding: LiveBinding): Promise<void> {
+  const result = await execute([
+    'docs', 'documents', 'get',
+    '--params', JSON.stringify({ documentId: binding.resourceId }),
+  ], { account: binding.account });
+  const doc = result.data as Record<string, unknown>;
+  const freshJson = JSON.stringify(doc, null, 2);
+  const sp = scratchpads.get(id);
+  if (!sp) return;
+  sp.lines = freshJson.split('\n');
+  if (sp.binding) {
+    sp.binding.revisionId = typeof doc.revisionId === 'string' ? doc.revisionId : undefined;
+  }
 }
 
 /**
@@ -311,18 +402,12 @@ async function syncIfBound(id: string): Promise<HandlerResponse | null> {
 
   try {
     if (binding.service === 'docs') {
-      // Docs API requires batchUpdate with discrete operations (insertText,
-      // deleteContentRange, etc.) — no full JSON replace endpoint.
-      //
-      // Future (#79): translate text content changes (textRun.content) to
-      // deleteContentRange + insertText using startIndex/endIndex from
-      // the JSON structure. Structural changes (add/remove paragraphs)
-      // that batchUpdate rejects should return guidance to use markdown
-      // mode + doc_create instead. One edit per sync cycle with reload.
-      //
-      // For now: local mutations are source of truth. The buffer diverges
-      // from the live doc. Agent can send modified JSON to workspace.
-      return null; // Local mutation already applied
+      // Docs JSON-mode mutations are handled upstream by
+      // maybeHandleDocsBoundMutation, which translates the intent into
+      // a batchUpdate request, pushes, and reloads. Reaching this point
+      // means a non-json operation on a docs-bound scratchpad — nothing
+      // to sync (those op types don't reflect into the doc anyway).
+      return null;
     } else if (binding.service === 'sheets') {
       // For Sheets: the buffer is the values JSON.
       // Push back via spreadsheets.values.update.

--- a/src/server/scratchpad/manager.ts
+++ b/src/server/scratchpad/manager.ts
@@ -17,6 +17,13 @@ export interface LiveBinding {
   service: 'docs' | 'sheets';
   resourceId: string;
   account: string;
+  /**
+   * Doc revision at import time (Docs only). Sent as
+   * `writeControl.requiredRevisionId` on batchUpdate so the API rejects
+   * stale writes when a collaborator has edited the doc since import.
+   * Updated after every successful sync+reload (issue #79).
+   */
+  revisionId?: string;
 }
 
 /** File reference tracked in the attachment side-table. */


### PR DESCRIPTION
Closes #79. Implements the deferred Docs sync path called out in ADR-301.

## What

When a Doc is imported as a JSON-mode scratchpad (`import source: doc, mode: json`), `json_set` mutations now push back via `documents.batchUpdate` and the buffer reloads from the doc — instead of diverging silently. Two supported path shapes:

| Path shape | Translates to |
|---|---|
| `$.body.content[N].paragraph.elements[M].textRun.content` | `deleteContentRange` + `insertText` over the element's range |
| `$.body.content[N].paragraph.paragraphStyle.<field>` | `updateParagraphStyle` with `fields: <field>` |

Anything else is rejected with guidance to use markdown mode + `doc_create` / `doc_write` for structural authoring. `json_delete` and `json_insert` on docs-bound scratchpads are always structural and always rejected.

## How it handles the fiddly bits

- **Trailing-newline trap.** A textRun whose `content` ends with `\n` includes the paragraph break in its `[startIndex, endIndex)`. Naive deletion removes the paragraph itself. The translator deletes through `endIndex - 1` when the old content ends with `\n` so the break survives.
- **Newline in new value.** Rejected — a `\n` in the replacement string is a structural edit (adds a paragraph break) dressed as a text edit.
- **Pre-validation.** The translator runs *before* the local mutation. Unsupported paths reject without ever mutating the buffer — the agent isn't left in a divergent state. (Differs from the existing sheets contract, which mutates first then syncs; for docs the failure modes include "this will never sync" rather than "network blip — retry," so pre-validation is the right call.)
- **Optimistic concurrency via `requiredRevisionId`.** `LiveBinding` gains `revisionId?`. `importDocJson` captures it; the translator includes `writeControl: { requiredRevisionId }` on every batchUpdate. The API rejects stale writes if a collaborator has edited the doc since import; the agent gets a clean error rather than silently corrupting content at stale indices. After every successful sync the binding's revisionId advances from the reloaded response.
- **Reload-on-success.** After a successful batchUpdate, the buffer is replaced with a fresh `documents.get` response. The doc is the source of truth post-sync — agents reading the buffer see canonical state, not stale local pre-sync edits.
- **Error contract on API failure.** Local buffer change is preserved; response matches the sheets-sync wording ("Local buffer still has your changes. Retry or use scratchpad reset to discard."). The reload doesn't fire on failure, so the binding's revisionId doesn't advance.

## Out of scope (and why)

- **Structural edits** (adding/removing paragraphs, list items, table cells). Each needs its own batchUpdate primitive (`createParagraphBullets`, `insertTableRow`, etc.); a fragile general-case diff was explicitly avoided in favor of the path-pattern dispatch. Agents needing structural authoring use markdown mode + `doc_create` / `doc_write`.
- **`textStyle` (bold/italic/color/etc.) and inline objects.** Same reasoning — distinct API primitives, narrow value over the existing `replaceText` / `insertText` ops in `manage_docs`. Worth a follow-up issue when there's a concrete use case.
- **`writeControl.targetRevisionId`** (the alternative concurrency model — replay on a known revision). Optimistic rejection is the simpler, stricter choice. Documented choice; revisit if collaboration patterns demand it.

## Coverage

- **18 translator unit tests** — every path shape (text variants, trailing-newline, paragraphStyle range/mask), every rejection branch (unsupported path, newline-in-value, non-string value, missing textRun, non-paragraph element, out-of-range index, malformed buffer JSON, `json_delete` / `json_insert`), and the `requiredRevisionId` presence in both supported request types.
- **5 integration tests** with a mocked `execute` — pre-validation rejection preserves buffer (no API call), success reloads the buffer from `documents.get` and advances `binding.revisionId`, API rejection preserves local change and surfaces the error, `json_delete` on a docs-bound scratchpad is rejected, `writeControl` is omitted when the binding has no revisionId (legacy import path).
- **678 tests pass overall**, `make build` clean.

## Live-verified end-to-end

Against a real Google account:
1. Created a throwaway doc with two paragraphs.
2. Imported as JSON scratchpad — binding captured `revisionId`.
3. `json_set $.body.content[1].paragraph.elements[0].textRun.content = "Goodbye, world!"` → doc updated, buffer reloaded; paragraph 2's `startIndex` correctly shifted from 37 to 17 (matching the 20-char shrink of paragraph 1).
4. `json_set $.body.content[2].paragraph.paragraphStyle.namedStyleType = "HEADING_1"` → heading style applied; the reloaded buffer shows Docs auto-assigned a `headingId`, proof the API processed the change.
5. `json_set` on `textRun.textStyle.bold` → clean rejection, buffer unchanged (verified empty `textStyle: {}` after).
6. `json_set` with a multi-line value → clean rejection on the newline check.

Test doc + scratchpad cleaned up afterward.