### PR TITLE
docs(readme): add badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Google Workspace MCP Server
 
+[![npm version](https://img.shields.io/npm/v/@aaronsb/google-workspace-mcp?logo=npm&label=npm)](https://www.npmjs.com/package/@aaronsb/google-workspace-mcp)
+[![Latest release](https://img.shields.io/github/v/release/aaronsb/google-workspace-mcp?include_prereleases&label=release)](https://github.com/aaronsb/google-workspace-mcp/releases)
+[![Node](https://img.shields.io/node/v/@aaronsb/google-workspace-mcp?logo=node.js&label=node)](https://nodejs.org)
+[![License](https://img.shields.io/github/license/aaronsb/google-workspace-mcp)](LICENSE)
+
 Give AI agents full access to Google Workspace — Gmail, Calendar, Drive, and more — through a single MCP server that handles multi-account credential routing, response formatting for AI consumption, and contextual guidance.
 
 Built on [Google's official Workspace CLI](https://github.com/googleworkspace/cli) (`gws`), which means API coverage grows as Google does. The server uses a manifest-driven factory that turns declarative YAML into fully functional MCP tools — adding a new Google API operation is a config change, not a code change.


### PR DESCRIPTION
Repo-health scan flagged missing README badges. Adds four below the H1:

- **npm version** → npmjs package page
- **Latest release** → GitHub releases (includes prereleases)
- **Node** → required Node version (from package.json `engines`, falls back to `>=` floor)
- **License** → LICENSE file

Notes on the other repo-health items:
- **Issue templates** — already present (`.github/ISSUE_TEMPLATE/bug_report.md`, `feature_request.md`, plus `.github/pull_request_template.md`). The scan flag was stale.
- **Branch protection** — needs admin access; left for @aaronsb to configure (e.g. require PR + passing `ci.yml` before merge to `main`).