### PR TITLE
fix: workspace-relative uploads, and confirmations that say what they acted on

### DIFF
--- a/src/__tests__/factory/defaults.test.ts
+++ b/src/__tests__/factory/defaults.test.ts
@@ -1,0 +1,51 @@
+/**
+ * The default formatters — what an operation says when no patch shapes its response.
+ *
+ * The action formatter is the one that matters here. Google does not agree with itself
+ * about what an identifier is called (`id` in Tasks, `documentId` in Docs,
+ * `spreadsheetId` in Sheets), and the formatter only recognised the literal key `id`.
+ * So `manage_docs create` returned, in full: "Operation completed." No id, no title —
+ * an agent reading the response text had nothing to act on.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { formatDefault } from '../../factory/defaults.js';
+import type { OperationDef } from '../../factory/types.js';
+
+const action = { type: 'action', description: '', resource: 'x.y' } as OperationDef;
+
+describe('formatDefault — action', () => {
+  it('names the resource when Google calls the id `documentId`', () => {
+    // The regression: a Docs create response carries no key called `id`.
+    const res = formatDefault({ documentId: 'doc-1', title: 'Quarterly numbers' }, action);
+
+    expect(res.text).toContain('doc-1');
+    expect(res.text).toContain('Quarterly numbers');
+    expect(res.text).toContain('Document ID');
+    // refs.id stays populated whatever Google named the field, so $N.id chaining works.
+    expect(res.refs.id).toBe('doc-1');
+  });
+
+  it('still handles a plain `id` (Tasks) and shows the title', () => {
+    const res = formatDefault({ id: 'task-1', title: 'buy milk' }, action);
+
+    expect(res.text).toContain('task-1');
+    expect(res.text).toContain('buy milk');
+    expect(res.refs.id).toBe('task-1');
+  });
+
+  it('handles spreadsheetId', () => {
+    const res = formatDefault({ spreadsheetId: 'sheet-1', properties: { title: 'Budget' } }, action);
+
+    expect(res.text).toContain('sheet-1');
+    expect(res.refs.id).toBe('sheet-1');
+  });
+
+  it('does not claim an id it was not given', () => {
+    // A response with no identifier at all must not invent one — and must still confirm.
+    const res = formatDefault({}, action);
+
+    expect(res.text).toContain('Operation completed.');
+    expect(res.text).not.toContain('ID:');
+  });
+});

--- a/src/factory/defaults.ts
+++ b/src/factory/defaults.ts
@@ -74,18 +74,46 @@ function formatDefaultDetail(data: unknown): HandlerResponse {
   };
 }
 
-/** Generic action formatter — confirmation message with returned fields. */
+/**
+ * Generic action formatter — confirm, and say WHAT was acted on.
+ *
+ * Google does not agree with itself about what an identifier is called: Tasks returns
+ * `id`, Docs returns `documentId`, Sheets returns `spreadsheetId`. This used to print
+ * only a key named exactly `id`, so creating a document produced the entire response
+ * "Operation completed." — no id, no title, nothing an agent could act on. The id was
+ * in `refs` (so `$0.documentId` chaining worked), but anything reading the text was
+ * told only that *something* had happened.
+ *
+ * So name the thing: whichever identifier came back, plus whatever the resource calls
+ * itself. A confirmation you cannot act on is barely a confirmation.
+ */
+const ID_KEYS = ['id', 'documentId', 'spreadsheetId', 'fileId', 'eventId', 'threadId'];
+const NAME_KEYS = ['title', 'name', 'summary'];
+
 function formatDefaultAction(data: unknown): HandlerResponse {
   const obj = (data ?? {}) as Record<string, unknown>;
-  const id = String(obj.id ?? 'unknown');
+
+  const idKey = ID_KEYS.find((k) => obj[k] !== undefined && obj[k] !== null);
+  const id = idKey ? String(obj[idKey]) : 'unknown';
+  const nameKey = NAME_KEYS.find((k) => typeof obj[k] === 'string' && obj[k] !== '');
 
   const parts: string[] = ['Operation completed.'];
-  if (obj.id) parts.push(`\n**ID:** ${id}`);
+  if (nameKey) parts.push(`\n\n**${titleCase(nameKey)}:** ${String(obj[nameKey])}`);
+  if (idKey) parts.push(`\n**${titleCase(idKey)}:** ${id}`);
 
   return {
     text: parts.join(''),
+    // `id` stays populated whatever Google called the field, so next-steps and
+    // queue_operations references keep resolving.
     refs: { id, ...extractScalarRefs(obj) },
   };
+}
+
+/** documentId -> "Document ID"; title -> "Title" */
+function titleCase(key: string): string {
+  return key
+    .replace(/Id$/, ' ID')
+    .replace(/^./, (c) => c.toUpperCase());
 }
 
 /** Find the first array in a response object (items, files, messages, etc). */

--- a/src/services/drive/patch.ts
+++ b/src/services/drive/patch.ts
@@ -11,7 +11,7 @@ import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { readFile } from 'node:fs/promises';
-import { basename } from 'node:path';
+import { basename, isAbsolute } from 'node:path';
 
 import { call, download, upload } from '../../google/client.js';
 import { lookupMimeType } from '../gmail/mime.js';
@@ -53,7 +53,17 @@ export const drivePatch: ServicePatch = {
      * for a small file.
      */
     upload: async (params, account): Promise<HandlerResponse> => {
-      const filePath = requireString(params, 'filePath');
+      // A RELATIVE path is workspace-relative — the same convention `download`,
+      // `export` and email attachments already use. It used to resolve against the
+      // server's cwd (which is wherever the MCP client happened to launch it, often
+      // `/`), so a file just written by manage_workspace or a scratchpad `send` could
+      // not be uploaded by the name it was given: `ENOENT: smoke/report.md`. The two
+      // halves of the same tool disagreed about what a path meant.
+      //
+      // Absolute paths are untouched, so anything uploading from outside the workspace
+      // keeps working.
+      const given = requireString(params, 'filePath');
+      const filePath = isAbsolute(given) ? given : resolveWorkspacePath(given);
       await verifyPathSafety(filePath);
       const media = await readFile(filePath);
 


### PR DESCRIPTION
Two findings from driving all 11 tools against a real account after #145.

### `manage_drive upload` resolved relative paths against the server's CWD

Every other file-taking operation — `download`, `export`, email attachments — treats a relative path as **workspace-relative**. `upload` resolved against `process.cwd()`, which is wherever the MCP client launched the server (commonly `/`). So a file you just wrote could not be uploaded by the name you gave it:

```
manage_workspace write   filename="smoke/report.md"     ✓
manage_drive     upload  filePath="smoke/report.md"     ✗ ENOENT
```

The two halves of the same tool disagreed about what a path means. It failed loudly rather than silently, which is why it never looked like a bug — but it's a trap.

Relative paths now resolve against the workspace. **Absolute paths are untouched**, so uploads from outside the workspace keep working — verified live, both ways.

### Confirmations that don't say what they confirmed

The generic action formatter looked only for a key named exactly `id`. Google is not consistent here: Tasks returns `id`, Docs returns `documentId`, Sheets returns `spreadsheetId`. So `manage_docs create` returned, in its entirety:

```
Operation completed.
```

No id, no title. The id *was* in `refs` — so `$0.documentId` chaining worked — but anything reading the response text was told only that something had happened somewhere. It now names the identifier Google actually returned, plus the title of what it created. `refs.id` stays populated regardless of the field name, so existing references keep resolving.

---

`make check` green — 672 tests, 36 files. Both fixes probed red before being fixed, and the upload fix verified live against Google.