### PR TITLE
fix(release): reconcile the GitHub release CI already made, and stop globbing the bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,7 +225,7 @@ publish-all: check-release-tag mcpb ## Publish to npm, MCP Registry, GitHub Rele
 	@echo "Publishing v$(VERSION) to all channels."
 	@echo "  1. npm (2FA in the browser — passkey/security key)"
 	@echo "  2. MCP Registry (requires GitHub auth)"
-	@echo "  3. GitHub Release (with the .mcpb bundle)"
+	@echo "  3. GitHub Release (reconciles the one CI made on tag push)"
 	@echo ""
 	@read -p "Continue? [y/N] " confirm && [ "$$confirm" = "y" ] || (echo "Aborted." && exit 1)
 	@echo ""
@@ -247,8 +247,35 @@ publish-all: check-release-tag mcpb ## Publish to npm, MCP Registry, GitHub Rele
 	mcp-publisher publish server.json
 	@echo ""
 	@echo "── GitHub Release ──"
-	@read -p "Release notes (one line, or empty for default): " notes; \
-	if [ -z "$$notes" ]; then notes="Release v$(VERSION)"; fi; \
-	gh release create "v$(VERSION)" --title "v$(VERSION)" --notes "$$notes" google-workspace-mcp-*.mcpb
+	@# RECONCILE, not create. The tag push already triggered release-mcpb.yml, which
+	@# creates the release with --generate-notes and uploads the bundle — so a bare
+	@# `gh release create` here fails "already exists" on EVERY release, and a red exit
+	@# at the end of a publish trains you to ignore the exit code of a publish. Run this
+	@# before CI finishes and the release is genuinely absent, so handle both.
+	@#
+	@# The bundle is named EXACTLY, never globbed. `google-workspace-mcp-*.mcpb` matched
+	@# the per-platform bundles of the mcpb-all era, which this repo stopped producing but
+	@# which still sit in working trees — and it does NOT match today's single output. On
+	@# v4.2.0 that glob resolved to two THREE-POINT-OH bundles from a year earlier while
+	@# omitting the one just built. Only the duplicate-release error stopped them shipping.
+	@bundle=google-workspace-mcp.mcpb; \
+	[ -f "$$bundle" ] || { echo "no $$bundle — run 'make mcpb'"; exit 1; }; \
+	packed=$$(unzip -p "$$bundle" manifest.json 2>/dev/null | sed -n 's/.*"version"[^"]*"\([^"]*\)".*/\1/p' | head -1); \
+	if [ -z "$$packed" ]; then \
+	  echo "warn: cannot read a version out of $$bundle (no unzip?) — staleness unchecked"; \
+	elif [ "$$packed" != "$(VERSION)" ]; then \
+	  echo "$$bundle holds v$$packed, but this is the v$(VERSION) publish."; \
+	  echo "  Attaching it would ship the wrong code under this tag. Rebuild: make mcpb"; exit 1; \
+	fi; \
+	read -p "Release notes (one line, or empty to keep the notes CI generated): " notes; \
+	if gh release view "v$(VERSION)" >/dev/null 2>&1; then \
+	  echo "gh: v$(VERSION) already exists (CI creates it on tag push) — updating in place"; \
+	  if [ -n "$$notes" ]; then gh release edit "v$(VERSION)" --notes "$$notes"; fi; \
+	  gh release upload "v$(VERSION)" "$$bundle" --clobber; \
+	elif [ -n "$$notes" ]; then \
+	  gh release create "v$(VERSION)" --title "v$(VERSION)" --notes "$$notes" "$$bundle"; \
+	else \
+	  gh release create "v$(VERSION)" --title "v$(VERSION)" --generate-notes "$$bundle"; \
+	fi
 	@echo ""
 	@echo "v$(VERSION) published to all channels."


### PR DESCRIPTION
## Description

Two defects in `make publish-all`, found while publishing v4.2.0. The first was masking the second.

**1. `gh release create` collides with CI, every time.** The tag push triggers `.github/workflows/release-mcpb.yml`, which creates the release with `--generate-notes` and uploads the bundle. `publish-all` then ran its own `gh release create` for the same tag and failed `already exists` — *after* npm and the MCP Registry had published. Every release ended in `make: *** Error 1` despite having fully succeeded, which teaches you to ignore the exit code of a publish.

**2. The bundle was globbed, and the glob was wrong.** `google-workspace-mcp-*.mcpb` dates from the `mcpb-all` era of per-platform bundles. This repo builds one bundle now — `google-workspace-mcp.mcpb` — which that pattern does **not** match. What it did match, in this working tree, were two bundles built 2026-07-12 carrying **version 3.0.0**:

```
google-workspace-mcp-darwin-arm64.mcpb   2026-07-12   "version": "3.0.0"
google-workspace-mcp-linux-x64.mcpb      2026-07-12   "version": "3.0.0"
google-workspace-mcp.mcpb                2026-08-16   "version": "4.2.0"   <- the one just built
```

Had defect 1 not aborted the step, v4.2.0 would have shipped with two v3.0.0 bundles attached and the real one missing. Anyone installing from the release asset would have gotten 3.0.0.

## Changes

- **Reconcile, don't create.** Update the release in place when it exists; create it when it doesn't, since running ahead of CI is the opposite race and equally real.
- **Name the bundle exactly.** No glob, so no stale artifact can be picked up again.
- **Refuse on a stale bundle.** Read the version out of the packed `manifest.json` and abort if it isn't the version being released. This check alone would have caught defect 2. Degrades to a warning if `unzip` is unavailable rather than blocking the publish.
- **Empty notes keep CI's generated notes** instead of overwriting them with a `Release vX.Y.Z` placeholder.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing Performed

`make -n publish-all` parses. Both branches replayed against the live v4.2.0 release with the `gh` mutations stubbed:

| Scenario | Result |
|---|---|
| bundle 4.2.0, publishing 4.2.0 | version matches, proceed |
| bundle 4.2.0, publishing 4.3.0 | **blocked** — "Attaching it would ship the wrong code under this tag" |
| release exists, notes empty | upload `--clobber`, keep CI notes |

Not exercised end to end: the real publish path needs npm 2FA and a TTY. The next release is the first full run.

The two stale 3.0.0 bundles are removed from the working tree (they are gitignored, so this affects nothing in the repo).

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Security Considerations

- [x] No sensitive information is exposed

Narrows what a publish can attach: an exact filename plus a version assertion, in place of a glob that could match any `.mcpb` left in the tree.