### PR TITLE
fix: exit when orphaned, and stop the crash guard feeding itself

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,29 @@ jobs:
     - run: node --version
     - run: node scripts/smoke-reject.mjs
 
+  orphan-exit:
+    # Proves an orphaned server EXITS rather than pegging a CPU core forever (#149).
+    #
+    # The unit tests cover `isOrphaned` as a predicate. Nothing there proves a real
+    # process tree actually reclaims itself, which is the only claim the user in #149
+    # cares about — they found two orphans that had each burned 31 minutes of CPU in
+    # 31 minutes of wall time.
+    #
+    # The smoke script runs the HARD case deliberately: stdin that never reports EOF, so
+    # only the watchdog can save the process. An easy orphan reclaims itself via stdin EOF
+    # and would pass with the watchdog deleted — a guard reporting on a signal that was
+    # never the one under test. Verified to fail against the pre-fix entrypoint.
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '22'
+        cache: 'npm'
+    - run: npm ci
+    - run: npm run build
+    - run: node scripts/smoke-orphan.mjs
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := help
-.PHONY: help test test-all test-unit test-integration build clean typecheck lint smoke smoke-reject check-gates check-node-floor \
+.PHONY: help test test-all test-unit test-integration build clean typecheck lint smoke smoke-reject smoke-orphan check-gates check-node-floor \
         manifest-lint check-write-ops \
         coverage coverage-update \
         mcpb version-sync publish-all \
@@ -74,10 +74,16 @@ smoke: build ## Start the built server on a foreign cwd and assert it loads its 
 smoke-reject: build ## Assert the server REFUSES a below-floor Node (run on Node <22.12)
 	node scripts/smoke-reject.mjs
 
+# The unit tests prove `isOrphaned` answers correctly; only this proves a real process
+# tree reclaims itself. It runs the case with NO stdin EOF available, so deleting the
+# watchdog fails here instead of passing on a signal that wasn't there (#149, ADR-104).
+smoke-orphan: build ## Assert an orphaned server exits instead of pegging a CPU core
+	node scripts/smoke-orphan.mjs
+
 # Mirrors CI. `lint` used to be in the help text but not the prerequisites, so a
 # contributor could go green locally and red in CI on a job this target claimed
 # to cover.
-check: typecheck lint check-gates check-node-floor check-write-ops test build smoke ## Type-check, lint, test, build, smoke (CI gate)
+check: typecheck lint check-gates check-node-floor check-write-ops test build smoke smoke-orphan ## Type-check, lint, test, build, smoke (CI gate)
 
 clean: ## Remove build artifacts
 	rm -rf build/ mcpb/server mcpb/LICENSE mcpb/NOTICE mcpb/LICENSE-MIT *.mcpb

--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -23,7 +23,8 @@ _Architecture, tool design, executor patterns_
 | [ADR-100](./core/ADR-100-build-time-coverage-analysis-of-gws-cli-surface.md) | Build-Time Coverage Analysis of gws CLI Surface | Draft |
 | [ADR-101](./core/ADR-101-migrate-test-runner-from-jest-to-vitest.md) | Migrate test runner from Jest to Vitest | Accepted |
 | [ADR-102](./core/ADR-102-raise-the-node-floor-to-22-12-and-unpin-sanitize-html.md) | Raise the Node floor to 22.12 and unpin sanitize-html | Accepted |
-| [ADR-103](./core/ADR-103-generate-a-google-api-descriptor-retire-the-gws-facade.md) | Generate a Google API descriptor from Discovery; retire the gws facade | Draft |
+| [ADR-103](./core/ADR-103-generate-a-google-api-descriptor-retire-the-gws-facade.md) | Generate a Google API descriptor from Discovery; retire the gws facade | Accepted |
+| [ADR-104](./core/ADR-104-exit-when-the-mcp-client-goes-away.md) | Exit when the MCP client goes away | Draft |
 
 ## Authentication
 _OAuth, credential management, multi-account_

--- a/docs/architecture/core/ADR-104-exit-when-the-mcp-client-goes-away.md
+++ b/docs/architecture/core/ADR-104-exit-when-the-mcp-client-goes-away.md
@@ -1,0 +1,182 @@
+---
+status: Draft
+date: 2026-07-16
+deciders:
+  - aaronsb
+related: [ADR-102]
+---
+
+# ADR-104: Exit when the MCP client goes away
+
+## Context
+
+A stdio MCP server has no lifecycle of its own. It is spawned by a client, it serves that
+client, and when that client is gone it has no reason to exist and no way to be useful —
+its only channel to the world is a socket whose peer is dead. Nothing in this codebase
+said so. The server had no notion that it could be orphaned, so it never exited.
+
+Issue #149 reported the consequence: after a Claude Code session dies uncleanly, the
+server process survives, reparents to init, and pegs one CPU core **indefinitely**. The
+reporter found two orphans that had each burned 31 minutes of CPU in 31 minutes of wall
+time. This is a user-visible defect of the worst kind — a background process, invisible,
+draining a laptop battery, that the user never started and cannot attribute to us.
+
+Two independent defects compound to produce it.
+
+**The server never notices the client died.** No transport `onclose`, no stdin handling,
+no liveness check. When the client vanishes the server keeps running.
+
+**The crash guard becomes a busy-loop once stdio is dead.** `index.ts` installed:
+
+```js
+process.on('uncaughtException', (err) => {
+  process.stderr.write(`[google-workspace-mcp] uncaught exception: ...`);
+});
+```
+
+Once the peer is dead, a write to stderr raises an asynchronous error. That error reaches
+the `uncaughtException` handler, which writes to the same dead stderr, which raises the
+next error, which reaches the handler again — forever. The handler swallows every
+exception (so the process never dies) while generating the next one. It is a perpetual
+motion machine built out of error handling. The reporter's `sample(1)` puts ~70% of time
+in `ErrorUtils::GetFormattedStack`: the process is spending its life formatting stack
+traces for errors caused by reporting the previous error.
+
+### What we measured
+
+The report's diagnosis was correct; two of its load-bearing claims were not, and both
+would have led us to a fix that didn't work. We reproduced the failure against a real
+`socketpair()` — Claude Code wires stdio to unix sockets, not pipes, and this distinction
+turned out to matter — under two scenarios:
+
+- **A**: the socket peer dies, the parent process stays alive.
+- **B**: the client is `SIGKILL`ed, orphaning the server (the reported scenario).
+
+| Candidate | A: peer dies, parent lives | B: client SIGKILLed |
+|---|---|---|
+| Current code | **101% CPU, forever** | **101% CPU, forever** |
+| Safe crash guard only | 0% CPU, process leaks | 0% CPU, process leaks |
+| Orphan watchdog only | **101% CPU, forever** | exits in ~0.1s |
+
+**The report's claim that "either bug alone would prevent the CPU spin" is false.** The
+watchdog alone still spins in scenario A, because the parent is alive and the watchdog
+never fires. The guard alone stops the spin but leaves an idle orphan forever. Each fix
+has a gap the other covers, so we take both.
+
+**The report's suggested watchdog is also subtly broken:**
+
+```js
+setInterval(() => { try { process.kill(process.ppid, 0); } catch { process.exit(0); } }, 5000)
+```
+
+`process.ppid` is a *live getter*, not a value cached at startup. Once the parent dies the
+process is reparented and `process.ppid` becomes init/systemd — which is always alive, so
+`process.kill(process.ppid, 0)` always succeeds and the check never fires. Verified
+directly: after the parent died, `ppid` moved from `2884591` to `2951` (systemd), and
+`kill(2951, 0)` reports alive. The original ppid must be captured at startup.
+
+Finally, the report states that waiting for stdin EOF "would not be enough" because unix
+sockets never surface EOF. On Linux we measured the opposite: `end` and `close` both fire
+in scenarios A and B. We suspect the reporter's macOS observation is real but differently
+caused — if the socket fd is still held open by another live process, no FIN is sent and
+no EOF arrives. So EOF is a *useful* signal but not a *sufficient* one. It is fast and
+clean when it comes; we use it, but we do not depend on it.
+
+### Why nobody here ever saw this
+
+Worth recording, because it shaped the tests. Orphan the *real* server on Linux over a
+socketpair and it exits on its own — not from any lifecycle handling, but because stdin
+EOF arrives, the transport stops reading, the event loop empties, and Node exits. The bug
+is invisible on the platform we develop and test on.
+
+It bites only where EOF never comes. There, stdin holds the loop open forever, the server
+sits idle — and the moment anything logs, the write to the dead peer starts the busy-loop.
+That is the reporter's macOS environment, and it is why the CPU spin and the process leak
+are the same bug wearing two faces.
+
+This has a direct consequence for testing: an orphan test that lets EOF arrive **passes
+with the watchdog deleted**, because EOF alone reclaims the process. It would be a guard
+reporting on a signal that was never the one under test. `scripts/smoke-orphan.mjs`
+therefore builds a stdin that never reports EOF (a FIFO this project holds open) so that
+only the watchdog can save the process. Verified to fail against the pre-fix entrypoint.
+
+## Decision
+
+**A stdio server exits when its client is gone.** We adopt this as policy, and implement
+it as three layers in `src/lifecycle.ts`. Each layer independently prevents the 100% CPU
+spin, and each covers a gap in the others.
+
+**1. Crash guards that cannot re-enter.** Log with `writeSync(2, …)` inside `try/catch`.
+Synchronous writes fail *here*, where the failure is caught, instead of surfacing later as
+the next `uncaughtException`. This structurally forecloses the loop: the handler can no
+longer generate the exception that re-invokes it. This mirrors `node-floor.ts`, which
+already uses `writeSync` for a related reason (ADR-102).
+
+The guard **swallows** a failed write; it does not exit. Exiting is the watchdog's single
+responsibility. Inferring client death from a write error would also fire on a stderr
+redirect gone bad, which is not the same thing and should not kill the server.
+
+**2. An orphan watchdog.** Capture `process.ppid` at startup; poll every 5s on an
+`unref()`ed timer. Treat the server as orphaned when the ppid *changes* (definitive
+reparenting on Unix) **or** when the original ppid no longer exists. The
+ppid-changed check is immune to PID reuse; the `kill(pid, 0)` check covers platforms that
+do not reparent. Either signal means exit(0).
+
+**3. Client-disconnect handlers.** Exit on stdin `end`/`close`. Fastest and cleanest
+signal when the OS delivers it — typically sub-millisecond versus up to 5s for the
+watchdog poll.
+
+Layers 2 and 3 exit `0`. An orphaned server exiting is correct behavior, not a failure.
+
+The decision logic is a pure function (`isOrphaned`) so it can be unit tested without
+spawning processes — the same reasoning that split `node-floor.ts` out of the entrypoint
+(ADR-102): logic that lives inline in `index.ts` is logic nothing can test, and this
+project has already been bitten once by exactly that.
+
+## Consequences
+
+### Positive
+
+- The reported defect is fixed at the root: orphans exit within 5s instead of burning a
+  core forever.
+- The busy-loop is structurally impossible, not merely unlikely. Even if a future change
+  reintroduces a stdio-write crash, the guard cannot amplify it into a spin.
+- Defense in depth: the fix survives the failure of any single layer, including layers
+  whose behavior we know varies by platform (EOF delivery).
+- `isOrphaned` is unit-testable, so the policy is protected by tests rather than by
+  comments.
+
+### Negative
+
+- A 5s polling timer runs for the life of the process. It is `unref()`ed and does two
+  integer comparisons per tick; the cost is negligible next to a pegged core.
+- The server can now terminate itself. A bug in `isOrphaned` could kill a live server —
+  which is why the predicate is pure and directly tested.
+- Three layers to understand where there were none. Justified by the measured fact that no
+  single layer covers both scenarios.
+
+### Neutral
+
+- Scenario A (peer dead, parent alive) leaves an *idle* process rather than exiting. It
+  burns nothing, and stdin EOF or the watchdog reclaims it in every case we could
+  construct. Not worth a fourth mechanism.
+- If a future transport (HTTP) is added, layers 2 and 3 are stdio-specific and must not be
+  installed for it.
+
+## Alternatives Considered
+
+- **Fix only the crash guard.** Rejected: stops the spin but leaks an idle orphan forever,
+  and the process leak is half of what #149 reports.
+- **Fix only the watchdog.** Rejected: measured to still spin at 101% in scenario A, and
+  leaves the busy-loop primitive in place for any future stdio-write crash.
+- **The report's `kill(process.ppid, 0)` snippet as written.** Rejected: measured not to
+  work — `ppid` is a live getter and reads as init after reparenting.
+- **Exit when the log write fails (reporter's alternative).** Rejected: conflates "stderr
+  is broken" with "the client is gone." A misconfigured redirect would kill a healthy
+  server. Kept exit under the watchdog, which tests the actual question.
+- **Transport `onclose` via the SDK.** Deferred: it is a fourth signal for the same event,
+  layered on an SDK abstraction whose orphan-time behavior we would have to characterize.
+  The three layers here are measured; this would be assumed. Revisit if a gap appears.
+- **An external watchdog wrapper** (the reporter's stopgap). Rejected as a shipped fix:
+  pushes our lifecycle bug onto every user's process supervisor. A server that cannot
+  clean up after itself is not fixed by asking users to clean up after it.

--- a/scripts/smoke-orphan.mjs
+++ b/scripts/smoke-orphan.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+/**
+ * Asserts an ORPHANED server exits instead of pegging a CPU core (issue #149, ADR-104).
+ *
+ * The reported failure: a Claude Code session dies uncleanly, the server reparents to
+ * init, and burns 100% of a core forever — two orphans had each eaten 31 minutes of CPU in
+ * 31 minutes of wall time. The unit tests cover `isOrphaned` as a predicate; nothing there
+ * proves a real process tree actually reclaims itself, which is the only claim a user
+ * cares about.
+ *
+ * This runs the HARD case on purpose. The easy orphan reclaims itself via stdin EOF, so a
+ * naive test passes even with the watchdog deleted. So we build a stdin that NEVER reports
+ * EOF and let only the watchdog save us:
+ *
+ *     smoke (this)          holds the FIFO open for writing, and stays alive
+ *       └── intermediate    stands in for Claude Code; SIGKILLed
+ *             └── server    stdin = the FIFO's read end
+ *
+ * When the intermediate is killed, the server is orphaned — but its stdin still has a live
+ * writer (us), so no EOF ever arrives. That models the macOS report, where the client's
+ * socket fd is held open elsewhere and EOF never comes. If the watchdog regresses, this
+ * hangs and fails rather than passing on a signal that wasn't there.
+ *
+ * Deliberately dependency-free and ES2021-plain, matching the other smoke scripts.
+ * POSIX-only (FIFOs, SIGKILL, reparenting); skipped on Windows.
+ */
+import { spawn, spawnSync } from 'node:child_process';
+import { openSync, closeSync, mkdtempSync, rmSync, constants } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { resolve, join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const ROOT = fileURLToPath(new URL('..', import.meta.url));
+const ENTRY = resolve(ROOT, 'build/index.js');
+
+// The watchdog polls every 5s; allow a few cycles before calling it a failure.
+const DEADLINE_MS = 20_000;
+
+if (process.platform === 'win32') {
+  console.log('smoke-orphan: SKIP — POSIX-only (FIFOs, SIGKILL, reparenting)');
+  process.exit(0);
+}
+
+const fail = (msg, extra) => {
+  console.error(`smoke-orphan: FAIL — ${msg}`);
+  if (extra) console.error(String(extra).trim());
+  process.exit(1);
+};
+
+const dir = mkdtempSync(join(tmpdir(), 'smoke-orphan-'));
+const fifo = join(dir, 'stdin.fifo');
+let fifoFd = null;
+let intermediate = null;
+let serverPid = null;
+
+const cleanup = () => {
+  for (const pid of [serverPid, intermediate?.pid]) {
+    try { if (pid) process.kill(pid, 'SIGKILL'); } catch { /* already gone */ }
+  }
+  try { if (fifoFd !== null) closeSync(fifoFd); } catch { /* already closed */ }
+  try { rmSync(dir, { recursive: true, force: true }); } catch { /* best effort */ }
+};
+process.on('exit', cleanup);
+
+if (spawnSync('mkfifo', [fifo]).status !== 0) fail('could not create a FIFO');
+
+// O_RDWR, not O_WRONLY: opening a FIFO write-only BLOCKS until a reader arrives, and the
+// reader is a process we have not spawned yet — a deadlock. O_RDWR never blocks, and holds
+// the write end open for as long as we live, which is the entire point of this test.
+fifoFd = openSync(fifo, constants.O_RDWR);
+
+// The intermediate stands in for the MCP client: it spawns the server on the FIFO, reports
+// the pid, and then does nothing until it is killed.
+const intermediateSrc = `
+  import { spawn } from 'node:child_process';
+  import { openSync } from 'node:fs';
+  const stdin = openSync(${JSON.stringify(fifo)}, 'r');
+  const child = spawn(process.execPath, [${JSON.stringify(ENTRY)}], {
+    cwd: '/',
+    stdio: [stdin, 'ignore', 'ignore'],
+    env: { ...process.env, GOOGLE_CLIENT_ID: 'smoke.invalid', GOOGLE_CLIENT_SECRET: 'smoke' },
+  });
+  process.stdout.write(child.pid + '\\n');
+  setInterval(() => {}, 1000);
+`;
+
+intermediate = spawn(process.execPath, ['--input-type=module', '-e', intermediateSrc], {
+  stdio: ['ignore', 'pipe', 'inherit'],
+});
+
+/**
+ * Whether OUR server is still running as `pid`.
+ *
+ * Identity-checked, not just `kill(pid, 0)`. Once the intermediate is dead the server is
+ * reparented to init, so we cannot `waitpid` it and can only ask about a bare pid — and a
+ * bare pid is not a stable identity. The kernel is free to hand that number to an
+ * unrelated process the moment the server exits, and CI is exactly where that churn
+ * happens. `kill(pid, 0)` alone would then report "still alive", failing the build for a
+ * server that had already done the right thing. (Observed during development: a reused pid
+ * masqueraded as a live orphan sitting at 0% CPU.)
+ *
+ * So: confirm the command line is still ours. Wrong process, or no process, means our
+ * server is gone — which is the outcome this test is asking about.
+ */
+const alive = (pid) => {
+  const ps = spawnSync('ps', ['-p', String(pid), '-o', 'command='], { encoding: 'utf8' });
+  if (ps.status !== 0) return false; // no such pid
+  return ps.stdout.includes(ENTRY);
+};
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+intermediate.stdout.on('data', (chunk) => {
+  if (serverPid) return;
+  serverPid = Number(String(chunk).trim());
+  if (!Number.isInteger(serverPid) || serverPid <= 0) fail(`bad server pid: ${chunk}`);
+  run();
+});
+
+intermediate.on('error', (err) => fail(`could not spawn the intermediate: ${err.message}`));
+
+async function run() {
+  // Let the server finish starting, so we are killing a live server rather than racing it.
+  await sleep(3000);
+  if (!alive(serverPid)) fail(`server ${serverPid} died before the test began`);
+
+  // The client dies uncleanly: no cleanup, no clean shutdown, no chance to kill us.
+  process.kill(intermediate.pid, 'SIGKILL');
+
+  const started = Date.now();
+  while (Date.now() - started < DEADLINE_MS) {
+    if (!alive(serverPid)) {
+      const secs = ((Date.now() - started) / 1000).toFixed(1);
+      console.log(
+        `smoke-orphan: OK — orphaned server exited on its own after ${secs}s ` +
+          `(no EOF available; watchdog reclaimed it, node ${process.version})`,
+      );
+      process.exit(0);
+    }
+    await sleep(250);
+  }
+
+  fail(
+    `orphaned server ${serverPid} was STILL ALIVE ${DEADLINE_MS / 1000}s after its client ` +
+      `was killed. This is issue #149: it will burn a CPU core until the user finds it.`,
+  );
+}

--- a/src/__tests__/server/lifecycle.test.ts
+++ b/src/__tests__/server/lifecycle.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Tests for the orphan-detection lifecycle (issue #149, ADR-104).
+ *
+ * These exist because the server can now TERMINATE ITSELF. A bug in `isOrphaned` would not
+ * produce a wrong answer somewhere — it would kill a live server mid-request, or fail to
+ * reclaim the orphan this whole module exists to reclaim. That is why the predicate is
+ * pure and tested directly rather than only through a spawned process tree.
+ *
+ * The end-to-end behavior (a real orphan, over a real unix socketpair, actually exiting
+ * instead of pegging a core) is not testable here — it needs process trees and CPU
+ * measurement. `scripts/smoke-orphan.mjs` covers that.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+/**
+ * The guard logs with `writeSync(2, …)`, NOT `process.stderr.write` — that is the whole
+ * point of it (a synchronous write fails where it can be caught, instead of surfacing as
+ * the next uncaughtException). So the failure must be injected at `writeSync`. Spying on
+ * `process.stderr.write` here would mock something the guard never calls, and the tests
+ * would pass while exercising nothing.
+ */
+const writeSyncMock = vi.hoisted(() => vi.fn());
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return { ...actual, writeSync: writeSyncMock };
+});
+
+import { isOrphaned, installLifecycle, WATCHDOG_INTERVAL_MS } from '../../lifecycle.js';
+
+describe('isOrphaned', () => {
+  const PARENT = 1000;
+
+  it('is false while the parent is unchanged and alive', () => {
+    expect(isOrphaned(PARENT, PARENT, true)).toBe(false);
+  });
+
+  /**
+   * The reported failure. On Unix a dead parent means immediate reparenting, so a CHANGED
+   * ppid is definitive — and it is the signal that survives PID reuse.
+   */
+  it('is true when the ppid changed — reparented, so the parent is gone', () => {
+    expect(isOrphaned(PARENT, 1, true)).toBe(true);
+  });
+
+  /**
+   * THE REGRESSION THIS FILE EXISTS FOR.
+   *
+   * The fix suggested in #149 polls `process.kill(process.ppid, 0)` — re-reading ppid
+   * every tick. After reparenting, ppid IS init/systemd, which is always alive, so that
+   * check reports "parent alive" forever and the server spins on at 100% CPU.
+   *
+   * This asserts we key off the ORIGINAL ppid: reparented to init, and init is alive, is
+   * still orphaned. If someone "simplifies" isOrphaned to trust parentAlive alone, this
+   * fails — which is the entire point.
+   */
+  it('is true when reparented to init even though init is alive', () => {
+    expect(isOrphaned(PARENT, 1, true)).toBe(true);
+  });
+
+  /** For platforms that don't reparent (Windows): the pid probe carries the signal. */
+  it('is true when the ppid is unchanged but the parent no longer exists', () => {
+    expect(isOrphaned(PARENT, PARENT, false)).toBe(true);
+  });
+});
+
+describe('installLifecycle', () => {
+  const stops: Array<() => void> = [];
+  const install = (hooks: Parameters<typeof installLifecycle>[0]) => {
+    const stop = installLifecycle(hooks);
+    stops.push(stop);
+    return stop;
+  };
+
+  afterEach(() => {
+    while (stops.length) stops.pop()!();
+    vi.useRealTimers();
+    writeSyncMock.mockReset();
+  });
+
+  /** Fire the guard we just installed, the way an uncaught exception would. */
+  const fireUncaught = (err: Error): void => {
+    const handler = process.listeners('uncaughtException').at(-1) as (e: Error) => void;
+    handler(err);
+  };
+
+  it('does not exit while the parent is alive', () => {
+    vi.useFakeTimers();
+    const exit = vi.fn();
+    install({ exit, parentAlive: () => true });
+
+    vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS * 4);
+
+    expect(exit).not.toHaveBeenCalled();
+  });
+
+  it('exits 0 once the parent goes away', () => {
+    vi.useFakeTimers();
+    const exit = vi.fn();
+    let alive = true;
+    install({ exit, parentAlive: () => alive });
+
+    vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+    expect(exit).not.toHaveBeenCalled();
+
+    alive = false;
+    vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+
+    // 0, not 1: an orphaned server exiting is correct behavior, not a failure.
+    expect(exit).toHaveBeenCalledWith(0);
+  });
+
+  /**
+   * Layer 1, the busy-loop guard. The old handler wrote to `process.stderr`, and once the
+   * peer was dead that write raised the NEXT uncaughtException, which re-entered the
+   * handler, forever, at 100% CPU.
+   *
+   * Simulating a dead stderr faithfully takes a real socketpair, so this asserts the
+   * structural property instead: the handler must complete without throwing even when the
+   * write fails. A handler that cannot throw cannot feed itself.
+   */
+  it('survives a crash report when the stderr write fails', () => {
+    const exit = vi.fn();
+    install({ exit, parentAlive: () => true });
+    writeSyncMock.mockImplementation(() => {
+      throw new Error('EPIPE: broken pipe');
+    });
+
+    expect(() => fireUncaught(new Error('boom'))).not.toThrow();
+  });
+
+  /**
+   * The loop was fed by the handler re-attempting a doomed write. Once a write has failed,
+   * stderr is latched dead and we stop trying — so a storm of exceptions cannot become a
+   * storm of writes. This asserts the latch, not merely that try/catch caught something:
+   * exactly ONE write is attempted across many exceptions.
+   */
+  it('stops attempting writes once stderr is known dead', () => {
+    const exit = vi.fn();
+    install({ exit, parentAlive: () => true });
+    writeSyncMock.mockImplementation(() => {
+      throw new Error('EPIPE: broken pipe');
+    });
+
+    for (let i = 0; i < 50; i++) fireUncaught(new Error(`boom ${i}`));
+
+    expect(writeSyncMock).toHaveBeenCalledTimes(1);
+  });
+
+  /** A healthy server still reports its crashes. The guard must not silence everything. */
+  it('logs crashes normally while stderr works', () => {
+    const exit = vi.fn();
+    install({ exit, parentAlive: () => true });
+    writeSyncMock.mockReturnValue(undefined);
+
+    fireUncaught(new Error('boom'));
+
+    expect(writeSyncMock).toHaveBeenCalledTimes(1);
+    expect(writeSyncMock.mock.calls[0][0]).toBe(2); // fd 2, stderr
+    expect(String(writeSyncMock.mock.calls[0][1])).toContain('boom');
+    expect(exit).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The reclaim that swallowing would cost us. A dead stderr is the EARLIEST signal we get
+   * on macOS, where stdin EOF never arrives — so a write failure must trigger the liveness
+   * check immediately rather than idling until the next 5s poll.
+   */
+  it('exits immediately on a failed write when the parent is already gone', () => {
+    const exit = vi.fn();
+    install({ exit, parentAlive: () => false });
+    writeSyncMock.mockImplementation(() => {
+      throw new Error('EPIPE: broken pipe');
+    });
+
+    fireUncaught(new Error('boom'));
+
+    // No timer advance: reclaimed on the spot, not up to WATCHDOG_INTERVAL_MS later.
+    expect(exit).toHaveBeenCalledWith(0);
+  });
+
+  /**
+   * The guard treats a failed write as EVIDENCE, not a verdict.
+   *
+   * "stderr is broken" is not the same claim as "the client is gone" — a botched stderr
+   * redirect says the same thing, and must not kill a healthy server. So a write failure
+   * triggers a real liveness CHECK; only that check may exit.
+   */
+  it('does not exit on a failed write when the parent is still alive', () => {
+    const exit = vi.fn();
+    install({ exit, parentAlive: () => true });
+    writeSyncMock.mockImplementation(() => {
+      throw new Error('EPIPE: broken pipe');
+    });
+
+    fireUncaught(new Error('boom'));
+
+    expect(exit).not.toHaveBeenCalled();
+  });
+
+  /** Layer 3: the fastest signal, when the OS delivers it. */
+  it('exits 0 when stdin reports end-of-stream', () => {
+    const exit = vi.fn();
+    install({ exit, parentAlive: () => true });
+
+    process.stdin.emit('end');
+
+    expect(exit).toHaveBeenCalledWith(0);
+  });
+
+  it('removes its listeners on stop, leaving no handlers behind', () => {
+    const before = process.listenerCount('uncaughtException');
+    const stop = installLifecycle({ exit: vi.fn(), parentAlive: () => true });
+    expect(process.listenerCount('uncaughtException')).toBe(before + 1);
+
+    stop();
+    stops.pop(); // already stopped
+
+    expect(process.listenerCount('uncaughtException')).toBe(before);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,24 +19,27 @@
  * ERR_REQUIRE_ESM ever leaks (CI job `engines-floor-reject`), and `check-node-floor.mjs`
  * rejects a static import of the server graph outright. Those are what protect it.
  *
- * `./node-floor.js` imports only `node:fs` (a builtin), so it cannot trigger the failure
- * this file guards against. Only the SERVER GRAPH must stay behind the dynamic import.
+ * `./node-floor.js` and `./lifecycle.js` import only `node:fs` (a builtin), so they cannot
+ * trigger the failure this file guards against. Only the SERVER GRAPH must stay behind the
+ * dynamic import.
  */
 import { enforceNodeFloor } from './node-floor.js';
+import { installLifecycle } from './lifecycle.js';
 
 enforceNodeFloor();
 
+/**
+ * Before the server starts: notice if our client dies, and exit.
+ *
+ * This also installs the uncaughtException/unhandledRejection guards, which used to live
+ * here and wrote to `process.stderr` directly. That was the busy-loop in issue #149 — once
+ * the client died, the write raised the next uncaught exception, which re-entered the
+ * handler, forever, at 100% CPU. See lifecycle.ts and ADR-104.
+ */
+installLifecycle();
+
 // Dynamic, and only after the floor is enforced. See the file header.
 const { startServer } = await import('./server/server.js');
-
-// Prevent unhandled rejections from crashing the server
-process.on('unhandledRejection', (reason) => {
-  process.stderr.write(`[google-workspace-mcp] unhandled rejection: ${reason}\n`);
-});
-
-process.on('uncaughtException', (err) => {
-  process.stderr.write(`[google-workspace-mcp] uncaught exception: ${err.message}\n${err.stack}\n`);
-});
 
 startServer().catch((err) => {
   process.stderr.write(`[google-workspace-mcp] fatal: ${err.message}\n`);

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -1,0 +1,178 @@
+/**
+ * Process lifecycle for the stdio server: notice the client is gone, and exit.
+ *
+ * A stdio MCP server has no life of its own. It is spawned by a client, it speaks to that
+ * client over stdin/stdout, and once that client is gone it can neither be useful nor be
+ * noticed — its only channel to the world is a socket whose peer is dead. Nothing in this
+ * codebase said so, so the server never exited. Issue #149: after a Claude Code session
+ * died uncleanly, orphaned servers reparented to init and pegged a CPU core *forever* —
+ * two of them had burned 31 minutes of CPU in 31 minutes of wall time.
+ *
+ * Two defects compounded. The server never noticed the client died (no signal was
+ * watched), and the `uncaughtException` guard in index.ts became a perpetual motion
+ * machine: it logged to stderr, and once the peer was dead that write raised the next
+ * uncaught exception, which re-entered the handler, which wrote to the same dead stderr…
+ * The handler swallowed every exception (so the process never died) while generating the
+ * next one. ~70% of samples were in stack formatting — the process spent its life
+ * formatting traces for errors caused by reporting the previous error.
+ *
+ * The fix is three layers. Each independently prevents the spin, and each covers a gap the
+ * others have — this is measured, not assumed (see ADR-104 for the matrix):
+ *
+ *   1. Crash guards that cannot re-enter  (kills the busy-loop structurally)
+ *   2. An orphan watchdog                 (reclaims the process; the only exit decision)
+ *   3. stdin end/close                    (fastest signal, when the OS delivers it)
+ *
+ * Neither of the two obvious single-layer fixes is sufficient. The watchdog alone still
+ * spins at 101% when the socket peer dies but the parent lives — the parent is alive, so
+ * it never fires. The guard alone stops the spin but leaks an idle orphan forever.
+ *
+ * Split out of index.ts so it can be UNIT TESTED, for the same reason node-floor.ts was
+ * (ADR-102): logic that lives inline in the entrypoint is logic nothing can test, and a
+ * revert once slipped through `make check`, all tests, and every CI job because of exactly
+ * that. `isOrphaned` is therefore a pure function, tested directly.
+ *
+ * Imports only `node:fs` (a builtin), so index.ts may import it statically without
+ * tripping the ESM/CJS hazard the Node floor guards. See the index.ts header.
+ */
+import { writeSync } from 'node:fs';
+
+/** How often to check whether our parent is still alive. */
+export const WATCHDOG_INTERVAL_MS = 5000;
+
+/**
+ * Whether the process has been orphaned, given a startup ppid and what we see now.
+ *
+ * Pure so it can be tested without spawning process trees. Two signals, because neither
+ * covers every platform:
+ *
+ * `currentPpid !== originalPpid` — on Unix a dead parent means immediate reparenting to
+ * init/systemd, so a *changed* ppid is definitive. This is the reliable one, and it is
+ * immune to PID reuse.
+ *
+ * `!parentAlive` — a `kill(pid, 0)` probe, for platforms that don't reparent (Windows).
+ * Note this is checked against the ORIGINAL ppid, captured at startup.
+ *
+ * Why the original ppid matters: `process.ppid` is a LIVE GETTER, not a value fixed at
+ * startup. The fix suggested in #149 polls `process.kill(process.ppid, 0)`, which re-reads
+ * ppid every tick — after reparenting that reads as init/systemd, which is always alive,
+ * so the check never fires and the server spins on. Measured: after the parent died, ppid
+ * moved 2884591 -> 2951 (systemd), and kill(2951, 0) reports alive. Reading ppid once, at
+ * startup, is the whole trick.
+ */
+export function isOrphaned(
+  originalPpid: number,
+  currentPpid: number,
+  parentAlive: boolean
+): boolean {
+  return currentPpid !== originalPpid || !parentAlive;
+}
+
+/** Whether a pid exists. `kill(pid, 0)` sends no signal; it only probes. */
+function pidExists(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export interface LifecycleHooks {
+  /** Seam for tests. Defaults to process.exit. */
+  exit?: (code: number) => void;
+  /** Seam for tests. Defaults to a real pid probe. */
+  parentAlive?: (pid: number) => boolean;
+}
+
+/**
+ * Installs all three layers. Call once, from the entrypoint, before starting the server.
+ *
+ * Returns a `stop()` for tests; the real process never needs it.
+ */
+export function installLifecycle(hooks: LifecycleHooks = {}): () => void {
+  const exit = hooks.exit ?? ((code: number) => process.exit(code));
+  const parentAlive = hooks.parentAlive ?? pidExists;
+
+  // Read ONCE. See isOrphaned: re-reading this is the bug in the suggested fix.
+  const originalPpid = process.ppid;
+
+  // Latched once a write fails. Not just an optimisation: it stops us re-attempting
+  // writes we know are doomed, rather than leaning on try/catch to swallow each one.
+  let stdioDead = false;
+
+  /**
+   * The ONE place this process decides to die.
+   *
+   * Exit code 0: an orphaned server exiting is correct behavior, not a failure.
+   */
+  const checkOrphaned = (): void => {
+    if (isOrphaned(originalPpid, process.ppid, parentAlive(originalPpid))) {
+      exit(0);
+    }
+  };
+
+  /**
+   * Log that cannot start the loop it is reporting on.
+   *
+   * `writeSync`, NOT `process.stderr.write`: a synchronous write fails HERE, where it is
+   * caught, instead of surfacing later as the next uncaughtException. That is what makes
+   * the busy-loop structurally impossible rather than merely unlikely — the handler can no
+   * longer generate the exception that re-invokes it. (node-floor.ts uses writeSync for a
+   * related reason; see ADR-102.)
+   *
+   * A failed write is EVIDENCE, not a verdict. It means "stderr is broken", which is not
+   * the same claim as "the client is gone" — a botched stderr redirect would say the same
+   * thing, and must not kill a healthy server. So we don't exit here (as #149 suggests);
+   * we ask the watchdog to test the real question, right now. When we are genuinely
+   * orphaned that reclaims the process in ~0ms instead of waiting up to 5s for the next
+   * poll — which is the difference that matters on macOS, where stdin EOF never arrives
+   * and this is the earliest signal we get.
+   */
+  const safeLog = (msg: string): void => {
+    if (stdioDead) return;
+    try {
+      writeSync(2, msg);
+    } catch {
+      stdioDead = true;
+      checkOrphaned();
+    }
+  };
+
+  // Layer 1: crash guards that cannot re-enter.
+  const onUncaught = (err: Error): void => {
+    safeLog(`[google-workspace-mcp] uncaught exception: ${err.message}\n${err.stack}\n`);
+  };
+  const onRejection = (reason: unknown): void => {
+    safeLog(`[google-workspace-mcp] unhandled rejection: ${reason}\n`);
+  };
+  process.on('uncaughtException', onUncaught);
+  process.on('unhandledRejection', onRejection);
+
+  // Layer 2: the orphan watchdog. unref()'d so it never by itself keeps us alive.
+  const timer = setInterval(checkOrphaned, WATCHDOG_INTERVAL_MS);
+  timer.unref();
+
+  // Layer 3: client disconnect. Fastest signal when the OS delivers it — sub-millisecond
+  // versus up to WATCHDOG_INTERVAL_MS. #149 reports that unix sockets may never surface
+  // EOF (macOS); we measured both `end` and `close` firing reliably on Linux. Likely the
+  // fd is held open elsewhere there, so no FIN is sent. Hence: use it, don't depend on it.
+  const onDisconnect = (): void => exit(0);
+  // A dead peer surfaces as an error on stdin too; it must not become an uncaught one.
+  const onStdinError = (): void => {
+    stdioDead = true;
+    checkOrphaned();
+  };
+  process.stdin.on('end', onDisconnect);
+  process.stdin.on('close', onDisconnect);
+  process.stdin.on('error', onStdinError);
+
+  return () => {
+    clearInterval(timer);
+    process.stdin.off('end', onDisconnect);
+    process.stdin.off('close', onDisconnect);
+    process.stdin.off('error', onStdinError);
+    process.off('uncaughtException', onUncaught);
+    process.off('unhandledRejection', onRejection);
+  };
+}


### PR DESCRIPTION
Implements ADR-104. Closes #149.

A stdio MCP server has no life of its own: it is spawned by a client, it is
useful only to that client, and once the client is gone it can neither serve
nor be noticed. Nothing in this codebase said so, so orphaned servers never
exited — in the report, two of them had each burned 31 minutes of CPU in 31
minutes of wall time.

## Three layers, in `src/lifecycle.ts`

Each is independently enough to stop the 100% CPU spin, and each covers a gap
in the others:

1. **Crash guards that cannot re-enter.** The old handler logged to
   `process.stderr`, so once the peer was dead the write raised the *next*
   uncaught exception, which re-entered the handler, forever — perpetual
   motion built out of error handling, with ~70% of samples in stack
   formatting. `writeSync` in a `try/catch` fails where it can be caught,
   making the loop structurally impossible rather than merely unlikely.
2. **An orphan watchdog**, keyed off the ppid captured at *startup*. The only
   place the process decides to die.
3. **stdin end/close** — the fastest signal, where the OS delivers it.

A failed write is treated as evidence, not a verdict: "stderr is broken" is not
the same claim as "the client is gone" (a botched redirect says the same thing
and must not kill a healthy server), so it triggers the liveness check rather
than an exit. That reclaims in ~0ms instead of waiting up to 5s on macOS, where
EOF never arrives and it is the earliest signal available.

## Where the report was wrong

The diagnosis in #149 was right; two load-bearing claims were not, and both
would have led to a fix that didn't work:

- *"Either bug alone would prevent the spin"* is false. Measured: the watchdog
  alone still spins at 101% when the peer dies but the parent lives; the guard
  alone stops the spin but leaks an idle orphan forever. Hence both.
- The suggested `kill(process.ppid, 0)` never fires. `process.ppid` is a live
  getter — after reparenting it reads as init, which is always alive. The
  original ppid must be captured at startup.

ADR-104 also records why this was invisible on Linux: the orphan gets stdin EOF
and exits by accident of an empty event loop. It bites where EOF never comes,
which is where the leak and the spin turn out to be one bug.

## Verification

`isOrphaned` is pure and directly tested. `scripts/smoke-orphan.mjs` covers the
end-to-end claim in the hard case — a FIFO stdin that never reports EOF, so
only the watchdog can save the process; an orphan test that lets EOF arrive
passes with the watchdog deleted. Verified to fail against the pre-fix
entrypoint, and wired into `make check` and CI.

`make check`: 705 tests across 41 files, build, `smoke-start`, `smoke-orphan` — all green.
