### PR TITLE
feat(gmail): add attachment and html support to reply and replyAll

### DIFF
--- a/src/factory/manifest.yaml
+++ b/src/factory/manifest.yaml
@@ -103,6 +103,15 @@ services:
             type: string
             description: "Reply body text"
             required: true
+          attachments:
+            type: string
+            description: "Workspace filenames to attach, comma-separated (files must exist in workspace via manage_workspace). Creates draft when present."
+          html:
+            type: boolean
+            description: "Treat body as HTML content (default: plain text)"
+          draft:
+            type: boolean
+            description: "Save as draft instead of sending (default: false, forced true when attachments present)"
         cli_args:
           messageId: "--message-id"
           body: "--body"
@@ -123,6 +132,15 @@ services:
           cc:
             type: string
             description: "Additional CC email(s), comma-separated"
+          attachments:
+            type: string
+            description: "Workspace filenames to attach, comma-separated (files must exist in workspace via manage_workspace). Creates draft when present."
+          html:
+            type: boolean
+            description: "Treat body as HTML content (default: plain text)"
+          draft:
+            type: boolean
+            description: "Save as draft instead of sending (default: false, forced true when attachments present)"
         cli_args:
           messageId: "--message-id"
           body: "--body"

--- a/src/services/gmail/patch.ts
+++ b/src/services/gmail/patch.ts
@@ -293,12 +293,80 @@ export const gmailPatch: ServicePatch = {
     reply: async (params, account): Promise<HandlerResponse> => {
       const messageId = requireString(params, 'messageId');
       const body = requireString(params, 'body');
-      const result = await execute([
-        'gmail', '+reply', '--message-id', messageId, '--body', body,
-      ], { account });
+      const draft = params.draft === true || params.draft === 'true';
+      const attachmentNames = params.attachments
+        ? String(params.attachments).split(',').map(s => s.trim()).filter(Boolean)
+        : [];
+
+      const args = ['gmail', '+reply', '--message-id', messageId, '--body', body];
+      if (params.html === true || params.html === 'true') args.push('--html');
+      if (draft || attachmentNames.length > 0) args.push('--draft');
+
+      let execOptions: { account: string; cwd?: string } = { account };
+      if (attachmentNames.length > 0) {
+        const relPaths = await validateAttachments(attachmentNames);
+        for (const p of relPaths) {
+          args.push('--attach', p);
+        }
+        execOptions = { account, cwd: getWorkspaceDir() };
+      }
+
+      const result = await execute(args, execOptions);
       const data = result.data as Record<string, unknown>;
+      const attachNote = attachmentNames.length > 0
+        ? `\n**Attachments:** ${attachmentNames.join(', ')}`
+        : '';
+
+      if (draft || attachmentNames.length > 0) {
+        return {
+          text: `Draft reply created.\n\n**Draft ID:** ${data.id ?? 'unknown'}${attachNote}`,
+          refs: { id: data.id, draftId: data.id, messageId, attachments: attachmentNames, isDraft: true },
+        };
+      }
+
       return {
         text: `Reply sent.\n\n**Message ID:** ${data.id ?? 'unknown'}`,
+        refs: { id: data.id, threadId: data.threadId, messageId },
+      };
+    },
+
+    replyAll: async (params, account): Promise<HandlerResponse> => {
+      const messageId = requireString(params, 'messageId');
+      const body = requireString(params, 'body');
+      const draft = params.draft === true || params.draft === 'true';
+      const attachmentNames = params.attachments
+        ? String(params.attachments).split(',').map(s => s.trim()).filter(Boolean)
+        : [];
+
+      const args = ['gmail', '+reply-all', '--message-id', messageId, '--body', body];
+      if (params.cc) args.push('--cc', String(params.cc));
+      if (params.html === true || params.html === 'true') args.push('--html');
+      if (draft || attachmentNames.length > 0) args.push('--draft');
+
+      let execOptions: { account: string; cwd?: string } = { account };
+      if (attachmentNames.length > 0) {
+        const relPaths = await validateAttachments(attachmentNames);
+        for (const p of relPaths) {
+          args.push('--attach', p);
+        }
+        execOptions = { account, cwd: getWorkspaceDir() };
+      }
+
+      const result = await execute(args, execOptions);
+      const data = result.data as Record<string, unknown>;
+      const attachNote = attachmentNames.length > 0
+        ? `\n**Attachments:** ${attachmentNames.join(', ')}`
+        : '';
+
+      if (draft || attachmentNames.length > 0) {
+        return {
+          text: `Draft reply-all created.\n\n**Draft ID:** ${data.id ?? 'unknown'}${attachNote}`,
+          refs: { id: data.id, draftId: data.id, messageId, attachments: attachmentNames, isDraft: true },
+        };
+      }
+
+      return {
+        text: `Reply-all sent.\n\n**Message ID:** ${data.id ?? 'unknown'}`,
         refs: { id: data.id, threadId: data.threadId, messageId },
       };
     },


### PR DESCRIPTION
## Summary

- `reply` and `replyAll` silently dropped the `attachments` parameter — it was accepted in the tool schema but never wired into the gws CLI call
- `reply` also had no `html` flag support, unlike `send`
- Neither operation had a `draft` param

## Changes

**`src/factory/manifest.yaml`**
- Added `attachments`, `html`, and `draft` params to both `reply` and `replyAll`

**`src/services/gmail/patch.ts`**
- Promoted `reply` and `replyAll` to full custom handlers in `gmailPatch`, mirroring the existing `send` handler's attachment logic:
  - Parses comma-separated attachment filenames from the workspace
  - Validates and resolves paths via `validateAttachments`
  - Passes `--attach` flags and sets `cwd` to the workspace dir (required by the gws upload endpoint)
  - Adds `--draft` when attachments are present (same behaviour as `send`)
  - Returns a clear draft ID in the response so callers know to send from Drafts

## Behaviour

Without attachments: `reply`/`replyAll` behave exactly as before — sends immediately.  
With attachments: creates a Gmail draft (consistent with `send`) and returns the draft ID.

## How to reproduce the bug

```
# File exists in workspace, replyAll silently sends without it
manage_email replyAll messageId=<id> body="see attached" attachments="report.pdf"
# → email arrives with no attachment, no error
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)