### PR TITLE
fix(docs): read every tab, not just the first

### DIFF
--- a/src/__tests__/factory/docs-patch.test.ts
+++ b/src/__tests__/factory/docs-patch.test.ts
@@ -12,6 +12,11 @@
  *
  *  - `create` silently discarded a title. `title` was not in the manifest at all, so
  *    the argument vanished with no error and every document was "Untitled document".
+ *
+ *  - `get` returned THE FIRST TAB of a multi-tab document and presented it as the whole
+ *    file (#152). Google's `body` is a legacy field holding only the first tab unless
+ *    documents.get is called with includeTabsContent=true; the reporter's document was
+ *    780 lines and came back as 142, with nothing in the response saying so.
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -43,6 +48,48 @@ function googleDoc(): Record<string, unknown> {
         ] } },
       ],
     },
+  };
+}
+
+/** One paragraph of body content, in Google's nesting. */
+function para(text: string): Record<string, unknown> {
+  return { paragraph: { elements: [{ textRun: { content: `${text}\n` } }] } };
+}
+
+/**
+ * A multi-tab document as Google ACTUALLY returns it with includeTabsContent=true.
+ *
+ * Note what is missing: there is no `body`. Verified live against three real documents —
+ * with the flag set, Google drops `body`, `headers`, `lists`, `inlineObjects` and
+ * `namedStyles` from the response entirely and puts the content under
+ * `tabs[].documentTab.body`. This shape is why reading `tabs` first is not a preference:
+ * code that reads `body` first returns an EMPTY document for every tabbed file.
+ */
+function tabbedDoc(): Record<string, unknown> {
+  return {
+    documentId: 'doc-2',
+    title: 'Meeting transcripts',
+    revisionId: 'rev-3',
+    tabs: [
+      {
+        tabProperties: { tabId: 't1', title: 'Monday', index: 0 },
+        documentTab: { body: { content: [para('Standup on Monday.')] } },
+      },
+      {
+        tabProperties: { tabId: 't2', title: 'Tuesday', index: 1 },
+        documentTab: { body: { content: [para('Standup on Tuesday.')] } },
+        childTabs: [
+          {
+            tabProperties: { tabId: 't2a', title: 'Action items', index: 0 },
+            documentTab: { body: { content: [para('Ship the fix.')] } },
+          },
+        ],
+      },
+      {
+        tabProperties: { tabId: 't3', title: 'Wednesday', index: 2 },
+        documentTab: { body: { content: [para('Standup on Wednesday.')] } },
+      },
+    ],
   };
 }
 
@@ -93,6 +140,161 @@ describe('docsPatch.get', () => {
 
     expect(mockCall).toHaveBeenCalledTimes(1);
     expect(mockCall).toHaveBeenCalledWith('docs', 'documents.get',
-      { documentId: 'doc-1' }, { account: ACCOUNT });
+      { documentId: 'doc-1', includeTabsContent: true }, { account: ACCOUNT });
+  });
+
+  it('ASKS for tab content — without the flag Google returns the first tab only', async () => {
+    // The whole bug in one assertion. Google's default is not "the document", it is
+    // "tab one", and it says nothing about the difference.
+    mockCall.mockResolvedValue(googleDoc());
+
+    await docsPatch.customHandlers!.get({ documentId: 'doc-1' }, ACCOUNT);
+
+    const [, , sentParams] = mockCall.mock.calls[0];
+    expect(sentParams).toMatchObject({ includeTabsContent: true });
+  });
+
+  it('renders a doc with no tabs exactly as before — body is still the fallback', async () => {
+    // Not every response carries `tabs`. The legacy shape must keep working, and it
+    // must not grow tab scaffolding it has no tabs for.
+    mockCall.mockResolvedValue(googleDoc());
+
+    const result = await docsPatch.customHandlers!.get({ documentId: 'doc-1' }, ACCOUNT);
+
+    expect(result.text).toContain('First line.');
+    expect(result.text).not.toContain('**Tabs:**');
+    expect(result.refs.tabs).toBe(0);
+  });
+});
+
+describe('docsPatch.get — multi-tab documents (#152)', () => {
+  it('returns EVERY tab, not just the first', async () => {
+    mockCall.mockResolvedValue(tabbedDoc());
+
+    const result = await docsPatch.customHandlers!.get({ documentId: 'doc-2' }, ACCOUNT);
+
+    expect(result.text).toContain('Standup on Monday.');
+    expect(result.text).toContain('Standup on Tuesday.');
+    expect(result.text).toContain('Standup on Wednesday.');
+  });
+
+  it('descends into childTabs — a nested tab is still document content', async () => {
+    mockCall.mockResolvedValue(tabbedDoc());
+
+    const result = await docsPatch.customHandlers!.get({ documentId: 'doc-2' }, ACCOUNT);
+
+    expect(result.text).toContain('Ship the fix.');
+  });
+
+  it('labels each tab, so concatenated transcripts do not read as one', async () => {
+    mockCall.mockResolvedValue(tabbedDoc());
+
+    const result = await docsPatch.customHandlers!.get({ documentId: 'doc-2' }, ACCOUNT);
+
+    expect(result.text).toContain('### Monday');
+    expect(result.text).toContain('### Tuesday');
+    // A child tab sits one heading level deeper than its parent.
+    expect(result.text).toContain('#### Action items');
+  });
+
+  it('says how many tabs it read — the response must not be silent about scope', async () => {
+    mockCall.mockResolvedValue(tabbedDoc());
+
+    const result = await docsPatch.customHandlers!.get({ documentId: 'doc-2' }, ACCOUNT);
+
+    // 3 top-level + 1 nested.
+    expect(result.text).toContain('**Tabs:** 4');
+    expect(result.refs.tabs).toBe(4);
+  });
+
+  it('reads a tabbed document that has NO body field — the real Google shape', async () => {
+    // The response above carries no `body`. Reading `body` first here returns an empty
+    // document while reporting success, which is the original bug wearing a new hat.
+    mockCall.mockResolvedValue(tabbedDoc());
+
+    const result = await docsPatch.customHandlers!.get({ documentId: 'doc-2' }, ACCOUNT);
+
+    expect(result.text).not.toContain('the document is empty');
+    expect(result.refs.characters).toBeGreaterThan(0);
+  });
+
+  it('prefers tabs over body when both are present — no duplicated first tab', async () => {
+    // Defensive, not observed live: if Google ever populates both, tab one must not be
+    // rendered twice.
+    mockCall.mockResolvedValue({
+      ...tabbedDoc(),
+      body: { content: [para('Standup on Monday.')] },
+    });
+
+    const result = await docsPatch.customHandlers!.get({ documentId: 'doc-2' }, ACCOUNT);
+
+    const occurrences = result.text.split('Standup on Monday.').length - 1;
+    expect(occurrences).toBe(1);
+  });
+
+  it('counts characters across all tabs, not just the one it used to read', async () => {
+    mockCall.mockResolvedValue(tabbedDoc());
+
+    const result = await docsPatch.customHandlers!.get({ documentId: 'doc-2' }, ACCOUNT);
+
+    const total = ['Standup on Monday.', 'Standup on Tuesday.', 'Ship the fix.', 'Standup on Wednesday.']
+      .reduce((sum, t) => sum + t.length, 0);
+    expect(result.refs.characters).toBe(total);
+  });
+
+  it('keeps a single-tab document free of tab scaffolding', async () => {
+    // Most documents have exactly one tab. Their output should not change at all.
+    mockCall.mockResolvedValue({
+      documentId: 'doc-3',
+      title: 'Plain',
+      tabs: [{
+        tabProperties: { tabId: 't1', title: 'Tab 1' },
+        documentTab: { body: { content: [para('Just some prose.')] } },
+      }],
+    });
+
+    const result = await docsPatch.customHandlers!.get({ documentId: 'doc-3' }, ACCOUNT);
+
+    expect(result.text).toContain('Just some prose.');
+    expect(result.text).not.toContain('### Tab 1');
+    expect(result.text).not.toContain('**Tabs:**');
+    expect(result.refs.tabs).toBe(1);
+  });
+
+  it('marks an empty tab as empty rather than dropping it', async () => {
+    // A tab with no content still tells the reader it exists — silently omitting it is
+    // the same class of lie as omitting the tab entirely.
+    mockCall.mockResolvedValue({
+      documentId: 'doc-4',
+      title: 'Half-written',
+      tabs: [
+        { tabProperties: { tabId: 't1', title: 'Draft' }, documentTab: { body: { content: [para('Some notes.')] } } },
+        { tabProperties: { tabId: 't2', title: 'Later' }, documentTab: { body: { content: [] } } },
+      ],
+    });
+
+    const result = await docsPatch.customHandlers!.get({ documentId: 'doc-4' }, ACCOUNT);
+
+    expect(result.text).toContain('### Later');
+    expect(result.text).toContain('_(this tab is empty)_');
+  });
+
+  it('survives a tab with no title and no documentTab', async () => {
+    // Defensive: tabProperties.title is not guaranteed, and a malformed tab must not
+    // take down the read of the tabs around it.
+    mockCall.mockResolvedValue({
+      documentId: 'doc-5',
+      title: 'Odd',
+      tabs: [
+        { tabProperties: {} },
+        { tabProperties: { title: 'Real' }, documentTab: { body: { content: [para('Content here.')] } } },
+      ],
+    });
+
+    const result = await docsPatch.customHandlers!.get({ documentId: 'doc-5' }, ACCOUNT);
+
+    expect(result.text).toContain('(untitled tab)');
+    expect(result.text).toContain('Content here.');
+    expect(result.refs.tabs).toBe(2);
   });
 });

--- a/src/__tests__/factory/docs-patch.test.ts
+++ b/src/__tests__/factory/docs-patch.test.ts
@@ -22,6 +22,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../../google/client.js');
 import { mockCall } from '../server/handlers/__mocks__/client.js';
+import { queryOf, requestFor } from '../support/request.js';
 import { docsPatch } from '../../services/docs/patch.js';
 
 const ACCOUNT = 'user@test.com';
@@ -154,6 +155,22 @@ describe('docsPatch.get', () => {
     expect(sentParams).toMatchObject({ includeTabsContent: true });
   });
 
+  it('puts includeTabsContent on the WIRE, as a query parameter', async () => {
+    // Every other assertion in this file inspects a MOCKED `call()`, which sits above
+    // the path/query/body split. That split is where the flag can die silently: if
+    // `includeTabsContent` ever loses `location: query` in the descriptor — regenerated
+    // routinely, per ADR-103 — splitParams routes it to the request BODY, buildRequest
+    // drops the body on a GET, and Google returns the first tab again. #152 would be
+    // back with this entire suite still green. So check the real request.
+    const request = await requestFor('docs', 'documents.get', {
+      documentId: 'doc-1',
+      includeTabsContent: true,
+    });
+
+    expect(queryOf(request)).toMatchObject({ includeTabsContent: 'true' });
+    expect(request.body).toBeUndefined();
+  });
+
   it('renders a doc with no tabs exactly as before — body is still the fallback', async () => {
     // Not every response carries `tabs`. The legacy shape must keep working, and it
     // must not grow tab scaffolding it has no tabs for.
@@ -277,6 +294,114 @@ describe('docsPatch.get — multi-tab documents (#152)', () => {
 
     expect(result.text).toContain('### Later');
     expect(result.text).toContain('_(this tab is empty)_');
+  });
+
+  it('does not call an UNREAD tab empty — a failed read is not a blank page', async () => {
+    // Google returned tabProperties but no documentTab for any tab. Reporting that as
+    // "this tab is empty" tells the reader the document is blank, which is the exact
+    // substitution this fix exists to stop: "I could not see it" is not "there is
+    // nothing there".
+    mockCall.mockResolvedValue({
+      documentId: 'doc-6',
+      title: 'Unreadable',
+      tabs: [
+        { tabProperties: { title: 'One' } },
+        { tabProperties: { title: 'Two' } },
+      ],
+    });
+
+    const result = await docsPatch.customHandlers!.get({ documentId: 'doc-6' }, ACCOUNT);
+
+    expect(result.text).not.toContain('this tab is empty');
+    expect(result.text).toContain('not the same as empty');
+    // …and the response says so up front rather than leaving it to be inferred.
+    expect(result.text).toContain('2 tab(s) returned no content');
+    expect(result.refs.unreadTabs).toBe(2);
+  });
+
+  it('falls back to body when a lone tab reports no content', async () => {
+    // The `??` bug: tabs[0].text was '' — not nullish — so a populated `body` was
+    // discarded and a document with content in it reported as empty.
+    mockCall.mockResolvedValue({
+      documentId: 'doc-7',
+      title: 'One empty tab',
+      tabs: [{ tabProperties: { title: 'Tab 1' }, documentTab: { body: { content: [] } } }],
+      body: { content: [para('real content here')] },
+    });
+
+    const result = await docsPatch.customHandlers!.get({ documentId: 'doc-7' }, ACCOUNT);
+
+    expect(result.text).toContain('real content here');
+    expect(result.text).not.toContain('the document is empty');
+    expect(result.refs.characters).toBe('real content here'.length);
+  });
+
+  it('counts characters and lines against the same text', async () => {
+    // Both numbers must describe document TEXT. `lines` used to count the rendered
+    // output — headings, placeholders, blank separators — so it could not be reconciled
+    // with `characters` sitting next to it in the same sentence.
+    mockCall.mockResolvedValue(tabbedDoc());
+
+    const result = await docsPatch.customHandlers!.get({ documentId: 'doc-2' }, ACCOUNT);
+
+    // Four tabs, one line of text each.
+    expect(result.refs.lines).toBe(4);
+    expect(result.text).toContain('**Length:** 71 characters, 4 line(s)');
+  });
+
+  it('distinguishes top-level tabs from nested ones in the count', async () => {
+    // The Docs tab strip shows 3 for this document; a bare "Tabs: 4" contradicts it with
+    // no way for the reader to tell which is wrong.
+    mockCall.mockResolvedValue(tabbedDoc());
+
+    const result = await docsPatch.customHandlers!.get({ documentId: 'doc-2' }, ACCOUNT);
+
+    expect(result.text).toContain('**Tabs:** 4 (3 top-level, 1 nested)');
+  });
+
+  it('warns that writes cannot address a tab', async () => {
+    // get now spans tabs; insertText indices do not. Saying nothing invites an agent to
+    // compute an index from this output and write to the wrong place (#157).
+    mockCall.mockResolvedValue(tabbedDoc());
+
+    const result = await docsPatch.customHandlers!.get({ documentId: 'doc-2' }, ACCOUNT);
+
+    expect(result.text).toContain('#157');
+    expect(result.text).toContain('relative to the FIRST tab');
+  });
+
+  it('flags a response that carries no tab data at all', async () => {
+    // With the flag set, every real document returned at least one tab. None is an
+    // anomaly, and `body` may be the first tab of several — so do not present it as
+    // the document without qualification.
+    mockCall.mockResolvedValue({
+      documentId: 'doc-8',
+      title: 'No tabs field',
+      body: { content: [para('Could be tab one of ten.')] },
+    });
+
+    const result = await docsPatch.customHandlers!.get({ documentId: 'doc-8' }, ACCOUNT);
+
+    expect(result.text).toContain('Could be tab one of ten.');
+    expect(result.text).toContain('may be the first tab only');
+  });
+
+  it('exposes tab titles in refs even when the heading is suppressed', async () => {
+    // A one-tab document whose tab the user RENAMED: the title is real content, and the
+    // rendered output deliberately omits it.
+    mockCall.mockResolvedValue({
+      documentId: 'doc-9',
+      title: 'Untitled document',
+      tabs: [{
+        tabProperties: { title: 'Q3 Financial Model' },
+        documentTab: { body: { content: [para('numbers')] } },
+      }],
+    });
+
+    const result = await docsPatch.customHandlers!.get({ documentId: 'doc-9' }, ACCOUNT);
+
+    expect(result.text).not.toContain('Q3 Financial Model');
+    expect(result.refs.tabTitles).toEqual(['Q3 Financial Model']);
   });
 
   it('survives a tab with no title and no documentTab', async () => {

--- a/src/server/scratchpad/adapters/import-doc.ts
+++ b/src/server/scratchpad/adapters/import-doc.ts
@@ -90,6 +90,17 @@ async function importDocJson(
   documentId: string,
 ): Promise<HandlerResponse> {
   try {
+    // NO includeTabsContent here, deliberately — do not "fix" this to match
+    // docsPatch.get (#152) without reading #155 first.
+    //
+    // The flag moves content to `tabs[].documentTab.body` and takes `body` away. This
+    // buffer is LIVE-BOUND (#79): docs-sync translates mutations against paths like
+    // `$.body.content[0].paragraph.elements[0].textRun.content`, so setting the flag
+    // trades a multi-tab import for a scratchpad that can no longer write anything back.
+    //
+    // The cost of leaving it: a multi-tab document imports as its first tab only. That is
+    // a real bug, tracked in #155, and it needs a decision about tab-aware sync paths
+    // rather than a one-line change here.
     const doc = await call('docs', 'documents.get',
       { documentId }, { account: email }) as Record<string, unknown>;
 

--- a/src/server/scratchpad/handler.ts
+++ b/src/server/scratchpad/handler.ts
@@ -373,6 +373,10 @@ function applyMutation(
 
 /** Re-fetch the doc, replace the buffer, and update the binding's revisionId. */
 async function reloadDocsBuffer(id: string, binding: LiveBinding): Promise<void> {
+  // NO includeTabsContent — this must stay in step with the import that created the
+  // buffer (see importDocJson, and #155). The flag removes `body`, which is what
+  // docs-sync addresses. Change one of these two call sites and a scratchpad's buffer
+  // and its reload disagree about the shape of the document.
   const doc = await call('docs', 'documents.get', {
     documentId: binding.resourceId,
   }, { account: binding.account }) as Record<string, unknown>;

--- a/src/services/docs/patch.ts
+++ b/src/services/docs/patch.ts
@@ -55,9 +55,20 @@ function tidy(text: string): string {
 
 interface FlatTab {
   title: string;
-  text: string;
+  /**
+   * NULL means Google returned no `documentTab` for this tab, so we did not read it.
+   * That is NOT the same claim as "this tab is empty", and collapsing the two is how a
+   * document nobody could read renders as a document with nothing in it — the defect
+   * this whole file is a correction for, one level in.
+   */
+  text: string | null;
   /** 0 for a top-level tab, +1 per level of `childTabs` nesting. */
   depth: number;
+}
+
+/** Lines in a tab's text — counted one way, so every number here means the same thing. */
+function countLines(text: string | null): number {
+  return text ? text.split('\n').length : 0;
 }
 
 /**
@@ -69,6 +80,9 @@ interface FlatTab {
  * level down.
  *
  * Google populates none of this unless documents.get is asked for it — see `get`.
+ *
+ * Array order is Google's order, which is reading order; `tabProperties.index` carries
+ * the same thing and is not consulted.
  */
 function flattenTabs(tabs: unknown, depth = 0): FlatTab[] {
   if (!Array.isArray(tabs)) return [];
@@ -83,13 +97,31 @@ function flattenTabs(tabs: unknown, depth = 0): FlatTab[] {
 
     out.push({
       title: typeof props?.title === 'string' && props.title ? props.title : '(untitled tab)',
-      text: tidy(extractText(documentTab?.body)),
+      // No documentTab at all is a failed read, not an empty tab. Keep them distinct.
+      text: documentTab ? tidy(extractText(documentTab.body)) : null,
       depth,
     });
     // Nested tabs belong directly after their parent, not in a separate pass.
     out.push(...flattenTabs(t.childTabs, depth + 1));
   }
   return out;
+}
+
+/**
+ * Render one tab as a titled section.
+ *
+ * The heading level tracks nesting depth so a subtab reads as subordinate to its parent.
+ * Depth is clamped at `######` because markdown has no seventh level: tabs nested more
+ * than three deep flatten to the same visual level. That is deliberate and currently
+ * unreachable — the Docs UI allows a single level of subtabs — so the clamp is a
+ * guard against a shape Google's API permits and its editor does not produce.
+ */
+function renderTab({ title, text, depth }: FlatTab): string {
+  const heading = '#'.repeat(Math.min(3 + depth, 6));
+  const body = text === null
+    ? '_(no content returned for this tab — it was not read, which is not the same as empty)_'
+    : text || '_(this tab is empty)_';
+  return `${heading} ${title}\n\n${body}\n`;
 }
 
 export const docsPatch: ServicePatch = {
@@ -116,6 +148,10 @@ export const docsPatch: ServicePatch = {
      * not a preference — read `body` first and a tabbed document comes back EMPTY. The
      * `body` fallback covers only the flagless shape, which nothing here now requests.
      *
+     * Google's reference says `body` is "left as empty" rather than dropped; measurement
+     * says dropped. The code assumes neither: it treats an empty `tabs[0]` and an absent
+     * `body` the same way round, so both shapes read correctly.
+     *
      * Single-tab documents report one tab titled "Tab 1" — a default, not something a
      * user typed, so one tab renders with no tab scaffolding at all.
      */
@@ -127,32 +163,78 @@ export const docsPatch: ServicePatch = {
 
       const title = typeof doc.title === 'string' ? doc.title : '(untitled)';
       const tabs = flattenTabs(doc.tabs);
+      const multiTab = tabs.length > 1;
 
-      // One tab is the ordinary case and reads best with no tab scaffolding at all, so
-      // it renders exactly as a single-body document does.
-      const body = tabs.length > 1
-        ? tabs
-          .map(({ title: tabTitle, text: tabText, depth }) =>
-            `${'#'.repeat(Math.min(3 + depth, 6))} ${tabTitle}\n\n` +
-            (tabText || '_(this tab is empty)_') + '\n')
-          .join('\n')
-          .trimEnd()
-        : (tabs[0]?.text ?? tidy(extractText(doc.body)));
+      // One tab is the ordinary case and reads best with no tab scaffolding at all, so it
+      // renders exactly as a single-body document does. `||` not `??`: a single tab that
+      // reported NO content must still fall back to `body`, and '' is not nullish — with
+      // `??` a populated `body` was discarded and the document reported as empty.
+      const singleText = tabs.length === 1
+        ? (tabs[0].text || tidy(extractText(doc.body)))
+        : tidy(extractText(doc.body));
 
-      const characters = tabs.length > 1
-        ? tabs.reduce((sum, t) => sum + t.text.length, 0)
-        : body.length;
-      const lines = body ? body.split('\n').length : 0;
+      const body = multiTab
+        ? tabs.map(renderTab).join('\n').trimEnd()
+        : singleText;
+
+      // Both numbers describe DOCUMENT TEXT, never the scaffolding rendered around it.
+      // They used to disagree: characters summed the tabs while lines counted the
+      // rendered output, headings and placeholders included, so a document of four
+      // one-line tabs reported "71 characters, 15 line(s)" and a wholly unread one
+      // managed "0 characters, 11 line(s)".
+      const characters = multiTab
+        ? tabs.reduce((sum, t) => sum + (t.text?.length ?? 0), 0)
+        : singleText.length;
+      const lines = multiTab
+        ? tabs.reduce((sum, t) => sum + countLines(t.text), 0)
+        : countLines(singleText);
+
+      const nested = tabs.filter((t) => t.depth > 0).length;
+      const unread = tabs.filter((t) => t.text === null).length;
+
+      // Anything that makes this response narrower than the document says so HERE, in the
+      // response, rather than leaving the reader to infer it from a number.
+      const caveats: string[] = [];
+      if (tabs.length === 0) {
+        // Asked for tab content and got none. Measured live, every document returns at
+        // least one tab when the flag is set, so this is an anomaly and `body` may well be
+        // the first tab of several.
+        caveats.push('Google returned no tab data, so this may be the first tab only.');
+      }
+      if (unread > 0) {
+        caveats.push(`${unread} tab(s) returned no content and could not be read.`);
+      }
+      if (multiTab) {
+        // The read spans tabs; the writes do not. See #157.
+        caveats.push('`insertText` indices are relative to the FIRST tab, and `write` appends to it — tab-targeted writes are not available yet (#157).');
+      }
 
       return {
         text:
           `## ${title}\n\n` +
           `**Document ID:** ${documentId}\n` +
           `**Revision:** ${String(doc.revisionId ?? '—')}\n` +
-          (tabs.length > 1 ? `**Tabs:** ${tabs.length}\n` : '') +
-          `**Length:** ${characters} characters, ${lines} line(s)\n\n` +
+          // The count includes nested tabs, which the Docs tab strip does not show — so
+          // say which is which rather than hand back a number that contradicts the UI.
+          (multiTab
+            ? `**Tabs:** ${tabs.length}${nested ? ` (${tabs.length - nested} top-level, ${nested} nested)` : ''}\n`
+            : '') +
+          `**Length:** ${characters} characters, ${lines} line(s)\n` +
+          caveats.map((c) => `\n> ${c}\n`).join('') +
+          '\n' +
           (body ? `---\n\n${body}\n` : '_(the document is empty)_\n'),
-        refs: { documentId, title, characters, lines, tabs: tabs.length },
+        refs: {
+          documentId,
+          title,
+          characters,
+          lines,
+          tabs: tabs.length,
+          // Titles ride along even for a single tab, whose heading is suppressed: the
+          // title is usually Google's default "Tab 1", but when a user has renamed a
+          // one-tab document's tab, that name is content and withholding it is a choice.
+          tabTitles: tabs.map((t) => t.title),
+          ...(unread > 0 ? { unreadTabs: unread } : {}),
+        },
       };
     },
 

--- a/src/services/docs/patch.ts
+++ b/src/services/docs/patch.ts
@@ -48,29 +48,111 @@ function extractText(node: unknown): string {
   return out;
 }
 
+/** Collapse runs of blank lines; a Doc is full of them and they carry no meaning here. */
+function tidy(text: string): string {
+  return text.replace(/\n{3,}/g, '\n\n').trim();
+}
+
+interface FlatTab {
+  title: string;
+  text: string;
+  /** 0 for a top-level tab, +1 per level of `childTabs` nesting. */
+  depth: number;
+}
+
+/**
+ * Flatten a document's tabs, depth-first, into the order a reader sees them.
+ *
+ * Tabs are a TREE, not a list: each carries its own body at `documentTab.body` and may
+ * nest further tabs under `childTabs`. A walk that reads only the top level silently
+ * drops every nested tab, which is the same failure this function exists to fix, one
+ * level down.
+ *
+ * Google populates none of this unless documents.get is asked for it — see `get`.
+ */
+function flattenTabs(tabs: unknown, depth = 0): FlatTab[] {
+  if (!Array.isArray(tabs)) return [];
+
+  const out: FlatTab[] = [];
+  for (const tab of tabs) {
+    if (!tab || typeof tab !== 'object') continue;
+    const t = tab as Record<string, unknown>;
+
+    const props = t.tabProperties as { title?: unknown } | undefined;
+    const documentTab = t.documentTab as { body?: unknown } | undefined;
+
+    out.push({
+      title: typeof props?.title === 'string' && props.title ? props.title : '(untitled tab)',
+      text: tidy(extractText(documentTab?.body)),
+      depth,
+    });
+    // Nested tabs belong directly after their parent, not in a separate pass.
+    out.push(...flattenTabs(t.childTabs, depth + 1));
+  }
+  return out;
+}
+
 export const docsPatch: ServicePatch = {
   customHandlers: {
     /**
-     * Read a document: its metadata AND — the point of the operation — its text.
+     * Read a document: its metadata AND — the point of the operation — ALL of its text.
+     *
+     * `includeTabsContent` is not an enhancement, it is the difference between reading
+     * the document and reading part of it. Google's `body` field is legacy: without the
+     * flag it holds THE FIRST TAB ONLY, and the response carries no hint that other tabs
+     * exist. A doc holding one meeting transcript per tab returned 142 of its 780 lines
+     * and presented them as the whole file (issue #152).
+     *
+     * That is this codebase's recurring defect shape — a read that under-reports with no
+     * error, indistinguishable from a document that really is short. The same instinct
+     * as the rate-limit retry in google/client.ts: never let "I could not see all of it"
+     * render as "this is all there is".
+     *
+     * With the flag, content moves to `tabs[].documentTab.body` and `body` is GONE — not
+     * empty, absent from the response, along with `headers`, `lists`, `inlineObjects` and
+     * `namedStyles`. Measured live against three real documents: without the flag,
+     * `body` held 10,388 characters and `tabs` was absent; with it, `body` was absent and
+     * the three tabs held 10,388 + 3,832 + 698. So reading `tabs` first is load-bearing,
+     * not a preference — read `body` first and a tabbed document comes back EMPTY. The
+     * `body` fallback covers only the flagless shape, which nothing here now requests.
+     *
+     * Single-tab documents report one tab titled "Tab 1" — a default, not something a
+     * user typed, so one tab renders with no tab scaffolding at all.
      */
     get: async (params, account): Promise<HandlerResponse> => {
       const documentId = requireString(params, 'documentId');
 
       const doc = await call('docs', 'documents.get',
-        { documentId }, { account }) as Record<string, unknown>;
+        { documentId, includeTabsContent: true }, { account }) as Record<string, unknown>;
 
       const title = typeof doc.title === 'string' ? doc.title : '(untitled)';
-      const text = extractText(doc.body).replace(/\n{3,}/g, '\n\n').trim();
-      const lines = text ? text.split('\n').length : 0;
+      const tabs = flattenTabs(doc.tabs);
+
+      // One tab is the ordinary case and reads best with no tab scaffolding at all, so
+      // it renders exactly as a single-body document does.
+      const body = tabs.length > 1
+        ? tabs
+          .map(({ title: tabTitle, text: tabText, depth }) =>
+            `${'#'.repeat(Math.min(3 + depth, 6))} ${tabTitle}\n\n` +
+            (tabText || '_(this tab is empty)_') + '\n')
+          .join('\n')
+          .trimEnd()
+        : (tabs[0]?.text ?? tidy(extractText(doc.body)));
+
+      const characters = tabs.length > 1
+        ? tabs.reduce((sum, t) => sum + t.text.length, 0)
+        : body.length;
+      const lines = body ? body.split('\n').length : 0;
 
       return {
         text:
           `## ${title}\n\n` +
           `**Document ID:** ${documentId}\n` +
           `**Revision:** ${String(doc.revisionId ?? '—')}\n` +
-          `**Length:** ${text.length} characters, ${lines} line(s)\n\n` +
-          (text ? `---\n\n${text}\n` : '_(the document is empty)_\n'),
-        refs: { documentId, title, characters: text.length, lines },
+          (tabs.length > 1 ? `**Tabs:** ${tabs.length}\n` : '') +
+          `**Length:** ${characters} characters, ${lines} line(s)\n\n` +
+          (body ? `---\n\n${body}\n` : '_(the document is empty)_\n'),
+        refs: { documentId, title, characters, lines, tabs: tabs.length },
       };
     },
 


### PR DESCRIPTION
Closes #152.

`manage_docs get` returned the first tab of a multi-tab document and presented it
as the whole file. No error, no hint that other tabs existed — @Laralike's
document was 780 lines and came back as 142. Their diagnosis was exactly right:
Google's `body` is a legacy field holding only the first tab unless
`documents.get` is called with `includeTabsContent=true`, and we never sent it.

This is the recurring defect shape in this codebase: a read that under-reports
with no error, indistinguishable from a document that really is short. Same
family as the rate-limited inbox that rendered as rows with no sender, and as
`get` itself returning metadata and no text.

## Measured live, and two assumptions corrected

Probed three real documents before trusting the mock. Both corrections matter:

**`body` is not empty with the flag — it is absent.** Along with `headers`,
`lists`, `inlineObjects` and `namedStyles`. Content moves wholesale to
`tabs[].documentTab.body`:

| | `body` chars | `tabs` |
|---|---|---|
| `includeTabsContent` unset | 10,388 | absent |
| `includeTabsContent=true` | *(field absent)* | 10,388 + 3,832 + 698 |

So reading `tabs` **first** is load-bearing, not a preference — read `body` first
and every tabbed document renders as empty. `body` survives only as the fallback
for the flagless shape, which nothing here now requests.

**Tabs are a tree.** `childTabs` nests arbitrarily, and a walk that reads only the
top level drops nested tabs — the same bug one level down. `flattenTabs` recurses
depth-first and renders a child one heading level below its parent.

## Output

Single-tab documents report one tab titled `"Tab 1"` — a Google default, not
something a user typed — so one tab renders with **no tab scaffolding at all** and
ordinary documents look exactly as they did. Multi-tab documents gain a
`**Tabs:** N` line and a heading per tab, so stacked transcripts do not read as
one continuous document and the response states the scope it covered.

Verified end-to-end against the real 3-tab document: **14,884 characters where it
previously returned 10,213 — 31% of it was missing.** The single-tab document
renders byte-identically to before, `tabs: 1` in refs.

## Deliberately not fixed here

`importDocJson` (`src/server/scratchpad/adapters/import-doc.ts:93`) makes the same
call and has the same blind spot, but it is live-bound for round-trip editing
(#79) and `docs-sync` addresses content by `$.body.content[…]` paths. Since the
flag *removes* `body`, setting it there would trade missing tabs for broken
write-back. Filed as #155 with the three options rather than fixed blind.

## Checks

`make check`: 717 tests across 41 files (+12), type-check, lint, build,
`smoke-start`, `smoke-orphan` — all green.
