### PR TITLE
Raise the Node floor to 22.12 and unpin sanitize-html (ADR-102)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,15 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: '20'
+        node-version: '22'
         cache: 'npm'
     - run: npm ci
     # Every test file must be run by some gate. `npm test` uses an allowlist of
     # vetted mocked directories, so a test added elsewhere would otherwise run
     # nowhere and report nothing.
     - run: node scripts/check-test-gates.mjs
+    # The floor we publish, execute, and enforce at startup must be ONE number.
+    - run: node scripts/check-node-floor.mjs
     - run: npm test
 
   type-check:
@@ -33,7 +35,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: '20'
+        node-version: '22'
         cache: 'npm'
     - run: npm ci
     - run: npm run type-check
@@ -44,34 +46,40 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: '20'
+        node-version: '22'
         cache: 'npm'
     - run: npm ci
     - run: npm run build
 
   engines-floor:
-    # package.json advertises `engines.node >= 18.14.1`, but every other job here
-    # runs Node 20 and the dev box runs 26 — so the floor we PUBLISH was executed
-    # by nothing. That gap shipped a startup crash once already: `sanitize-html`
-    # ^2.17.6 is CommonJS and require()s the pure-ESM htmlparser2@12, which throws
-    # ERR_REQUIRE_ESM on Node <20.19. It is a static import in the startup graph,
-    # so every Node 18 consumer would have crashed on first start — and it passed
-    # the full suite and all four jobs, because none of them ran Node 18.
+    # Executes the floor we PUBLISH, rather than advertising it.
     #
-    # Build on 20 (tsc and Vitest need it), then run the BUILT server on the floor
-    # against the PRODUCTION dependency tree only — which is what a consumer installs.
+    # The other jobs run whatever Node is current, and the dev box runs newer still,
+    # so without this job nothing ever runs the *oldest* Node we claim to support. A
+    # dependency that is fine on the Node you test and broken on the Node you ship is
+    # invisible to every check that runs on the Node you test — which is exactly how
+    # `sanitize-html` ^2.17.6 (CommonJS, require()ing the pure-ESM htmlparser2@12 →
+    # ERR_REQUIRE_ESM below the floor) once reached a merge-ready branch green.
+    #
+    # The second setup-node below MUST equal `engines.node` in package.json. That
+    # coupling is the entire value of this job: raise the floor, raise it here, or
+    # the guard silently stops guarding the thing it names.
+    #
+    # Build on current Node (tsc and Vitest need it), then run the BUILT server on the
+    # floor against the PRODUCTION dependency tree only — which is what a consumer
+    # installs, and all a consumer gets.
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: '20'
+        node-version: '22'
         cache: 'npm'
     - run: npm ci
     - run: npm run build
     - uses: actions/setup-node@v4
       with:
-        node-version: '18.14.1'   # the exact floor in package.json engines
+        node-version: '22.12.0'   # == engines.node in package.json. Keep in sync.
     - run: rm -rf node_modules && npm ci --omit=dev
     - run: node --version
     - run: node scripts/smoke-start.mjs
@@ -82,7 +90,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: '20'
+        node-version: '22'
         cache: 'npm'
     - run: npm ci
     - run: npm run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,37 @@ jobs:
     - run: node --version
     - run: node scripts/smoke-start.mjs
 
+  engines-floor-reject:
+    # The mirror of engines-floor, and the guard-for-the-guard.
+    #
+    # engines-floor proves the server STARTS above the floor. Nothing proved it REFUSES
+    # below it — so the startup guard's entire reason for existing had zero coverage.
+    # src/index.ts reaches the server via `await import()` AFTER the version check,
+    # precisely so sanitize-html -> htmlparser2@12 is never evaluated on a runtime that
+    # cannot require() ESM. Turn that one line back into a static import and the crash
+    # returns while check-node-floor, typecheck, lint, all 681 tests and every other job
+    # stay green — because every runtime in CI is above the floor. The only thing
+    # defending it was a code comment saying "do not tidy this into a static import."
+    #
+    # So: run the built entrypoint on a Node BELOW the floor and assert it exits non-zero
+    # with our message and WITHOUT ERR_REQUIRE_ESM. That behavioral test is what actually
+    # protects the dynamic import.
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '22'
+        cache: 'npm'
+    - run: npm ci
+    - run: npm run build
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '20.19.0'   # deliberately BELOW the floor — that is the point
+    - run: rm -rf node_modules && npm ci --omit=dev
+    - run: node --version
+    - run: node scripts/smoke-reject.mjs
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,10 +108,21 @@ docker run -i --rm \
 
 ### Node version
 
-The published package supports **Node >=18.14.1** (`engines`). The **development**
-toolchain needs more: Vitest requires **Node ^20.19 || ^22.12 || >=24**. If you are
-on Node 18 you can install and run the server, but the test suite will not start —
-use Node 20.19+ to develop.
+**Node >=22.12** — one number, for both running and developing the server (ADR-102).
+
+There used to be two floors: a lower one for consumers and a higher one for the test
+toolchain. Conflating them shipped a startup crash to every Node 18 user once, so they
+are now the same number, and that number is checked three ways:
+
+- `engines.node` in `package.json` — what npm tells a consumer at install time
+- the `engines-floor` CI job — actually *runs* the built server on exactly that Node
+- `MIN_NODE` in `src/index.ts` — a startup guard, so an unsupported runtime gets a
+  readable sentence instead of a stack trace from inside `node_modules`
+
+`make check` runs `check-node-floor`, which fails if those three ever disagree. If you
+raise the floor, raise it in all three; the check will tell you if you miss one.
+
+Node 18 and Node 20 are both end-of-life (April 2025 and April 2026).
 
 ## Pull Request Process
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := help
-.PHONY: help test test-all test-unit test-integration build clean typecheck lint smoke check-gates \
+.PHONY: help test test-all test-unit test-integration build clean typecheck lint smoke check-gates check-node-floor \
         manifest-discover manifest-diff manifest-lint \
         coverage coverage-update \
         mcpb mcpb-all version-sync publish-all \
@@ -56,6 +56,11 @@ build: ## Compile TypeScript to build/ (and verify the output)
 check-gates: ## Assert every test file is COLLECTED by some gate
 	node scripts/check-test-gates.mjs
 
+# The floor is written in three places (engines, the CI job that executes it, and the
+# startup guard). A comment saying "keep in sync" is a coupling maintained by nobody.
+check-node-floor: ## Assert the Node floor agrees everywhere it is declared
+	node scripts/check-node-floor.mjs
+
 # Depends on build: smoking a stale build/ is exactly the "measured the wrong
 # artifact" failure this whole branch is about.
 smoke: build ## Start the built server on a foreign cwd and assert it loads its tools
@@ -64,7 +69,7 @@ smoke: build ## Start the built server on a foreign cwd and assert it loads its 
 # Mirrors CI. `lint` used to be in the help text but not the prerequisites, so a
 # contributor could go green locally and red in CI on a job this target claimed
 # to cover.
-check: typecheck lint check-gates test build smoke ## Type-check, lint, test, build, smoke (CI gate)
+check: typecheck lint check-gates check-node-floor test build smoke ## Type-check, lint, test, build, smoke (CI gate)
 
 clean: ## Remove build artifacts
 	rm -rf build/ mcpb/server mcpb/bin *.mcpb

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := help
-.PHONY: help test test-all test-unit test-integration build clean typecheck lint smoke check-gates check-node-floor \
+.PHONY: help test test-all test-unit test-integration build clean typecheck lint smoke smoke-reject check-gates check-node-floor \
         manifest-discover manifest-diff manifest-lint \
         coverage coverage-update \
         mcpb mcpb-all version-sync publish-all \
@@ -65,6 +65,12 @@ check-node-floor: ## Assert the Node floor agrees everywhere it is declared
 # artifact" failure this whole branch is about.
 smoke: build ## Start the built server on a foreign cwd and assert it loads its tools
 	node scripts/smoke-start.mjs
+
+# Deliberately NOT in `check`: it must run on a Node BELOW the floor, which this dev box
+# is not. It self-skips loudly rather than passing vacuously. CI runs it (engines-floor-reject),
+# and check-node-floor fails the build if that job disappears.
+smoke-reject: build ## Assert the server REFUSES a below-floor Node (run on Node <22.12)
+	node scripts/smoke-reject.mjs
 
 # Mirrors CI. `lint` used to be in the help text but not the prerequisites, so a
 # contributor could go green locally and red in CI on a job this target claimed
@@ -137,9 +143,16 @@ mcpb: build ## Build .mcpb for current platform (PLATFORM=linux-x64 etc.)
 	rm -rf mcpb/server mcpb/bin
 	mkdir -p mcpb/server
 	cp -r build/* mcpb/server/
-	cp package.json mcpb/server/package.json
-	cd mcpb/server && npm install --production --ignore-scripts --silent
-	rm -f mcpb/server/package.json mcpb/server/package-lock.json
+	cp package.json package-lock.json mcpb/server/
+	cd mcpb/server && npm ci --omit=dev --ignore-scripts --silent
+	rm -f mcpb/server/package-lock.json
+	@# The bundle ships NO full package.json, but the built output is ESM and the entry
+	@# uses top-level await. With nothing declaring "type": "module", Node falls back to
+	@# module-syntax DETECTION (default-on only since 20.19/22.7) — and on any host
+	@# without it the entrypoint dies with a raw SyntaxError before our version guard can
+	@# run, on exactly the runtimes that guard exists for. Make the bundle explicitly ESM.
+	@node -e "require('fs').writeFileSync('mcpb/server/package.json', JSON.stringify({type:'module'}, null, 2) + '\n')"
+	@echo "  mcpb/server/package.json → {\"type\": \"module\"}"
 	./scripts/download-gws-binary.sh $(PLATFORM) $(GWS_VERSION)
 	mcpb pack mcpb google-workspace-mcp-$(PLATFORM).mcpb
 	node scripts/verify-mcpb.cjs google-workspace-mcp-$(PLATFORM).mcpb

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ npx @aaronsb/google-workspace-mcp
 
 ### Prerequisites
 
-1. **Node.js** 18+
+1. **Node.js** 22.12 or newer — Node 18 and 20 are both end-of-life
 2. **Google Cloud OAuth credentials** — create at [console.cloud.google.com/apis/credentials](https://console.cloud.google.com/apis/credentials):
    - Create an OAuth 2.0 Client ID (Desktop application)
    - Enable the APIs you want (Gmail, Calendar, Drive, Sheets, etc.)

--- a/docs/architecture/core/ADR-102-raise-the-node-floor-to-22-12-and-unpin-sanitize-html.md
+++ b/docs/architecture/core/ADR-102-raise-the-node-floor-to-22-12-and-unpin-sanitize-html.md
@@ -60,7 +60,7 @@ A comment reading "keep these in sync" is a coupling maintained by nobody, so `s
 
 - **This is a breaking change for consumers on Node 18 or 20.** It warrants a minor version bump and a release note. The mitigation is that they get a clear instruction rather than a crash — but they are still blocked until they upgrade.
 - **The `.mcpb` break is narrower than it first appears — and an earlier draft of this ADR overstated it.** That draft called the host's Node "the main risk… not fully knowable from here." Investigating rather than speculating showed the bundle *could never have run below ~20.19 anyway*: it ships no `package.json`, so its ESM entrypoint only parsed at all thanks to Node's module-syntax detection, which is default-on from 20.19/22.7. Any `.mcpb` user on Node 18 was already broken, silently. The real exposure is hosts on **20.19–22.11**, who move from a working server to a clear "upgrade Node" message. Still a hard stop; a much smaller and better-understood one.
-- **The floor still cannot be *tested* against a real Claude Desktop.** `compatibility.runtimes.node` should stop the host installing onto an inadequate runtime, but that depends on the host honoring the field, which is **unverified**. The startup guard is the backstop for every case it does not. Validate against a real `.mcpb` install before release.
+- **`compatibility.runtimes.node` remains UNVERIFIED.** The bundle was installed into a real Claude Desktop and works (see Evidence), but on a host running Node 26 — well above the floor. A host that honors the field and a host that ignores it behave identically there, so the install proves only that the field does not *break* a valid install. Whether it actually blocks an inadequate runtime is untested, and testing it needs a Claude Desktop on Node < 22.12. **The startup guard is the backstop for every case it does not cover**, and unlike the manifest field, the guard is proven — on real Node 20.19.0, in CI, every run.
 - The floor is now written in four files. That is more places to drift — which is exactly why `check-node-floor` fails the build when they do.
 
 ### Neutral
@@ -93,7 +93,19 @@ A review round on the first version of this change found that **the new guards a
 | | `22.12.0-rc.1` (pre-release of the floor) | rejected — *used to be waved through as "equal"* |
 | `.mcpb` bundle | run with module-syntax detection disabled | starts; guard fires and prints the message *(previously: raw `SyntaxError`, guard never ran)* |
 
-`npm audit --omit=dev` after the unpin: **0 vulnerabilities**. `sanitize-html@2.17.6`, `htmlparser2@12.0.0`. Unit suite: 681/681 — passing with a pure-ESM transitive, which is ADR-101 arriving.
+`npm audit --omit=dev` after the unpin: **0 vulnerabilities**. `sanitize-html@2.17.6`, `htmlparser2@12.0.0`. Unit suite: **703/703** — passing with a pure-ESM transitive, which is ADR-101 arriving.
+
+CI, on a real below-floor runtime: `smoke-reject: OK — on v20.19.0 (below the 22.12.0 floor) the server refused to start, explained why, and never leaked ERR_REQUIRE_ESM.`
+
+### Validated against a real .mcpb install
+
+The bundle was built, installed into Claude Desktop by double-click, and exercised end to end: 11 tools loaded, all three accounts visible, live Gmail calls returning real data. This confirms the three things CI cannot:
+
+- The bundle **parses and boots** — which it can only do because it now ships `{"type": "module"}`. The previous bundle depended on Node's syntax detection to run at all.
+- **OAuth credentials survive** the upgrade; they live in `~/.config/gws`, outside the bundle.
+- **`sanitize-html@2.17.6` with pure-ESM `htmlparser2@12` runs in the real host** — the dependency this entire ADR exists to unblock.
+
+What it does **not** confirm is `compatibility.runtimes.node` (see Negative): the host is on Node 26, so honoring the field and ignoring it look the same.
 
 ## Alternatives Considered
 

--- a/docs/architecture/core/ADR-102-raise-the-node-floor-to-22-12-and-unpin-sanitize-html.md
+++ b/docs/architecture/core/ADR-102-raise-the-node-floor-to-22-12-and-unpin-sanitize-html.md
@@ -1,0 +1,87 @@
+---
+status: Draft
+date: 2026-07-11
+deciders:
+  - aaronsb
+related: [ADR-101]
+---
+
+# ADR-102: Raise the Node floor to 22.12 and unpin sanitize-html
+
+## Context
+
+`sanitize-html` is pinned to **exactly `2.17.5`**. The pin is not a security measure — 2.17.5 carries the fix for GHSA-rpr9-rxv7-x643, whose vulnerable range is 2.17.3 alone. The pin exists because we *cannot take the next patch*:
+
+`sanitize-html` 2.17.6 moves to the pure-ESM `htmlparser2@12`. `sanitize-html` is itself **CommonJS** (`index.js:1` is `require('htmlparser2')`), and a CJS `require()` of an ESM-only package only resolves unflagged on Node **≥20.19 / ≥22.12**. It is a static import in the startup graph (`markdown.ts` → `html-sanitize.ts`), so on an older Node the server does not degrade — it fails to boot, with `ERR_REQUIRE_ESM` thrown from inside somebody else's `node_modules`.
+
+That is not hypothetical. This exact bump reached a merge-ready branch during ADR-101, passing the full test suite and every CI job, because the dev box ran Node 26 and CI pinned Node 20. It would have crashed **every Node 18 consumer on first start**. The `engines-floor` CI job built during ADR-101 exists precisely to make that impossible: it runs the built server on the declared floor against the production dependency tree. It is what makes this ADR safe to execute.
+
+So the floor is the whole question. Two numbers are available, and they are no longer the same:
+
+- **≥20.19** — the *minimum that works*. The lowest Node with unflagged `require(ESM)`.
+- **≥22.12** — the *minimum that is supported*. Node 22 is Active LTS until April 2027.
+
+It is July 2026. **Node 18 reached end-of-life in April 2025, and Node 20 in April 2026.** Declaring `>=20.19` today would mean advertising a floor that is *already out of support* on the day it ships, and doing this exercise again within the year.
+
+### The floor is not just an npm field
+
+`engines.node` is advisory: npm warns, it does not block. And the `.mcpb` bundle does not consult it at all — `mcpb/manifest.json` runs a bare `node`, meaning **the host's runtime**, whose version we neither control nor can test in CI. A floor that exists only in `package.json` is a floor that protects nobody.
+
+## Decision
+
+**Raise the floor to Node `>=22.12.0`, unpin `sanitize-html` to `^2.17.6`, and enforce the floor in three places that must agree.**
+
+The two-floor model from ADR-101 (consumers on 18.14.1, contributors on 20.19 for Vitest) is **collapsed into one number**. Conflating those two floors is what produced the original crash; keeping them separate invites the same confusion back. One number, checked three ways:
+
+| Where | What it does |
+|---|---|
+| `engines.node` in `package.json` | what npm tells a consumer at install time (advisory) |
+| the `engines-floor` CI job | **executes** the built server on exactly that Node, production deps only |
+| `MIN_NODE` in `src/index.ts` | startup guard — a readable error instead of `ERR_REQUIRE_ESM` |
+
+The startup guard is the only defence the `.mcpb` bundle has. `src/index.ts` therefore imports **nothing** from the server graph at module scope: ESM evaluates static imports before the importing module's body, so a static `import { startServer }` would pull in `sanitize-html` — and crash — *before* any check in that file could run. The version check runs first; the server is loaded by dynamic `import()` only once the runtime is known to be adequate. This is the one place in the codebase where import style is load-bearing.
+
+A comment reading "keep these in sync" is a coupling maintained by nobody, so `scripts/check-node-floor.mjs` fails the build if the three ever disagree, or if the `engines-floor` job disappears entirely.
+
+## Consequences
+
+### Positive
+
+- **The `sanitize-html` pin is gone.** Future patches can be taken normally. Production vulnerabilities remain **0**.
+- **The floor we publish is the floor we execute.** Raising it in one place and forgetting the others is now a build failure, not a latent crash.
+- **An unsupported runtime produces a sentence, not a stack trace.** Verified against the real failure mode: with the floor set above the running Node *and* the `ERR_REQUIRE_ESM` condition active simultaneously, our message wins the race — the guard runs before the import that would throw.
+- **We ship onto a supported runtime.** Node 22 is Active LTS until April 2027, versus a floor that was already EOL.
+
+### Negative
+
+- **This is a breaking change for consumers on Node 18 or 20**, and therefore for the `.mcpb` bundle if the host's Node is older than 22.12. It warrants a minor version bump and a release note. The mitigation is that they get a clear instruction rather than a crash — but they are still blocked until they upgrade.
+- **`.mcpb` risk is real and not fully knowable from here.** The bundle runs the host's Node. If Claude Desktop ships a runtime below 22.12, `.mcpb` users will hit the startup guard. That is strictly better than `ERR_REQUIRE_ESM`, but it is still a hard stop, and we cannot test it in CI. **This is the main risk of this ADR and should be validated against a real `.mcpb` install before release.**
+- The floor is now written in three files. That is more places to change — which is exactly why it is checked.
+
+### Neutral
+
+- CI now runs Node 22 across all jobs (was 20), with the `engines-floor` job pinned to exactly `22.12.0`.
+- Test count unchanged. No runtime behavior changes beyond the version guard.
+
+## Evidence
+
+Falsified, not asserted. Each guard was made to fail on purpose:
+
+| Guard | Injected failure | Result |
+|---|---|---|
+| `check-node-floor.mjs` | `engines.node` raised, CI + startup guard left behind | exit 1, names all three |
+| | `engines-floor` CI job left on the old Node | exit 1 |
+| | `MIN_NODE` not updated | exit 1 |
+| | `engines-floor` job deleted entirely | exit 1 |
+| startup guard (`src/index.ts`) | floor set above the running Node, **with `ERR_REQUIRE_ESM` active** | our message, exit 1 — `ERR_REQUIRE_ESM` never printed |
+| `engines-floor` CI job | (standing) runs the built server on 22.12.0, prod deps only | handshake + tools loaded |
+
+`npm audit --omit=dev` after the unpin: **0 vulnerabilities**. `sanitize-html@2.17.6`, `htmlparser2@12.0.0`.
+
+## Alternatives Considered
+
+**Floor at `>=20.19` (what issue #139 proposed).** The minimum that unblocks the pin, and the smallest break for consumers. Rejected: Node 20 went EOL in April 2026, so this ships onto an unsupported runtime and schedules the same migration again within the year. The consumer breakage is nearly identical (anyone below 20.19 breaks either way); the difference is whether the destination is supported.
+
+**Leave the pin, don't raise the floor.** Genuinely tenable: 2.17.5 is *not* vulnerable, so the pin costs nothing today except the ability to take future patches. Rejected because the cost is not static — the pin blocks every future `sanitize-html` patch including the next security one, and we would be making this decision under time pressure instead of calmly. Doing it now, with the `engines-floor` guard already built and green, is the cheap moment.
+
+**Declare the floor only in `mcpb/manifest.json` (`compatibility.runtimes.node`) and let the host refuse the install.** Cleaner in principle, but it relies on the host honoring the field — which has *not* been verified — and does nothing for `npx` users. The startup guard covers every case, including hosts that ignore the manifest. Adding the manifest declaration as well remains worthwhile and is left as follow-up.

--- a/docs/architecture/core/ADR-102-raise-the-node-floor-to-22-12-and-unpin-sanitize-html.md
+++ b/docs/architecture/core/ADR-102-raise-the-node-floor-to-22-12-and-unpin-sanitize-html.md
@@ -23,6 +23,8 @@ So the floor is the whole question. Two numbers are available, and they are no l
 
 It is July 2026. **Node 18 reached end-of-life in April 2025, and Node 20 in April 2026.** Declaring `>=20.19` today would mean advertising a floor that is *already out of support* on the day it ships, and doing this exercise again within the year.
 
+Stated precisely, because an earlier draft of this ADR got it wrong: **Node 22 is in *Maintenance* LTS** — Node 24 took over the Active LTS line in October 2025. Node 22 receives security and critical fixes until **April 2027**, roughly nine months from this decision. So 22.12 is *supported*, not *current*: it is the lowest floor that is simultaneously (a) able to `require()` ESM unflagged and (b) still receiving fixes. That is the honest characterisation, and it means the next floor bump is a question for early 2027, not 2029.
+
 ### The floor is not just an npm field
 
 `engines.node` is advisory: npm warns, it does not block. And the `.mcpb` bundle does not consult it at all — `mcpb/manifest.json` runs a bare `node`, meaning **the host's runtime**, whose version we neither control nor can test in CI. A floor that exists only in `package.json` is a floor that protects nobody.
@@ -49,14 +51,17 @@ A comment reading "keep these in sync" is a coupling maintained by nobody, so `s
 
 - **The `sanitize-html` pin is gone.** Future patches can be taken normally. Production vulnerabilities remain **0**.
 - **The floor we publish is the floor we execute.** Raising it in one place and forgetting the others is now a build failure, not a latent crash.
-- **An unsupported runtime produces a sentence, not a stack trace.** Verified against the real failure mode: with the floor set above the running Node *and* the `ERR_REQUIRE_ESM` condition active simultaneously, our message wins the race — the guard runs before the import that would throw.
-- **We ship onto a supported runtime.** Node 22 is Active LTS until April 2027, versus a floor that was already EOL.
+- **An unsupported runtime produces a sentence, not a stack trace.** Verified against the real failure mode: with the floor set above the running Node *and* the `ERR_REQUIRE_ESM` condition active simultaneously, our message wins the race — the guard runs before the import that would throw. The message is written with `fs.writeSync(2, …)` rather than `process.stderr.write`, because Node's writes to a *pipe* are asynchronous on **macOS** — and Claude Desktop spawns the `.mcpb` server with piped stdio on the platform where `.mcpb` matters most. `process.stderr.write` followed immediately by `process.exit(1)` can tear the process down before the buffer drains, leaving the user a bare exit code and no message at all: strictly worse than the stack trace we were replacing.
+- **We ship onto a supported runtime.** Node 22 receives fixes until April 2027, versus a floor that was already EOL.
+- **The `.mcpb` bundle is now explicitly ESM.** It previously shipped with *no* `package.json`, so nothing declared `"type": "module"` and the entrypoint only parsed because Node's module-syntax *detection* is default-on from 20.19/22.7. On any host without it, the built entry died with a raw `SyntaxError` — meaning the startup guard could not run **in the one delivery channel it exists for**. The bundle now ships `{"type": "module"}`, and `compatibility.runtimes.node` tells the host the floor before it ever launches the server.
+- **The bundle installs from the lockfile.** `make mcpb` used `npm install --production` with no lockfile, so with `sanitize-html` unpinned to `^2.17.6` the bundle could ship a version CI never validated — and `2.17.6` is itself the precedent for a patch bump swapping in a transitive with a new Node requirement. It now uses `npm ci --omit=dev`.
 
 ### Negative
 
-- **This is a breaking change for consumers on Node 18 or 20**, and therefore for the `.mcpb` bundle if the host's Node is older than 22.12. It warrants a minor version bump and a release note. The mitigation is that they get a clear instruction rather than a crash — but they are still blocked until they upgrade.
-- **`.mcpb` risk is real and not fully knowable from here.** The bundle runs the host's Node. If Claude Desktop ships a runtime below 22.12, `.mcpb` users will hit the startup guard. That is strictly better than `ERR_REQUIRE_ESM`, but it is still a hard stop, and we cannot test it in CI. **This is the main risk of this ADR and should be validated against a real `.mcpb` install before release.**
-- The floor is now written in three files. That is more places to change — which is exactly why it is checked.
+- **This is a breaking change for consumers on Node 18 or 20.** It warrants a minor version bump and a release note. The mitigation is that they get a clear instruction rather than a crash — but they are still blocked until they upgrade.
+- **The `.mcpb` break is narrower than it first appears — and an earlier draft of this ADR overstated it.** That draft called the host's Node "the main risk… not fully knowable from here." Investigating rather than speculating showed the bundle *could never have run below ~20.19 anyway*: it ships no `package.json`, so its ESM entrypoint only parsed at all thanks to Node's module-syntax detection, which is default-on from 20.19/22.7. Any `.mcpb` user on Node 18 was already broken, silently. The real exposure is hosts on **20.19–22.11**, who move from a working server to a clear "upgrade Node" message. Still a hard stop; a much smaller and better-understood one.
+- **The floor still cannot be *tested* against a real Claude Desktop.** `compatibility.runtimes.node` should stop the host installing onto an inadequate runtime, but that depends on the host honoring the field, which is **unverified**. The startup guard is the backstop for every case it does not. Validate against a real `.mcpb` install before release.
+- The floor is now written in four files. That is more places to drift — which is exactly why `check-node-floor` fails the build when they do.
 
 ### Neutral
 
@@ -65,18 +70,30 @@ A comment reading "keep these in sync" is a coupling maintained by nobody, so `s
 
 ## Evidence
 
-Falsified, not asserted. Each guard was made to fail on purpose:
+### What the guards were missing
+
+A review round on the first version of this change found that **the new guards attested to properties they never measured** — the recurring defect of this codebase, arriving for the sixth time. Specifically:
+
+`check-node-floor` verified that `MIN_NODE` *exists and has the right value*. But the load-bearing property of `src/index.ts` is not the value of a constant — it is that the server is reached via `await import()` **after** the check. Revert that one line to a static `import` and the `ERR_REQUIRE_ESM` crash returns, while `check-node-floor`, typecheck, lint, all 681 tests and every CI job stay green — because every runtime in CI is *above* the floor, where the crash cannot occur. The only thing defending it was a code comment saying "do not tidy this into a static import."
+
+**A comment is not a guard.** The fix is one behavioral test: run the built entrypoint on a Node *below* the floor and assert it exits non-zero, prints our message, and never leaks `ERR_REQUIRE_ESM` (`scripts/smoke-reject.mjs`, `engines-floor-reject` CI job). It refuses to run *above* the floor, so it cannot pass vacuously. `engines-floor` proves the server starts above the floor; `engines-floor-reject` proves it refuses below it. Neither is meaningful without the other.
+
+### Falsified, not asserted
 
 | Guard | Injected failure | Result |
 |---|---|---|
-| `check-node-floor.mjs` | `engines.node` raised, CI + startup guard left behind | exit 1, names all three |
-| | `engines-floor` CI job left on the old Node | exit 1 |
-| | `MIN_NODE` not updated | exit 1 |
-| | `engines-floor` job deleted entirely | exit 1 |
-| startup guard (`src/index.ts`) | floor set above the running Node, **with `ERR_REQUIRE_ESM` active** | our message, exit 1 — `ERR_REQUIRE_ESM` never printed |
-| `engines-floor` CI job | (standing) runs the built server on 22.12.0, prod deps only | handshake + tools loaded |
+| `smoke-reject.mjs` | **`await import()` reverted to a static import** | exit 1 — "ERR_REQUIRE_ESM leaked… someone turned the `await import()` back into a static import" |
+| | run above the floor (where it would prove nothing) | refuses to run |
+| `check-node-floor.mjs` | static import of the server graph in `src/index.ts` | exit 1 |
+| | `engines.node` raised, other sites left behind | exit 1, names all four |
+| | floor pin **commented out** in ci.yml | exit 1 *(used to report "executed in CI" — comments were matched as if live)* |
+| | `smoke-start` step deleted from `engines-floor` | exit 1 *(used to stay green: it checked a version string, not that anything ran)* |
+| | `engines-floor-reject` job deleted | exit 1 |
+| startup guard | floor above running Node, **with `ERR_REQUIRE_ESM` active** | our message, exit 1 — `ERR_REQUIRE_ESM` never printed |
+| | `22.12.0-rc.1` (pre-release of the floor) | rejected — *used to be waved through as "equal"* |
+| `.mcpb` bundle | run with module-syntax detection disabled | starts; guard fires and prints the message *(previously: raw `SyntaxError`, guard never ran)* |
 
-`npm audit --omit=dev` after the unpin: **0 vulnerabilities**. `sanitize-html@2.17.6`, `htmlparser2@12.0.0`.
+`npm audit --omit=dev` after the unpin: **0 vulnerabilities**. `sanitize-html@2.17.6`, `htmlparser2@12.0.0`. Unit suite: 681/681 — passing with a pure-ESM transitive, which is ADR-101 arriving.
 
 ## Alternatives Considered
 

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "name": "google-workspace-mcp",
   "display_name": "Google Workspace",
   "version": "2.7.1",
-  "description": "Give AI agents access to Gmail, Calendar, Drive, and more — with multi-account support and manifest-driven API coverage",
+  "description": "Give AI agents access to Gmail, Calendar, Drive, and more \u2014 with multi-account support and manifest-driven API coverage",
   "author": {
     "name": "aaronsb",
     "url": "https://github.com/aaronsb"
@@ -78,7 +78,7 @@
     "google_client_id": {
       "type": "string",
       "title": "Google OAuth Client ID",
-      "description": "Create at https://console.cloud.google.com/apis/credentials — OAuth 2.0 Client ID (Desktop application)",
+      "description": "Create at https://console.cloud.google.com/apis/credentials \u2014 OAuth 2.0 Client ID (Desktop application)",
       "sensitive": true,
       "required": true
     },
@@ -92,7 +92,7 @@
     "workspace_dir": {
       "type": "string",
       "title": "Workspace Directory",
-      "description": "Directory for file operations (upload/download/export). Must be a dedicated folder — not your home, Documents, Desktop, or Google Drive directory. Default: ~/.local/share/google-workspace-mcp/workspace/",
+      "description": "Directory for file operations (upload/download/export). Must be a dedicated folder \u2014 not your home, Documents, Desktop, or Google Drive directory. Default: ~/.local/share/google-workspace-mcp/workspace/",
       "required": false
     }
   },
@@ -101,6 +101,9 @@
       "darwin",
       "win32",
       "linux"
-    ]
+    ],
+    "runtimes": {
+      "node": ">=22.12.0"
+    }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@googleworkspace/cli": "^0.22.5",
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "sanitize-html": "2.17.5",
+        "sanitize-html": "^2.17.6",
         "yaml": "^2.9.0"
       },
       "bin": {
@@ -25,7 +25,7 @@
         "vitest": "^4.1.10"
       },
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1516,6 +1516,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
       "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "domelementtype": "^2.3.0",
@@ -1530,6 +1531,7 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -1542,6 +1544,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
       "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1554,6 +1557,7 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
       "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "domelementtype": "^2.3.0"
@@ -1569,6 +1573,7 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
       "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "dom-serializer": "^2.0.0",
@@ -1612,6 +1617,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
       "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -2371,6 +2377,7 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
       "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "dev": true,
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -3550,18 +3557,122 @@
       "license": "MIT"
     },
     "node_modules/sanitize-html": {
-      "version": "2.17.5",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.5.tgz",
-      "integrity": "sha512-ZmU1joGRrvoyctKIiuwUxqR6moLoU2Wk+2bMccN6f7UwhAmwYDvWziqPxRDDN2Qip62NqnIrVrT9akbL6Wretg==",
+      "version": "2.17.6",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.6.tgz",
+      "integrity": "sha512-M4bo9tfv1yfhQZZKkc6dL07ALrGJtfvNOuhX3hU9AVPR/uPQ+nKOJBqTYc7LfMQblTW04mtSWDJWEyLvygJsLA==",
       "license": "MIT",
       "dependencies": {
         "deepmerge": "^4.2.2",
         "escape-string-regexp": "^4.0.0",
-        "htmlparser2": "^10.1.0",
+        "htmlparser2": "^12.0.0",
         "is-plain-object": "^5.0.0",
         "launder": "^1.7.1",
         "parse-srcset": "^1.0.2",
         "postcss": "^8.3.11"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/dom-serializer": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-3.1.1.tgz",
+      "integrity": "sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0",
+        "entities": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/domelementtype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-3.0.0.tgz",
+      "integrity": "sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/domhandler": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-6.0.1.tgz",
+      "integrity": "sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/domutils": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-4.0.2.tgz",
+      "integrity": "sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^3.0.0",
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/htmlparser2": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-12.0.0.tgz",
+      "integrity": "sha512-Tz7u1i95/g2x2jz81+x0FBVhBhY5aRTvD3tXXdFaljuNdzDLJ8UGNRrTcj2cgQvAg3iW/h77Fz15nLW0L0CrZw==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0",
+        "domutils": "^4.0.2",
+        "entities": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/semver": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@googleworkspace/cli": "^0.22.5",
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "sanitize-html": "2.17.5",
+    "sanitize-html": "^2.17.6",
     "yaml": "^2.9.0"
   },
   "devDependencies": {
@@ -42,6 +42,6 @@
     "vitest": "^4.1.10"
   },
   "engines": {
-    "node": ">=18.14.1"
+    "node": ">=22.12.0"
   }
 }

--- a/scripts/check-node-floor.mjs
+++ b/scripts/check-node-floor.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+/**
+ * Asserts the Node floor is the SAME NUMBER everywhere it is written down.
+ *
+ * The floor lives in three places, and each one is load-bearing in a different way:
+ *
+ *   1. package.json `engines.node`  — what npm tells a consumer at install time.
+ *   2. ci.yml `engines-floor` job   — the Node the built server is actually EXECUTED on.
+ *   3. src/index.ts `MIN_NODE`      — the runtime guard that produces a readable error
+ *                                     instead of ERR_REQUIRE_ESM, and the only defence
+ *                                     the .mcpb bundle has (it runs the HOST's node).
+ *
+ * If (1) drifts above (2), the floor we publish is no longer the floor we test, and a
+ * dependency broken below it merges green — that is precisely how the sanitize-html
+ * startup crash happened. If (3) drifts, the guard rejects runtimes that are fine or,
+ * worse, waves through runtimes that are not.
+ *
+ * The comment in ci.yml used to say "keep in sync." A coupling maintained by a comment
+ * is a coupling maintained by nobody. This is the check.
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
+
+const ROOT = fileURLToPath(new URL('..', import.meta.url));
+const read = (p) => readFileSync(resolve(ROOT, p), 'utf8');
+
+const found = {};
+const errors = [];
+
+// 1. package.json engines.node — expect a bare ">=X.Y.Z"
+const engines = JSON.parse(read('package.json')).engines?.node;
+const enginesMatch = /^>=\s*(\d+\.\d+\.\d+)$/.exec(engines ?? '');
+if (!enginesMatch) {
+  errors.push(
+    `package.json engines.node is ${JSON.stringify(engines)} — expected an exact ">=X.Y.Z" ` +
+    `so it can be compared against the version CI actually runs.`,
+  );
+} else {
+  found['package.json engines.node'] = enginesMatch[1];
+}
+
+// 2. ci.yml — the node-version of the engines-floor job's SECOND setup-node (the one
+//    that runs the built server). Scoped to that job so the other jobs, which track
+//    current Node on purpose, are not dragged into the comparison.
+const ci = read('.github/workflows/ci.yml');
+const floorJob = /^ {2}engines-floor:$([\s\S]*?)(?=^ {2}\S|\Z)/m.exec(ci);
+if (!floorJob) {
+  errors.push('.github/workflows/ci.yml has no `engines-floor:` job — the floor is executed by nothing.');
+} else {
+  const versions = [...floorJob[1].matchAll(/node-version:\s*'([^']+)'/g)].map((m) => m[1]);
+  const exact = versions.filter((v) => /^\d+\.\d+\.\d+$/.test(v));
+  if (exact.length !== 1) {
+    errors.push(
+      `the engines-floor job declares ${exact.length} exact node-versions (${JSON.stringify(versions)}) — ` +
+      `expected exactly one pinned X.Y.Z, the floor to execute.`,
+    );
+  } else {
+    found['ci.yml engines-floor job'] = exact[0];
+  }
+}
+
+// 3. src/index.ts MIN_NODE
+const minNode = /const MIN_NODE = '([^']+)'/.exec(read('src/index.ts'));
+if (!minNode) {
+  errors.push('src/index.ts has no `const MIN_NODE = \'...\'` — the startup guard is gone.');
+} else {
+  found['src/index.ts MIN_NODE'] = minNode[1];
+}
+
+const versions = [...new Set(Object.values(found))];
+if (errors.length === 0 && versions.length > 1) {
+  errors.push('the Node floor DISAGREES across the places it is declared:');
+  for (const [where, v] of Object.entries(found)) errors.push(`    ${v.padEnd(10)} ${where}`);
+  errors.push(
+    '  The floor we publish, the floor we execute in CI, and the floor the server\n' +
+    '  enforces at startup must be one number. Pick one and change all three.',
+  );
+}
+
+if (errors.length > 0) {
+  console.error('check-node-floor:\n');
+  for (const e of errors) console.error(`  ${e}`);
+  process.exit(1);
+}
+
+console.log(`check-node-floor: Node >=${versions[0]} — declared, executed in CI, and enforced at startup.`);

--- a/scripts/check-node-floor.mjs
+++ b/scripts/check-node-floor.mjs
@@ -7,8 +7,10 @@
  *
  *   1. package.json `engines.node`        — what npm tells a consumer at install time.
  *   2. ci.yml `engines-floor` job         — the Node the built server is EXECUTED on.
- *   3. src/index.ts `MIN_NODE`            — the runtime guard that produces a readable
- *                                           error instead of ERR_REQUIRE_ESM.
+ *   3. src/node-floor.ts `MIN_NODE`       — the runtime guard that produces a readable
+ *                                           error instead of ERR_REQUIRE_ESM. index.ts must
+ *                                           CALL it, and must not statically import the
+ *                                           server graph, or it runs after the crash.
  *   4. mcpb/manifest.json                 — `compatibility.runtimes.node`; the ONLY one
  *      the .mcpb host reads, and the only thing that can stop Claude Desktop from
  *      installing this extension onto a runtime that cannot run it.
@@ -103,13 +105,18 @@ if (!rejectJob) {
   errors.push('the engines-floor-reject job does not run `scripts/smoke-reject.mjs`.');
 }
 
-// ---- 3. src/index.ts MIN_NODE -----------------------------------------------------
-const indexSrc = read('src/index.ts');
-const minNode = /^\s*const MIN_NODE = '([^']+)'/m.exec(indexSrc);
+// ---- 3. src/node-floor.ts MIN_NODE -------------------------------------------------
+const floorSrc = read('src/node-floor.ts');
+const minNode = /^export const MIN_NODE = '([^']+)'/m.exec(floorSrc);
 if (!minNode) {
-  errors.push("src/index.ts has no `const MIN_NODE = '...'` — the startup guard is gone.");
+  errors.push("src/node-floor.ts has no `export const MIN_NODE = '...'` — the startup guard is gone.");
 } else {
-  found['src/index.ts MIN_NODE'] = minNode[1];
+  found['src/node-floor.ts MIN_NODE'] = minNode[1];
+}
+
+const indexSrc = read('src/index.ts');
+if (!/enforceNodeFloor\(\)/.test(indexSrc)) {
+  errors.push('src/index.ts never calls enforceNodeFloor() — the floor is declared but not enforced at startup.');
 }
 
 // The guard is only worth anything if the server graph is reached by a DYNAMIC import

--- a/scripts/check-node-floor.mjs
+++ b/scripts/check-node-floor.mjs
@@ -1,80 +1,151 @@
 #!/usr/bin/env node
 /**
- * Asserts the Node floor is the SAME NUMBER everywhere it is written down.
+ * Asserts the Node floor is the SAME NUMBER everywhere it is written down, AND that
+ * the CI jobs which are supposed to exercise it actually contain the steps that do.
  *
- * The floor lives in three places, and each one is load-bearing in a different way:
+ * The floor lives in four places, each load-bearing in a different way:
  *
- *   1. package.json `engines.node`  — what npm tells a consumer at install time.
- *   2. ci.yml `engines-floor` job   — the Node the built server is actually EXECUTED on.
- *   3. src/index.ts `MIN_NODE`      — the runtime guard that produces a readable error
- *                                     instead of ERR_REQUIRE_ESM, and the only defence
- *                                     the .mcpb bundle has (it runs the HOST's node).
+ *   1. package.json `engines.node`        — what npm tells a consumer at install time.
+ *   2. ci.yml `engines-floor` job         — the Node the built server is EXECUTED on.
+ *   3. src/index.ts `MIN_NODE`            — the runtime guard that produces a readable
+ *                                           error instead of ERR_REQUIRE_ESM.
+ *   4. mcpb/manifest.json                 — `compatibility.runtimes.node`; the ONLY one
+ *      the .mcpb host reads, and the only thing that can stop Claude Desktop from
+ *      installing this extension onto a runtime that cannot run it.
  *
  * If (1) drifts above (2), the floor we publish is no longer the floor we test, and a
- * dependency broken below it merges green — that is precisely how the sanitize-html
- * startup crash happened. If (3) drifts, the guard rejects runtimes that are fine or,
- * worse, waves through runtimes that are not.
+ * dependency broken below it merges green — exactly how the sanitize-html startup crash
+ * happened. If (3) drifts, the guard rejects good runtimes or waves through bad ones.
+ * If (4) drifts, the bundle advertises itself as compatible with every Node in existence.
  *
- * The comment in ci.yml used to say "keep in sync." A coupling maintained by a comment
- * is a coupling maintained by nobody. This is the check.
+ * Two earlier versions of this script were themselves instances of the bug it exists to
+ * catch, which is why it now works the way it does:
+ *
+ *   - It matched `node-version:` in COMMENT text, so a commented-out pin still reported
+ *     "executed in CI" (the same defect as the previous round's comment-grepping CI flag).
+ *     Comments are stripped before anything is matched.
+ *   - It asserted the floor was "executed in CI" while checking only that a version
+ *     STRING appeared — deleting the steps that actually run the server left it green.
+ *     It now requires the executing steps to be present by name.
+ *   - It used `\Z` as an end-of-input anchor. JavaScript has no `\Z` (that is Python and
+ *     PCRE); it matches a literal 'Z'. The job-scoping regex only terminated by luck.
  */
-import { readFileSync } from 'node:fs';
+import { readFileSync, existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { resolve } from 'node:path';
 
 const ROOT = fileURLToPath(new URL('..', import.meta.url));
 const read = (p) => readFileSync(resolve(ROOT, p), 'utf8');
 
+/** Strip YAML comments. Naive but sufficient: no `#` appears inside a quoted scalar here. */
+const stripComments = (yaml) =>
+  yaml.split('\n').map((l) => l.replace(/(^|\s)#.*$/, '')).join('\n');
+
 const found = {};
 const errors = [];
 
-// 1. package.json engines.node — expect a bare ">=X.Y.Z"
+// ---- 1. package.json engines.node ------------------------------------------------
 const engines = JSON.parse(read('package.json')).engines?.node;
 const enginesMatch = /^>=\s*(\d+\.\d+\.\d+)$/.exec(engines ?? '');
 if (!enginesMatch) {
   errors.push(
-    `package.json engines.node is ${JSON.stringify(engines)} — expected an exact ">=X.Y.Z" ` +
+    `package.json engines.node is ${JSON.stringify(engines)} — expected an exact ">=X.Y.Z", ` +
     `so it can be compared against the version CI actually runs.`,
   );
 } else {
   found['package.json engines.node'] = enginesMatch[1];
 }
 
-// 2. ci.yml — the node-version of the engines-floor job's SECOND setup-node (the one
-//    that runs the built server). Scoped to that job so the other jobs, which track
-//    current Node on purpose, are not dragged into the comparison.
-const ci = read('.github/workflows/ci.yml');
-const floorJob = /^ {2}engines-floor:$([\s\S]*?)(?=^ {2}\S|\Z)/m.exec(ci);
+// ---- 2 & the CI jobs that must exercise the floor ---------------------------------
+const ci = stripComments(read('.github/workflows/ci.yml'));
+
+/** The body of a top-level job, scoped from its key to the next top-level key or EOF. */
+function jobBody(name) {
+  // `$(?![\s\S])` is a real end-of-input anchor. `\Z` is not one in JavaScript.
+  const re = new RegExp(`^ {2}${name}:$([\\s\\S]*?)(?=^ {2}\\S|$(?![\\s\\S]))`, 'm');
+  return re.exec(ci)?.[1] ?? null;
+}
+
+const floorJob = jobBody('engines-floor');
 if (!floorJob) {
   errors.push('.github/workflows/ci.yml has no `engines-floor:` job — the floor is executed by nothing.');
 } else {
-  const versions = [...floorJob[1].matchAll(/node-version:\s*'([^']+)'/g)].map((m) => m[1]);
+  const versions = [...floorJob.matchAll(/node-version:\s*'([^']+)'/g)].map((m) => m[1]);
   const exact = versions.filter((v) => /^\d+\.\d+\.\d+$/.test(v));
   if (exact.length !== 1) {
     errors.push(
       `the engines-floor job declares ${exact.length} exact node-versions (${JSON.stringify(versions)}) — ` +
-      `expected exactly one pinned X.Y.Z, the floor to execute.`,
+      `expected exactly one pinned X.Y.Z: the floor to execute.`,
     );
   } else {
     found['ci.yml engines-floor job'] = exact[0];
   }
+  // Declaring a version is not executing on it. Require the steps that actually run
+  // the built server against the production tree — deleting them used to leave this
+  // script cheerfully reporting "executed in CI".
+  for (const step of ['npm ci --omit=dev', 'scripts/smoke-start.mjs']) {
+    if (!floorJob.includes(step)) {
+      errors.push(`the engines-floor job no longer runs \`${step}\` — it declares the floor but does not execute on it.`);
+    }
+  }
 }
 
-// 3. src/index.ts MIN_NODE
-const minNode = /const MIN_NODE = '([^']+)'/.exec(read('src/index.ts'));
+// The reject path needs its own coverage: a job that runs the entrypoint BELOW the floor
+// and proves the guard actually fires. Without it, reverting src/index.ts's dynamic import
+// to a static one restores the ERR_REQUIRE_ESM crash with every gate still green.
+const rejectJob = jobBody('engines-floor-reject');
+if (!rejectJob) {
+  errors.push(
+    '.github/workflows/ci.yml has no `engines-floor-reject:` job — nothing proves the startup ' +
+    'guard actually REJECTS a below-floor Node. The guard\'s whole purpose is untested.',
+  );
+} else if (!rejectJob.includes('scripts/smoke-reject.mjs')) {
+  errors.push('the engines-floor-reject job does not run `scripts/smoke-reject.mjs`.');
+}
+
+// ---- 3. src/index.ts MIN_NODE -----------------------------------------------------
+const indexSrc = read('src/index.ts');
+const minNode = /^\s*const MIN_NODE = '([^']+)'/m.exec(indexSrc);
 if (!minNode) {
-  errors.push('src/index.ts has no `const MIN_NODE = \'...\'` — the startup guard is gone.');
+  errors.push("src/index.ts has no `const MIN_NODE = '...'` — the startup guard is gone.");
 } else {
   found['src/index.ts MIN_NODE'] = minNode[1];
 }
 
+// The guard is only worth anything if the server graph is reached by a DYNAMIC import
+// after it. A static import evaluates before this file's body runs, so the crash would
+// happen before the check. smoke-reject proves this behaviorally on a below-floor Node;
+// this catches it at lint speed, with a message that says why.
+if (/^import\s[^;]*from\s+'\.\/server\//m.test(indexSrc)) {
+  errors.push(
+    "src/index.ts statically imports the server graph. ESM evaluates static imports BEFORE\n" +
+    "    this file's body, so the version guard would run only AFTER the very crash it exists\n" +
+    "    to prevent. Load the server with `await import('./server/server.js')` instead.",
+  );
+}
+
+// ---- 4. mcpb/manifest.json compatibility.runtimes.node -----------------------------
+if (existsSync(resolve(ROOT, 'mcpb/manifest.json'))) {
+  const runtime = JSON.parse(read('mcpb/manifest.json')).compatibility?.runtimes?.node;
+  const runtimeMatch = /^>=\s*(\d+\.\d+\.\d+)$/.exec(runtime ?? '');
+  if (!runtimeMatch) {
+    errors.push(
+      `mcpb/manifest.json compatibility.runtimes.node is ${JSON.stringify(runtime)} — expected ">=X.Y.Z". ` +
+      `This is the only floor the .mcpb host reads; without it the bundle claims to run on any Node.`,
+    );
+  } else {
+    found['mcpb/manifest.json runtimes.node'] = runtimeMatch[1];
+  }
+}
+
+// ---- they must all be the same number ----------------------------------------------
 const versions = [...new Set(Object.values(found))];
 if (errors.length === 0 && versions.length > 1) {
   errors.push('the Node floor DISAGREES across the places it is declared:');
   for (const [where, v] of Object.entries(found)) errors.push(`    ${v.padEnd(10)} ${where}`);
   errors.push(
-    '  The floor we publish, the floor we execute in CI, and the floor the server\n' +
-    '  enforces at startup must be one number. Pick one and change all three.',
+    '  The floor we publish, the floor we execute, the floor the server enforces at startup,\n' +
+    '  and the floor the .mcpb host reads must be ONE number. Pick one and change all four.',
   );
 }
 
@@ -84,4 +155,7 @@ if (errors.length > 0) {
   process.exit(1);
 }
 
-console.log(`check-node-floor: Node >=${versions[0]} — declared, executed in CI, and enforced at startup.`);
+console.log(
+  `check-node-floor: Node >=${versions[0]} — declared (npm + mcpb), executed in CI above AND ` +
+  `below the floor, and enforced at startup by a dynamic-import guard.`,
+);

--- a/scripts/smoke-reject.mjs
+++ b/scripts/smoke-reject.mjs
@@ -38,9 +38,10 @@ import { resolve } from 'node:path';
 const ROOT = fileURLToPath(new URL('..', import.meta.url));
 const ENTRY = process.argv[2] ? resolve(process.argv[2]) : resolve(ROOT, 'build/index.js');
 
-const MIN_NODE = /const MIN_NODE = '([^']+)'/.exec(readFileSync(resolve(ROOT, 'src/index.ts'), 'utf8'))?.[1];
+const MIN_NODE = /^export const MIN_NODE = '([^']+)'/m
+  .exec(readFileSync(resolve(ROOT, 'src/node-floor.ts'), 'utf8'))?.[1];
 if (!MIN_NODE) {
-  console.error('smoke-reject: could not read MIN_NODE from src/index.ts — the guard is gone.');
+  console.error('smoke-reject: could not read MIN_NODE from src/node-floor.ts — the guard is gone.');
   process.exit(1);
 }
 

--- a/scripts/smoke-reject.mjs
+++ b/scripts/smoke-reject.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/**
+ * Runs the BUILT entrypoint on a BELOW-FLOOR Node and asserts it rejects properly.
+ *
+ * This is the guard-for-the-guard, and it exists because every other check in this
+ * repo verifies the startup guard's *spelling* rather than its *behavior*:
+ *
+ *   - `check-node-floor.mjs` confirms `MIN_NODE` has the right value.
+ *   - `smoke-start.mjs` confirms the server starts ABOVE the floor.
+ *   - Nothing confirmed the server REJECTS below it.
+ *
+ * So the load-bearing property was unprotected. `src/index.ts` reaches the server via
+ * `await import()` *after* the version check, specifically so that `sanitize-html` →
+ * `htmlparser2@12` is never evaluated on a runtime that cannot `require()` ESM. Revert
+ * that one line to a static `import` and the guard silently stops running before the
+ * crash it exists to prevent — while `check-node-floor`, typecheck, lint, all 681
+ * tests, and every CI job stay green, because every runtime in CI is above the floor.
+ * The only thing defending it was a code comment saying "do not tidy this into a
+ * static import." A comment is not a guard.
+ *
+ * This script is that guard. Run it on a Node BELOW the floor. It asserts:
+ *
+ *   1. the process exits non-zero,
+ *   2. our human-readable message appears,
+ *   3. ERR_REQUIRE_ESM does NOT appear   — proves the guard ran BEFORE the import,
+ *   4. no SyntaxError appears            — proves the file parsed as ESM at all
+ *                                          (the .mcpb bundle ships no package.json,
+ *                                          so this is a real failure mode).
+ *
+ * Usage: node scripts/smoke-reject.mjs [entrypoint]   (default: build/index.js)
+ *        Must be executed by a Node older than the floor, or it self-skips loudly.
+ */
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
+
+const ROOT = fileURLToPath(new URL('..', import.meta.url));
+const ENTRY = process.argv[2] ? resolve(process.argv[2]) : resolve(ROOT, 'build/index.js');
+
+const MIN_NODE = /const MIN_NODE = '([^']+)'/.exec(readFileSync(resolve(ROOT, 'src/index.ts'), 'utf8'))?.[1];
+if (!MIN_NODE) {
+  console.error('smoke-reject: could not read MIN_NODE from src/index.ts — the guard is gone.');
+  process.exit(1);
+}
+
+const cmp = (a, b) => {
+  const pa = a.split('-')[0].split('.').map(Number);
+  const pb = b.split('-')[0].split('.').map(Number);
+  for (let i = 0; i < 3; i++) {
+    if ((pa[i] ?? 0) !== (pb[i] ?? 0)) return (pa[i] ?? 0) - (pb[i] ?? 0);
+  }
+  return 0;
+};
+
+if (cmp(process.versions.node, MIN_NODE) >= 0) {
+  console.error(
+    `smoke-reject: MUST run on a Node BELOW the floor (${MIN_NODE}), but this is ` +
+    `${process.version}. Running it above the floor proves nothing — the guard would ` +
+    `not fire. In CI this runs under an explicitly below-floor setup-node step.`,
+  );
+  process.exit(1);
+}
+
+const r = spawnSync(process.execPath, [ENTRY], {
+  cwd: '/',                       // as npx / .mcpb do: cwd is not the project root
+  encoding: 'utf8',
+  input: '{}\n',
+  timeout: 30_000,
+  env: { ...process.env, GOOGLE_CLIENT_ID: 'smoke.invalid', GOOGLE_CLIENT_SECRET: 'smoke' },
+});
+
+const out = `${r.stdout ?? ''}${r.stderr ?? ''}`;
+const fail = (why) => {
+  console.error(`smoke-reject: FAIL — ${why}\n`);
+  console.error(`  node:      ${process.version}  (floor is ${MIN_NODE})`);
+  console.error(`  entry:     ${ENTRY}`);
+  console.error(`  exit code: ${r.status}\n`);
+  console.error(out.trim() || '  (no output at all)');
+  process.exit(1);
+};
+
+// 4 — the file must PARSE. The .mcpb bundle ships without a package.json, so if the
+// bundle is not explicitly ESM the entrypoint dies here and the guard never runs.
+if (/SyntaxError|Cannot use import statement|await is only valid/.test(out)) {
+  fail('the entrypoint failed to PARSE — the guard never ran. Is the bundle missing `"type": "module"`?');
+}
+
+// 3 — the guard must run BEFORE the server graph is imported. If this appears, the
+// dynamic import was reverted to a static one and the crash is back.
+if (/ERR_REQUIRE_ESM/.test(out)) {
+  fail('ERR_REQUIRE_ESM leaked — the server graph was imported BEFORE the version check. ' +
+       'Someone turned the `await import()` in src/index.ts back into a static import.');
+}
+
+// 1 — it must refuse to run.
+if (r.status === 0) fail('the server started on a below-floor Node instead of refusing.');
+
+// 2 — and it must say why, in words.
+if (!out.includes(`requires Node >=${MIN_NODE}`)) {
+  fail('exited non-zero but never printed the version message (dropped stderr? wrong message?).');
+}
+
+console.log(
+  `smoke-reject: OK — on ${process.version} (below the ${MIN_NODE} floor) the server refused ` +
+  `to start, explained why, and never leaked ERR_REQUIRE_ESM.`,
+);

--- a/src/__tests__/server/node-floor.test.ts
+++ b/src/__tests__/server/node-floor.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Tests for the Node floor comparison.
+ *
+ * This file exists because its absence let a real regression through: a revert of the
+ * pre-release fix below passed `make check`, all 681 tests, and every CI job, because
+ * nothing anywhere exercised the comparison. `check-node-floor.mjs` asserts MIN_NODE has
+ * the right VALUE and that the entrypoint imports the server dynamically — neither says
+ * anything about whether the arithmetic is right.
+ */
+import { describe, it, expect } from 'vitest';
+import { meets, MIN_NODE, floorMessage } from '../../node-floor.js';
+
+describe('meets', () => {
+  const FLOOR = '22.12.0';
+
+  it('accepts the floor exactly', () => {
+    expect(meets('22.12.0', FLOOR)).toBe(true);
+  });
+
+  it.each([
+    ['22.12.1', 'patch above'],
+    ['22.13.0', 'minor above'],
+    ['24.0.0', 'major above'],
+    ['26.4.0', 'well above'],
+  ])('accepts %s (%s)', (version) => {
+    expect(meets(version, FLOOR)).toBe(true);
+  });
+
+  it.each([
+    ['22.11.0', 'minor below'],
+    ['22.0.0', 'same major, minor below'],
+    ['21.99.99', 'major below'],
+    ['20.19.0', 'the old floor'],
+    ['18.14.1', 'the floor before that'],
+  ])('rejects %s (%s)', (version) => {
+    expect(meets(version, FLOOR)).toBe(false);
+  });
+
+  // The regression the review caught: '-rc.1' landed in the patch slot, parseInt('0-rc')
+  // was 0, and the release candidate compared EQUAL to the floor — waved through, in the
+  // dangerous direction. A pre-release of the floor may predate the require(ESM) backport
+  // the floor exists to guarantee.
+  describe('pre-releases sort BELOW their release (semver §11.3)', () => {
+    it.each([
+      '22.12.0-rc.1',
+      '22.12.0-pre',
+      '22.12.0-nightly20260101',
+    ])('rejects %s — a pre-release of the floor is below the floor', (version) => {
+      expect(meets(version, FLOOR)).toBe(false);
+    });
+
+    it.each([
+      '23.0.0-rc.1',
+      '22.13.0-pre',
+    ])('accepts %s — a pre-release of a HIGHER version still clears the floor', (version) => {
+      expect(meets(version, FLOOR)).toBe(true);
+    });
+  });
+
+  it('tolerates a leading v', () => {
+    expect(meets('v24.0.0', FLOOR)).toBe(true);
+    expect(meets('v20.0.0', FLOOR)).toBe(false);
+  });
+
+  it('treats a missing component as zero', () => {
+    expect(meets('22', FLOOR)).toBe(false);      // 22.0.0 < 22.12.0
+    expect(meets('22.12', FLOOR)).toBe(true);    // 22.12.0 == floor
+    expect(meets('23', FLOOR)).toBe(true);
+  });
+
+  it('does not wave through a version it cannot parse', () => {
+    // Unparseable components degrade to 0 — i.e. toward "older", never toward "newer".
+    expect(meets('not-a-version', FLOOR)).toBe(false);
+    expect(meets('', FLOOR)).toBe(false);
+  });
+});
+
+describe('MIN_NODE', () => {
+  it('is an exact three-part version', () => {
+    // check-node-floor.mjs compares this against engines.node, the CI job and the mcpb
+    // manifest by exact string match; a range or a two-part version breaks that coupling.
+    expect(MIN_NODE).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it('is at least 22.12.0 — the unflagged require(ESM) threshold', () => {
+    // Below this, sanitize-html (CommonJS) cannot require() the pure-ESM htmlparser2@12
+    // and the server crashes at startup. Lowering MIN_NODE without lowering that
+    // dependency is the exact bug this floor exists to prevent.
+    expect(meets(MIN_NODE, '22.12.0')).toBe(true);
+  });
+});
+
+describe('floorMessage', () => {
+  it('names both the required and the actual version', () => {
+    const msg = floorMessage('v20.19.0');
+    expect(msg).toContain(`requires Node >=${MIN_NODE}`);
+    expect(msg).toContain('v20.19.0');
+  });
+
+  it('tells .mcpb users to upgrade the app, not the server', () => {
+    // The bundle runs the HOST's node; upgrading this package cannot help them.
+    expect(floorMessage('v20.19.0')).toContain('upgrade the app');
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,53 @@
 #!/usr/bin/env node
-import { startServer } from './server/server.js';
+/**
+ * Entrypoint. Deliberately imports NOTHING from the server graph at module scope.
+ *
+ * ESM evaluates static imports before the importing module's body runs, so a
+ * `import { startServer } from './server/server.js'` here would pull in the whole
+ * dependency graph — including `sanitize-html`, which is CommonJS and `require()`s
+ * the pure-ESM `htmlparser2` — BEFORE any check in this file could execute. On a
+ * Node below the floor that throws `ERR_REQUIRE_ESM` from deep inside node_modules:
+ * a stack trace naming somebody else's files, for a problem that is entirely ours.
+ *
+ * So the version check runs first, and the server is loaded by DYNAMIC import only
+ * once the runtime is known to be adequate. This is the one place in the codebase
+ * where import style is load-bearing; do not "tidy" it into a static import.
+ *
+ * This matters most for the .mcpb bundle, whose manifest runs a bare `node` — the
+ * HOST's runtime, whose version we neither control nor can test in CI.
+ */
+
+/** Keep in sync with `engines.node` in package.json. */
+const MIN_NODE = '22.12.0';
+
+function parse(version: string): number[] {
+  return version.replace(/^v/, '').split('.').map((n) => parseInt(n, 10) || 0);
+}
+
+/** True if `actual` is at least `min`. Plain compare, no dependency — by design. */
+function meets(actual: string, min: string): boolean {
+  const a = parse(actual);
+  const m = parse(min);
+  for (let i = 0; i < 3; i++) {
+    if ((a[i] ?? 0) > (m[i] ?? 0)) return true;
+    if ((a[i] ?? 0) < (m[i] ?? 0)) return false;
+  }
+  return true;
+}
+
+if (!meets(process.versions.node, MIN_NODE)) {
+  process.stderr.write(
+    `\n[gws-mcp] This server requires Node >=${MIN_NODE}, but is running on ${process.version}.\n\n` +
+    `  Node 18 and Node 20 are both end-of-life (April 2025 and April 2026).\n` +
+    `  Upgrading is the fix: https://nodejs.org/en/download\n\n` +
+    `  Running this as a Claude Desktop extension (.mcpb)? The bundle uses the Node\n` +
+    `  runtime Claude Desktop provides — upgrade the app rather than this server.\n\n`,
+  );
+  process.exit(1);
+}
+
+// Dynamic, and only after the guard above. See the file header.
+const { startServer } = await import('./server/server.js');
 
 // Prevent unhandled rejections from crashing the server
 process.on('unhandledRejection', (reason) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,51 +2,31 @@
 /**
  * Entrypoint. Deliberately imports NOTHING from the server graph at module scope.
  *
- * ESM evaluates static imports before the importing module's body runs, so a
+ * ESM evaluates static imports before the importing module's body runs, so
  * `import { startServer } from './server/server.js'` here would pull in the whole
- * dependency graph — including `sanitize-html`, which is CommonJS and `require()`s
- * the pure-ESM `htmlparser2` — BEFORE any check in this file could execute. On a
- * Node below the floor that throws `ERR_REQUIRE_ESM` from deep inside node_modules:
- * a stack trace naming somebody else's files, for a problem that is entirely ours.
+ * dependency graph — including `sanitize-html`, which is CommonJS and `require()`s the
+ * pure-ESM `htmlparser2` — BEFORE any check in this file could execute. On a Node below
+ * the floor that throws `ERR_REQUIRE_ESM` from deep inside node_modules: a stack trace
+ * naming somebody else's files, for a problem that is entirely ours.
  *
- * So the version check runs first, and the server is loaded by DYNAMIC import only
- * once the runtime is known to be adequate. This is the one place in the codebase
- * where import style is load-bearing; do not "tidy" it into a static import.
+ * So the floor is enforced first, and the server is loaded by DYNAMIC import only once
+ * the runtime is known to be adequate. This matters most for the .mcpb bundle, whose
+ * manifest runs a bare `node` — the HOST's runtime, whose version we neither control nor
+ * can test in CI.
  *
- * This matters most for the .mcpb bundle, whose manifest runs a bare `node` — the
- * HOST's runtime, whose version we neither control nor can test in CI.
+ * This ordering is NOT protected by this comment — comments protect nothing.
+ * `scripts/smoke-reject.mjs` runs the built entrypoint on a below-floor Node and fails if
+ * ERR_REQUIRE_ESM ever leaks (CI job `engines-floor-reject`), and `check-node-floor.mjs`
+ * rejects a static import of the server graph outright. Those are what protect it.
+ *
+ * `./node-floor.js` imports only `node:fs` (a builtin), so it cannot trigger the failure
+ * this file guards against. Only the SERVER GRAPH must stay behind the dynamic import.
  */
+import { enforceNodeFloor } from './node-floor.js';
 
-/** Keep in sync with `engines.node` in package.json. */
-const MIN_NODE = '22.12.0';
+enforceNodeFloor();
 
-function parse(version: string): number[] {
-  return version.replace(/^v/, '').split('.').map((n) => parseInt(n, 10) || 0);
-}
-
-/** True if `actual` is at least `min`. Plain compare, no dependency — by design. */
-function meets(actual: string, min: string): boolean {
-  const a = parse(actual);
-  const m = parse(min);
-  for (let i = 0; i < 3; i++) {
-    if ((a[i] ?? 0) > (m[i] ?? 0)) return true;
-    if ((a[i] ?? 0) < (m[i] ?? 0)) return false;
-  }
-  return true;
-}
-
-if (!meets(process.versions.node, MIN_NODE)) {
-  process.stderr.write(
-    `\n[gws-mcp] This server requires Node >=${MIN_NODE}, but is running on ${process.version}.\n\n` +
-    `  Node 18 and Node 20 are both end-of-life (April 2025 and April 2026).\n` +
-    `  Upgrading is the fix: https://nodejs.org/en/download\n\n` +
-    `  Running this as a Claude Desktop extension (.mcpb)? The bundle uses the Node\n` +
-    `  runtime Claude Desktop provides — upgrade the app rather than this server.\n\n`,
-  );
-  process.exit(1);
-}
-
-// Dynamic, and only after the guard above. See the file header.
+// Dynamic, and only after the floor is enforced. See the file header.
 const { startServer } = await import('./server/server.js');
 
 // Prevent unhandled rejections from crashing the server

--- a/src/node-floor.ts
+++ b/src/node-floor.ts
@@ -1,0 +1,78 @@
+/**
+ * The Node version floor, and the comparison that enforces it.
+ *
+ * Split out of index.ts so it can be UNIT TESTED. It previously lived inline in the
+ * entrypoint, where it was untestable — and that mattered: a revert of the pre-release
+ * fix once slipped through `make check`, all 681 tests and every CI job, because nothing
+ * anywhere exercised the comparison. `check-node-floor.mjs` checks that MIN_NODE has the
+ * right VALUE and that the entrypoint imports the server dynamically; neither says
+ * anything about whether the arithmetic is correct.
+ *
+ * This module imports only `node:fs` (a builtin). It CANNOT trigger the ESM/CJS failure
+ * the guard exists to prevent, so index.ts may import it statically. Only the server
+ * graph must stay behind the dynamic import.
+ */
+import { writeSync } from 'node:fs';
+
+/** Keep in sync with `engines.node`, the engines-floor CI job, and mcpb/manifest.json. */
+export const MIN_NODE = '22.12.0';
+
+interface Version { parts: number[]; prerelease: boolean }
+
+/**
+ * `22.12.0-rc.1` is *below* `22.12.0`, not equal to it (semver §11.3).
+ *
+ * An earlier version split on '.' and parseInt'd each part, so `-rc.1` landed in the
+ * patch slot, `parseInt('0-rc', 10)` came out 0, and the release candidate compared
+ * EQUAL to the floor — waved through, in the dangerous direction. Node's nightly and RC
+ * builds do report a suffixed `process.versions.node`, and a pre-release of the floor
+ * release may predate the very `require(ESM)` backport this floor exists to guarantee.
+ */
+function parse(version: string): Version {
+  const [core, ...rest] = version.replace(/^v/, '').split('-');
+  return {
+    parts: core.split('.').map((n) => parseInt(n, 10) || 0),
+    prerelease: rest.length > 0,
+  };
+}
+
+/** True if `actual` is at least `min`. Plain compare, no dependency — by design. */
+export function meets(actual: string, min: string): boolean {
+  const a = parse(actual);
+  const m = parse(min);
+  for (let i = 0; i < 3; i++) {
+    const av = a.parts[i] ?? 0;
+    const mv = m.parts[i] ?? 0;
+    if (av > mv) return true;
+    if (av < mv) return false;
+  }
+  // Cores equal: a pre-release of that core sorts BEFORE the release itself, so it
+  // passes only if the floor is that same pre-release.
+  return !a.prerelease || m.prerelease;
+}
+
+export function floorMessage(actual: string, min: string = MIN_NODE): string {
+  return (
+    `\n[gws-mcp] This server requires Node >=${min}, but is running on ${actual}.\n\n` +
+    `  Node 18 and Node 20 are both end-of-life (April 2025 and April 2026).\n` +
+    `  Upgrading is the fix: https://nodejs.org/en/download\n\n` +
+    `  Running this as a Claude Desktop extension (.mcpb)? The bundle uses the Node\n` +
+    `  runtime Claude Desktop provides — upgrade the app rather than this server.\n\n`
+  );
+}
+
+/**
+ * Exits the process if the running Node is below the floor.
+ *
+ * `writeSync`, NOT `process.stderr.write`: Node's writes to a PIPE are asynchronous on
+ * macOS (synchronous only on Linux/Windows), and Claude Desktop spawns the .mcpb server
+ * with piped stdio — on the platform where .mcpb matters most. `process.stderr.write(...)`
+ * followed immediately by `process.exit(1)` can tear the process down before the buffer
+ * drains, leaving a bare exit code and NO message: strictly worse than the stack trace
+ * this replaces. This is the one code path whose entire value is its output.
+ */
+export function enforceNodeFloor(actual: string = process.versions.node): void {
+  if (meets(actual, MIN_NODE)) return;
+  writeSync(2, floorMessage(`v${actual.replace(/^v/, '')}`));
+  process.exit(1);
+}


### PR DESCRIPTION
Closes #139.

## The pin was never about security

`sanitize-html` was pinned to exactly `2.17.5`. That version **carries** the fix for GHSA-rpr9-rxv7-x643 — the advisory's vulnerable range is `2.17.3` alone. The pin existed because we could not take the **next** patch:

`2.17.6` moves to the pure-ESM `htmlparser2@12`. `sanitize-html` is itself **CommonJS**, so its `require()` of an ESM-only package needs Node ≥20.19. It's a *static import in the startup graph*, so below the floor the server doesn't degrade — it **fails to boot** with `ERR_REQUIRE_ESM` from inside somebody else's `node_modules`.

That bump reached a merge-ready branch during ADR-101 — green on the full suite and every CI job — because the dev box runs Node 26 and CI pinned Node 20. It would have crashed **every Node 18 consumer on first start**.

## Why 22.12, not the 20.19 the issue proposed

It is July 2026. **Node 18 went EOL April 2025; Node 20 in April 2026.** `>=20.19` would ship onto an already-unsupported runtime. Node 22 is in **Maintenance LTS** (Node 24 took the Active line in Oct 2025) with fixes until April 2027 — so 22.12 is the lowest floor that is *both* able to `require()` ESM unflagged *and* still supported.

ADR-101's **two-floor model collapses into one number**. Conflating those floors is what produced the original crash.

## Six review rounds in, the lesson is the same

An adversarial review of the first version of this branch found ten defects, and the top one was the sixth consecutive instance of this codebase's signature bug — **a guard that attests to a property it never measures**:

`check-node-floor` verified `MIN_NODE` *exists and has the right value*. But the load-bearing property is that the server is reached via `await import()` **after** the check. Revert that one line to a static `import` and the crash returns while `check-node-floor`, typecheck, lint, every test and every CI job stay green — because every runtime in CI is *above* the floor, where the crash can't happen. The only thing defending it was a code comment saying *"do not tidy this into a static import."*

**A comment is not a guard.** The fix is one behavioral test.

## What ships

The floor is enforced in **four** places, and `check-node-floor` fails the build if they disagree:

| Where | What it does |
|---|---|
| `engines.node` | what npm tells a consumer at install (advisory only) |
| `engines-floor` CI job | **executes** the built server on exactly that Node, prod deps only |
| `MIN_NODE` (`src/node-floor.ts`) | startup guard — a sentence instead of a stack trace |
| `mcpb/manifest.json` `runtimes.node` | the **only** floor the `.mcpb` host reads |

Plus `engines-floor-reject`: runs the built entrypoint on **Node 20.19.0** and asserts it exits non-zero, prints our message, and never leaks `ERR_REQUIRE_ESM`. It **refuses to run above the floor**, so it cannot pass vacuously. `engines-floor` proves the server starts above the floor; `engines-floor-reject` proves it refuses below it. Neither means anything alone.

## The `.mcpb` bundle couldn't run the guard at all

In the one delivery channel the guard exists for. The bundle shipped **no `package.json`**, so nothing declared `"type": "module"` and the ESM entrypoint only parsed thanks to Node's module-syntax *detection* (default-on from 20.19/22.7). On any host without it, the entry died with a raw `SyntaxError` **before the guard could run**. Now ships `{"type": "module"}` — verified it starts, and that the guard fires inside it, with detection explicitly disabled.

Corollary: the `.mcpb` break is **narrower than ADR-102's first draft claimed**. The bundle could never have run below ~20.19 anyway, so Node 18 users were already broken. Real exposure is hosts on 20.19–22.11. Investigated rather than speculated.

## Everything else the review found, all falsified

- `check-node-floor` matched `node-version:` inside YAML **comments** — a commented-out pin still reported "executed in CI". *The same comment-grepping defect as the previous round.* Comments now stripped.
- It claimed the floor was "executed in CI" while checking only that a version **string** appeared; deleting the steps that run the server left it green. Now requires them by name.
- It used `\Z` as an end-of-input anchor. **JavaScript has no `\Z`** — it matches a literal `Z`. The regex terminated by luck.
- `meets()` **waved through pre-releases of the floor**: `22.12.0-rc.1` compared *equal* to `22.12.0`. Semver says a pre-release sorts below its release, and an RC of the floor may predate the `require(ESM)` backport the floor exists to guarantee. False pass, dangerous direction.
- `process.stderr.write` + `process.exit(1)` **can drop the message entirely** — Node's writes to a pipe are async on **macOS**, and Claude Desktop spawns `.mcpb` servers with piped stdio. The one code path whose entire value is its output could produce a bare exit code on the platform where `.mcpb` matters most. Now `fs.writeSync`.
- `make mcpb` ran `npm install --production` with **no lockfile**, so with sanitize-html unpinned the bundle could ship a version CI never validated. Now `npm ci --omit=dev`.
- `mcpb/manifest.json` declared **no runtime**, so the bundle advertised itself as compatible with every Node in existence.

And one I caught in my own work: a commit whose message **claimed two fixes it did not contain** (a stray `git checkout` reverted them). Nothing noticed — because `meets()`, production logic on every user's startup path, **had no tests**. Extracted to `src/node-floor.ts` and covered by 22 tests. Suite: 681 → **703**.

## Evidence

| Guard | Injected failure | Result |
|---|---|---|
| `smoke-reject` | `await import()` reverted to a static import | exit 1 — "ERR_REQUIRE_ESM leaked" |
| | run above the floor | refuses to run |
| `check-node-floor` | static import of the server graph | exit 1 |
| | floor pin commented out in ci.yml | exit 1 |
| | `smoke-start` step deleted from `engines-floor` | exit 1 |
| | `engines-floor-reject` job deleted | exit 1 |
| | any of the four floor sites drifts | exit 1, names all four |
| startup guard | `22.12.0-rc.1` | rejected |
| `.mcpb` bundle | run with syntax detection disabled | starts; guard fires |

**CI, on real Node 20.19.0:** `smoke-reject: OK — the server refused to start, explained why, and never leaked ERR_REQUIRE_ESM.`

- `npm audit --omit=dev`: **0 vulnerabilities** (`sanitize-html@2.17.6`, `htmlparser2@12.0.0`)
- **703/703 tests** pass with a pure-ESM transitive — the thing Jest could not load. ADR-101 arriving.
- CI: 6/6 green.

## Still to validate

`compatibility.runtimes.node` *should* stop Claude Desktop installing onto an inadequate runtime — but that depends on the host honoring the field, which is **unverified**. The startup guard is the backstop for every case it doesn't. Being tested against a real `.mcpb` install now.

Breaking change for Node 18/20 consumers — warrants a minor version bump and a release note.