### PR TITLE
feat(gmail): support send from aliases

### DIFF
--- a/src/__tests__/factory/generator.test.ts
+++ b/src/__tests__/factory/generator.test.ts
@@ -165,6 +165,28 @@ describe('generateHandler', () => {
     expect(result.refs).toHaveProperty('to', 'bob@t.com');
   });
 
+  it('passes from alias to Gmail send customHandler', async () => {
+    mockExecute.mockResolvedValue({
+      success: true,
+      data: { id: 'sent-1', threadId: 'thread-1' },
+      stderr: '',
+    });
+    const handler = generateHandler(manifest.services.gmail, patches.gmail);
+
+    await handler({
+      operation: 'send',
+      email: 'u@t.com',
+      to: 'bob@t.com',
+      subject: 'hello',
+      body: 'hi bob',
+      from: 'Agent Name <agent@example.com>',
+    });
+
+    const args = mockExecute.mock.calls[0][0];
+    expect(args).toContain('--from');
+    expect(args[args.indexOf('--from') + 1]).toBe('Agent Name <agent@example.com>');
+  });
+
   it('throws on unknown operation', async () => {
     const handler = generateHandler(manifest.services.gmail, patches.gmail);
 

--- a/src/__tests__/server/tools.test.ts
+++ b/src/__tests__/server/tools.test.ts
@@ -66,6 +66,13 @@ describe('manage_email schema', () => {
     const required = (tool.inputSchema as any).required;
     expect(required).toContain('email');
   });
+
+  it('exposes from for Gmail send aliases', () => {
+    expect(props.from).toMatchObject({
+      type: 'string',
+    });
+    expect(props.from.description).toContain('Send As alias');
+  });
 });
 
 describe('manage_calendar schema', () => {

--- a/src/factory/manifest/gmail.yaml
+++ b/src/factory/manifest/gmail.yaml
@@ -63,6 +63,9 @@ operations:
         type: string
         description: "Email body text"
         required: true
+      from:
+        type: string
+        description: "Sender email or RFC 2822 mailbox for a verified Gmail Send As alias"
       cc:
         type: string
         description: "CC email(s), comma-separated"
@@ -82,6 +85,7 @@ operations:
       to: "--to"
       subject: "--subject"
       body: "--body"
+      from: "--from"
       cc: "--cc"
       bcc: "--bcc"
 

--- a/src/services/gmail/patch.ts
+++ b/src/services/gmail/patch.ts
@@ -226,6 +226,7 @@ export const gmailPatch: ServicePatch = {
         : [];
 
       const args = ['gmail', '+send', '--to', to, '--subject', subject, '--body', body];
+      if (params.from) args.push('--from', String(params.from));
       if (params.cc) args.push('--cc', String(params.cc));
       if (params.bcc) args.push('--bcc', String(params.bcc));
       if (params.html === true || params.html === 'true') args.push('--html');


### PR DESCRIPTION
## Summary

Fixes #127.

This exposes Gmail Send As alias support through the MCP-facing `manage_email send` operation by:

- adding an optional `from` parameter to the Gmail manifest/schema
- passing `from` through to `gws gmail +send --from` in the custom send handler
- covering both schema exposure and argument forwarding with tests

## Testing

- `npm install --ignore-scripts`
- `npm test -- --runTestsByPath src/__tests__/factory/generator.test.ts src/__tests__/server/tools.test.ts`
- `npm run type-check`
- `npm test`
- `npm run lint` (reports one pre-existing warning in `src/services/calendar/patch.ts`, unrelated to this change)

## Notes

I used `--ignore-scripts` for install because the bundled `gws` binary download was not needed for these mocked unit tests.