### PR TITLE
fix(gmail): reply/replyAll honour attachments, html and draft (closes #132)

### DIFF
--- a/src/__tests__/factory/generator.test.ts
+++ b/src/__tests__/factory/generator.test.ts
@@ -1,3 +1,6 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { loadManifest, generateTools, generateSchema, generateHandler } from '../../factory/generator.js';
 import { patches } from '../../factory/patches.js';
 import type { Manifest, ServiceDef } from '../../factory/types.js';
@@ -193,6 +196,147 @@ describe('generateHandler', () => {
     await expect(
       handler({ operation: 'nonexistent', email: 'u@t.com' }),
     ).rejects.toThrow('Unknown gmail operation: nonexistent');
+  });
+
+  describe('reply and replyAll honour attachments, html and draft (#132)', () => {
+    let workspace: string;
+    let originalWorkspaceDir: string | undefined;
+
+    beforeAll(async () => {
+      workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'gws-reply-test-'));
+      await fs.writeFile(path.join(workspace, 'report.pdf'), 'pdf');
+      await fs.writeFile(path.join(workspace, 'data.csv'), 'a,b');
+      originalWorkspaceDir = process.env.WORKSPACE_DIR;
+      process.env.WORKSPACE_DIR = workspace;
+    });
+
+    afterAll(async () => {
+      if (originalWorkspaceDir === undefined) delete process.env.WORKSPACE_DIR;
+      else process.env.WORKSPACE_DIR = originalWorkspaceDir;
+      await fs.rm(workspace, { recursive: true, force: true });
+    });
+
+    const okDraft = { success: true as const, data: { id: 'draft-1' }, stderr: '' };
+    const okSent = { success: true as const, data: { id: 'sent-1', threadId: 'thread-1' }, stderr: '' };
+
+    it.each([
+      ['reply', '+reply'],
+      ['replyAll', '+reply-all'],
+    ])('%s attaches workspace files and forces draft', async (operation, helper) => {
+      mockExecute.mockResolvedValue(okDraft);
+      const handler = generateHandler(manifest.services.gmail, patches.gmail);
+
+      const result = await handler({
+        operation,
+        email: 'u@t.com',
+        messageId: 'msg-1',
+        body: 'see attached',
+        attachments: 'report.pdf, data.csv',
+      });
+
+      const [args, options] = mockExecute.mock.calls[0];
+      expect(args).toContain(helper);
+      // Attachments imply a draft — gws cannot attach to a live send
+      expect(args).toContain('--draft');
+      expect(args.filter(a => a === '--attach')).toHaveLength(2);
+      expect(args).toContain('report.pdf');
+      expect(args).toContain('data.csv');
+      // --attach paths are relative to cwd, so cwd must be the workspace
+      expect(options).toMatchObject({ cwd: workspace });
+      expect(result.refs).toMatchObject({ isDraft: true, draftId: 'draft-1' });
+    });
+
+    it.each([
+      ['reply'],
+      ['replyAll'],
+    ])('%s passes html flag through', async (operation) => {
+      mockExecute.mockResolvedValue(okSent);
+      const handler = generateHandler(manifest.services.gmail, patches.gmail);
+
+      await handler({
+        operation,
+        email: 'u@t.com',
+        messageId: 'msg-1',
+        body: '<b>hi</b>',
+        html: true,
+      });
+
+      expect(mockExecute.mock.calls[0][0]).toContain('--html');
+    });
+
+    it.each([
+      ['reply'],
+      ['replyAll'],
+    ])('%s sends live when no attachments and no draft flag', async (operation) => {
+      mockExecute.mockResolvedValue(okSent);
+      const handler = generateHandler(manifest.services.gmail, patches.gmail);
+
+      const result = await handler({
+        operation,
+        email: 'u@t.com',
+        messageId: 'msg-1',
+        body: 'plain reply',
+      });
+
+      expect(mockExecute.mock.calls[0][0]).not.toContain('--draft');
+      expect(result.refs).not.toHaveProperty('isDraft');
+    });
+
+    it.each([
+      ['reply'],
+      ['replyAll'],
+    ])('%s honours an explicit draft flag with no attachments', async (operation) => {
+      mockExecute.mockResolvedValue(okDraft);
+      const handler = generateHandler(manifest.services.gmail, patches.gmail);
+
+      const result = await handler({
+        operation,
+        email: 'u@t.com',
+        messageId: 'msg-1',
+        body: 'hold this',
+        draft: true,
+      });
+
+      expect(mockExecute.mock.calls[0][0]).toContain('--draft');
+      expect(result.refs).toMatchObject({ isDraft: true });
+    });
+
+    it('replyAll still passes cc alongside attachments', async () => {
+      mockExecute.mockResolvedValue(okDraft);
+      const handler = generateHandler(manifest.services.gmail, patches.gmail);
+
+      await handler({
+        operation: 'replyAll',
+        email: 'u@t.com',
+        messageId: 'msg-1',
+        body: 'see attached',
+        cc: 'carol@t.com',
+        attachments: 'report.pdf',
+      });
+
+      const args = mockExecute.mock.calls[0][0];
+      expect(args[args.indexOf('--cc') + 1]).toBe('carol@t.com');
+      expect(args).toContain('--attach');
+    });
+
+    it.each([
+      ['reply'],
+      ['replyAll'],
+    ])('%s rejects an attachment outside the workspace', async (operation) => {
+      mockExecute.mockResolvedValue(okDraft);
+      const handler = generateHandler(manifest.services.gmail, patches.gmail);
+
+      await expect(
+        handler({
+          operation,
+          email: 'u@t.com',
+          messageId: 'msg-1',
+          body: 'sneaky',
+          attachments: '../../../etc/passwd',
+        }),
+      ).rejects.toThrow();
+      expect(mockExecute).not.toHaveBeenCalled();
+    });
   });
 
   it('applies afterExecute hook for gmail search hydration', async () => {

--- a/src/factory/manifest/gmail.yaml
+++ b/src/factory/manifest/gmail.yaml
@@ -91,7 +91,7 @@ operations:
 
   reply:
     type: action
-    description: "reply to a message (thread-aware)"
+    description: "reply to a message (thread-aware, creates draft when attachments present)"
     helper: "+reply"
     params:
       messageId:
@@ -102,13 +102,22 @@ operations:
         type: string
         description: "Reply body text"
         required: true
+      attachments:
+        type: string
+        description: "Workspace filenames to attach, comma-separated (files must exist in workspace via manage_workspace). Creates draft when present."
+      html:
+        type: boolean
+        description: "Treat body as HTML content (default: plain text)"
+      draft:
+        type: boolean
+        description: "Save as draft instead of sending (default: false, forced true when attachments present)"
     cli_args:
       messageId: "--message-id"
       body: "--body"
 
   replyAll:
     type: action
-    description: "reply-all to a message (thread-aware, includes all recipients)"
+    description: "reply-all to a message (thread-aware, includes all recipients, creates draft when attachments present)"
     helper: "+reply-all"
     params:
       messageId:
@@ -122,6 +131,15 @@ operations:
       cc:
         type: string
         description: "Additional CC email(s), comma-separated"
+      attachments:
+        type: string
+        description: "Workspace filenames to attach, comma-separated (files must exist in workspace via manage_workspace). Creates draft when present."
+      html:
+        type: boolean
+        description: "Treat body as HTML content (default: plain text)"
+      draft:
+        type: boolean
+        description: "Save as draft instead of sending (default: false, forced true when attachments present)"
     cli_args:
       messageId: "--message-id"
       body: "--body"

--- a/src/services/gmail/patch.ts
+++ b/src/services/gmail/patch.ts
@@ -299,12 +299,80 @@ export const gmailPatch: ServicePatch = {
     reply: async (params, account): Promise<HandlerResponse> => {
       const messageId = requireString(params, 'messageId');
       const body = requireString(params, 'body');
-      const result = await execute([
-        'gmail', '+reply', '--message-id', messageId, '--body', body,
-      ], { account });
+      const draft = params.draft === true || params.draft === 'true';
+      const attachmentNames = params.attachments
+        ? String(params.attachments).split(',').map(s => s.trim()).filter(Boolean)
+        : [];
+
+      const args = ['gmail', '+reply', '--message-id', messageId, '--body', body];
+      if (params.html === true || params.html === 'true') args.push('--html');
+      if (draft || attachmentNames.length > 0) args.push('--draft');
+
+      let execOptions: { account: string; cwd?: string } = { account };
+      if (attachmentNames.length > 0) {
+        const relPaths = await validateAttachments(attachmentNames);
+        for (const p of relPaths) {
+          args.push('--attach', p);
+        }
+        execOptions = { account, cwd: getWorkspaceDir() };
+      }
+
+      const result = await execute(args, execOptions);
       const data = result.data as Record<string, unknown>;
+      const attachNote = attachmentNames.length > 0
+        ? `\n**Attachments:** ${attachmentNames.join(', ')}`
+        : '';
+
+      if (draft || attachmentNames.length > 0) {
+        return {
+          text: `Draft reply created.\n\n**Draft ID:** ${data.id ?? 'unknown'}${attachNote}`,
+          refs: { id: data.id, draftId: data.id, messageId, attachments: attachmentNames, isDraft: true },
+        };
+      }
+
       return {
         text: `Reply sent.\n\n**Message ID:** ${data.id ?? 'unknown'}`,
+        refs: { id: data.id, threadId: data.threadId, messageId },
+      };
+    },
+
+    replyAll: async (params, account): Promise<HandlerResponse> => {
+      const messageId = requireString(params, 'messageId');
+      const body = requireString(params, 'body');
+      const draft = params.draft === true || params.draft === 'true';
+      const attachmentNames = params.attachments
+        ? String(params.attachments).split(',').map(s => s.trim()).filter(Boolean)
+        : [];
+
+      const args = ['gmail', '+reply-all', '--message-id', messageId, '--body', body];
+      if (params.cc) args.push('--cc', String(params.cc));
+      if (params.html === true || params.html === 'true') args.push('--html');
+      if (draft || attachmentNames.length > 0) args.push('--draft');
+
+      let execOptions: { account: string; cwd?: string } = { account };
+      if (attachmentNames.length > 0) {
+        const relPaths = await validateAttachments(attachmentNames);
+        for (const p of relPaths) {
+          args.push('--attach', p);
+        }
+        execOptions = { account, cwd: getWorkspaceDir() };
+      }
+
+      const result = await execute(args, execOptions);
+      const data = result.data as Record<string, unknown>;
+      const attachNote = attachmentNames.length > 0
+        ? `\n**Attachments:** ${attachmentNames.join(', ')}`
+        : '';
+
+      if (draft || attachmentNames.length > 0) {
+        return {
+          text: `Draft reply-all created.\n\n**Draft ID:** ${data.id ?? 'unknown'}${attachNote}`,
+          refs: { id: data.id, draftId: data.id, messageId, attachments: attachmentNames, isDraft: true },
+        };
+      }
+
+      return {
+        text: `Reply-all sent.\n\n**Message ID:** ${data.id ?? 'unknown'}`,
         refs: { id: data.id, threadId: data.threadId, messageId },
       };
     },


### PR DESCRIPTION
Supersedes #129, which was structurally conflicted — it was written against the single-file `src/factory/manifest.yaml`, since split into per-service files by ADR-304 (`f4963c7`).

**The implementation commit is @JeremyYowell's, cherry-picked with authorship intact.** I only re-targeted the manifest hunks onto `src/factory/manifest/gmail.yaml` and added the test coverage the original was missing.

## The bug (#132)

`manage_email` is a single tool with an `operation` enum, so the generated schema **unions the params of every operation**. `attachments` and `draft` therefore appear as properties on the tool — with nothing marking them `send`-only — while `customHandlers.reply` hardcoded its argument list:

```js
const result = await execute([
  'gmail', '+reply', '--message-id', messageId, '--body', body,
], { account });
```

An agent passing `attachments` with `operation: reply` had them silently dropped: the reply always sent live, and the attachment never attached. `replyAll` had no custom handler at all, so it never saw them either.

The `gws` CLI supports `--attach` (repeatable), `--html`, and `--draft` on both `+reply` and `+reply-all`, so nothing was missing downstream — only the wiring.

## Changes

- `reply` and `replyAll` now pass `attachments`, `html` and `draft` through, mirroring `send`: attachments are validated against the workspace, force `--draft` (gws cannot attach to a live send), and run with `cwd` set to the workspace so relative `--attach` paths resolve.
- Manifest declares the three params on both operations.

## Tests

There was **no coverage of the attachment path anywhere** — not for `reply`, not even for `send`. That is how this shipped. Added 11 tests, pointing `WORKSPACE_DIR` at a temp dir with real files so `verifyPathSafety`'s `realpath` check is genuinely exercised rather than mocked away.

Covering both operations: attachments force draft and set cwd; `html` reaches the CLI; no-attachments-no-draft still sends live (regression guard); explicit `draft` honoured; `replyAll` still passes `cc` alongside attachments; and a `../../../etc/passwd` traversal is rejected before `execute()` is called.

**9 of the 11 fail against the pre-fix handler.** The 2 that pass are the send-live guards — which the old code satisfied by always sending live, which was the bug.

## Verification

- 38/38 suites, **691 tests** passing (680 → 691)
- type-check, lint, build clean (the one eslint warning is pre-existing, in `calendar/patch.ts:105`)
- Rebased on `main` after #128 merged; the two touch the same files and this sits on top cleanly.

Closes #132.