### PR TITLE
docs: API coverage page + README refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,21 @@ Built on [Google's official Workspace CLI](https://github.com/googleworkspace/cl
 
 ## What's Available
 
-**5 tools, 32+ operations across 3 core services:**
+**7 Google-service tools (~80 operations) plus account, batching, and content-authoring tools.** The full surface — what's covered, what isn't, and how it grows — is mapped in **[API coverage](docs/coverage.md)**.
 
-| Tool | Operations | What It Does |
-|------|-----------|--------------|
-| `manage_email` | search, read, send, reply, replyAll, forward, triage, trash, untrash, modify, labels, threads, getThread | Full Gmail — search, read, compose, thread management, label management |
-| `manage_calendar` | list, agenda, get, create, quickAdd, update, delete, calendars, freebusy | Calendar CRUD, natural language event creation, availability checks |
-| `manage_drive` | search, get, upload, download, copy, delete, export, listPermissions, share, unshare | File management, Google Docs export, sharing and permissions |
-| `manage_accounts` | list, authenticate, remove, status, refresh, scopes | Multi-account lifecycle — add accounts, manage credentials and scopes |
-| `queue_operations` | — | Chain operations sequentially with `$N.field` result references |
+| Tool | What It Does |
+|------|--------------|
+| `manage_email` | Gmail — search, read (plain or sanitized HTML body), send, reply / reply-all, forward, triage, trash, labels, threads, attachments |
+| `manage_calendar` | Calendar — list, agenda, get, create, quickAdd (natural language), update, delete, calendars, freebusy |
+| `manage_drive` | Drive — search, get, upload, download, copy, rename / move (`update`), delete, export, permissions, comments, view images |
+| `manage_sheets` | Sheets — read / write ranges (row-numbered output), append, clear, manage tabs, copy / duplicate / rename |
+| `manage_docs` | Docs — get, create, append, insert text, find-and-replace |
+| `manage_tasks` | Tasks — list / create / update / complete tasks and task lists |
+| `manage_meet` | Meet — browse past conferences, participants, transcripts, recordings, smart notes |
+| `manage_accounts` | Multi-account lifecycle — add accounts, manage credentials and scopes |
+| `manage_scratchpad` | Compose / edit multi-line content (line- or JSON-path-addressed), attach files, send to any target; JSON mode live-syncs to Docs / Sheets |
+| `manage_workspace` | File operations in the workspace sandbox (exchange point for attachments, downloads, exports) |
+| `queue_operations` | Chain operations sequentially with `$N.field` result references |
 
 Every response includes **next-steps** guidance — the agent always knows what it can do next.
 

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -1,0 +1,44 @@
+# API Coverage
+
+This server exposes a **curated subset** of the [`gws` CLI](https://github.com/googleworkspace/cli)'s surface — the operations and parameters that are actually useful to an AI agent, with LLM-friendly descriptions, sensible defaults, and patched response formatting. It is not a 1:1 passthrough of every Google API method. See [ADR-100](architecture/core/ADR-100-build-time-coverage-analysis-of-gws-cli-surface.md) (build-time coverage analysis) and [ADR-300](architecture/api/ADR-300-service-tool-factory-with-manifest-driven-generation.md) (the manifest-driven factory).
+
+Adding an operation is a config change, not a code change: drop an entry into `src/factory/manifest/<service>.yaml` and it becomes a fully-formed MCP tool operation. So coverage grows on demand, in the direction agents actually need.
+
+## Snapshot
+
+> Generated `2026-05-11` against `gws 0.22.5`. Regenerate with `make coverage`; this table will drift as gws adds methods or the manifest grows.
+
+**72 / 344 operations covered (21%)** across 12 gws services. The MCP tools surface 7 of them (`manage_email`, `manage_calendar`, `manage_drive`, `manage_sheets`, `manage_docs`, `manage_tasks`, `manage_meet`); the rest aren't exposed yet.
+
+| Service | Covered | % | Gaps | MCP tool |
+|---|---:|---:|---:|---|
+| docs | 4 / 4 | 100% | — | `manage_docs` |
+| tasks | 9 / 14 | 64% | 5 | `manage_tasks` |
+| meet | 10 / 18 | 56% | 8 | `manage_meet` |
+| sheets | 9 / 19 | 47% | 10 | `manage_sheets` |
+| drive | 15 / 65 | 23% | 50 | `manage_drive` |
+| calendar | 9 / 40 | 23% | 31 | `manage_calendar` |
+| gmail | 14 / 85 | 16% | 71 | `manage_email` |
+| events | 1 / 17 | 6% | 16 | — |
+| chat | 1 / 46 | 2% | 45 | — |
+| slides | 0 / 5 | 0% | 5 | — |
+| people | 0 / 24 | 0% | 24 | — |
+| keep | 0 / 7 | 0% | 7 | — |
+
+Low percentages on the high-surface services (gmail, drive) are by design — most of the uncovered methods are admin/domain operations, label/permission plumbing variants, or pagination/filtering parameters that an agent rarely needs. The covered slice is the "do useful work in a conversation" set. `make coverage` prints the full per-operation parameter-gap list for anyone curating an addition.
+
+### Not exposed yet
+
+- **people** (Contacts) — `gws auth login` doesn't offer the `contacts.readonly` scope ([googleworkspace/cli#556](https://github.com/googleworkspace/cli/issues/556)).
+- **slides**, **keep**, **chat**, **events** — no concrete agent use case has driven coverage. Open an issue if you have one.
+
+## Regenerating
+
+| Command | What it does |
+|---|---|
+| `make coverage` | Discovers the live gws CLI surface, diffs it against the curated manifest, prints the coverage table + every uncovered operation + every parameter gap in covered operations. |
+| `make coverage-update` | Same, but writes the result to `coverage-baseline.json` so the next run can show "new since baseline." |
+| `make manifest-discover` | Dumps the full discovered manifest (all gws operations, with `# CURATE` markers) to `discovered-manifest.yaml` — the raw material for a new manifest entry. |
+| `make manifest-diff` | Diffs the curated manifest against `discovered-manifest.yaml`. |
+
+To add an operation: find it in `discovered-manifest.yaml`, copy the entry into the right `src/factory/manifest/<service>.yaml`, curate the description / defaults / param mappings, then `make manifest-lint && make test`. See `.claude/ways/factory/way.md` for the full workflow.


### PR DESCRIPTION
Per request: run `make coverage`, turn the result into a docs page, link it near the top of the README so readers get a clear picture of the API surface.

## Changes

- **`docs/coverage.md`** (new) — the curated-subset philosophy (links ADR-100 / ADR-300), a dated/version-stamped snapshot of the coverage table (72/344 ops across 12 gws services; 7 exposed as MCP tools), the not-yet-exposed services with the reason for each (Contacts: missing scope; Slides/Keep/Chat/Events: no driving use case), and the regeneration commands (`make coverage`, `make coverage-update`, `make manifest-discover`, `make manifest-diff`). The doc is explicit that it's a point-in-time snapshot — `make coverage` is the live source.
- **`README.md`** — links the coverage page from "What's Available", and refreshes that section, which was stale ("5 tools, 32+ operations across 3 core services" → all 7 service tools + accounts / scratchpad / workspace / queue with accurate one-liners, reflecting everything merged through v2.7.1).

Pure docs — no code review needed per the request. No version bump.