### PR TITLE
fix(manifest): say each param once — and make the claims true

### DIFF
--- a/src/__tests__/factory/calendar-patch.test.ts
+++ b/src/__tests__/factory/calendar-patch.test.ts
@@ -558,6 +558,91 @@ describe('calendarPatch', () => {
       expect(conferenceData.createRequest.conferenceSolutionKey.type).toBe('hangoutsMeet');
     });
 
+    it('removes an existing Meet link when meet: false', async () => {
+      // Measured against live Google, because no amount of reading the code could settle
+      // it: events.patch with `conferenceData: null` returns 200 and leaves the link in
+      // place, and so does `{}`. Only a full events.update omitting conferenceData
+      // removes it. The manifest used to tell the model Google forbids removal outright.
+      mockCall
+        .mockResolvedValueOnce({ id: 'evt-1', summary: 'Standup', location: 'Room A', hangoutLink: 'https://meet.google.com/abc' })
+        .mockResolvedValueOnce({ id: 'evt-1', summary: 'Standup', location: 'Room A' });
+
+      await calendarPatch.customHandlers!.update({ eventId: 'evt-1', meet: false }, 'user@test.com');
+
+      // Read first, then a full replace — not a patch.
+      expect(mockCall.mock.calls[0][1]).toBe('events.get');
+      expect(mockCall.mock.calls[1][1]).toBe('events.update');
+      const params = mockCall.mock.calls[1][2];
+      expect(params.conferenceData).toBeUndefined();
+      const request = await requestFor('calendar', 'events.update', params);
+      // Without the version the omission is ignored rather than read as a removal.
+      expect(queryOf(request).conferenceDataVersion).toBe('1');
+    });
+
+    it('preserves the rest of the event when removing a Meet link', async () => {
+      // events.update REPLACES the resource. A version of this that skipped the read
+      // wiped the probe event's location during development — silently, with a 200.
+      mockCall
+        .mockResolvedValueOnce({
+          id: 'evt-1', summary: 'Standup', location: 'Room A', description: 'notes',
+          attendees: [{ email: 'a@test.com' }], hangoutLink: 'https://meet.google.com/abc',
+        })
+        .mockResolvedValueOnce({ id: 'evt-1' });
+
+      await calendarPatch.customHandlers!.update({ eventId: 'evt-1', meet: false }, 'user@test.com');
+
+      const params = mockCall.mock.calls[1][2];
+      expect(params.summary).toBe('Standup');
+      expect(params.location).toBe('Room A');
+      expect(params.description).toBe('notes');
+      expect(params.attendees).toEqual([{ email: 'a@test.com' }]);
+    });
+
+    it('strips server-owned fields rather than echoing them back', async () => {
+      mockCall
+        .mockResolvedValueOnce({
+          id: 'evt-1', etag: '"123"', kind: 'calendar#event', htmlLink: 'https://x',
+          created: '2026-01-01', updated: '2026-01-02', iCalUID: 'uid@google.com',
+          sequence: 3, creator: { email: 'c@test.com' }, organizer: { email: 'o@test.com' },
+          hangoutLink: 'https://meet.google.com/abc', conferenceData: { conferenceId: 'abc' },
+          summary: 'Standup',
+        })
+        .mockResolvedValueOnce({ id: 'evt-1' });
+
+      await calendarPatch.customHandlers!.update({ eventId: 'evt-1', meet: false }, 'user@test.com');
+
+      const params = mockCall.mock.calls[1][2];
+      for (const field of ['etag', 'kind', 'htmlLink', 'created', 'updated', 'iCalUID',
+        'sequence', 'creator', 'organizer', 'hangoutLink', 'conferenceData']) {
+        expect(params[field]).toBeUndefined();
+      }
+      expect(params.summary).toBe('Standup');
+    });
+
+    it('applies other changes in the same call that removes the link', async () => {
+      mockCall
+        .mockResolvedValueOnce({ id: 'evt-1', summary: 'Old', location: 'Room A', hangoutLink: 'https://meet.google.com/abc' })
+        .mockResolvedValueOnce({ id: 'evt-1' });
+
+      await calendarPatch.customHandlers!.update(
+        { eventId: 'evt-1', meet: false, summary: 'New' }, 'user@test.com');
+
+      const params = mockCall.mock.calls[1][2];
+      expect(params.summary).toBe('New');      // caller's change wins over the read
+      expect(params.location).toBe('Room A');  // untouched field survives
+    });
+
+    it('treats meet: false as a change on its own', async () => {
+      // It used to fall through to the "nothing to change" guard, so the one request
+      // that could remove a link was rejected as empty.
+      mockCall
+        .mockResolvedValueOnce({ id: 'evt-1', summary: 'Standup' })
+        .mockResolvedValueOnce({ id: 'evt-1' });
+
+      await expect(calendarPatch.customHandlers!.update(
+        { eventId: 'evt-1', meet: false }, 'user@test.com')).resolves.toBeDefined();
+    });
+
     it('honors explicit calendarId', async () => {
       mockCall.mockResolvedValue({ id: 'evt-1' });
       await calendarPatch.customHandlers!.update(

--- a/src/__tests__/factory/generator.test.ts
+++ b/src/__tests__/factory/generator.test.ts
@@ -47,8 +47,9 @@ describe('loadManifest', () => {
 });
 
 /**
- * Collisions that ALREADY exist, frozen by fingerprint so new ones fail. Not endorsed —
- * see the issue named in known-param-collisions.txt.
+ * Escape hatch for a collision that cannot be harmonized. Empty since #161, which makes
+ * the test below a hard gate rather than a ratchet. Adding a line is a deliberate act;
+ * see the file's own header before you do.
  */
 const KNOWN_COLLISIONS = new Set(readFileSync(
   new URL('./known-param-collisions.txt', import.meta.url), 'utf-8',
@@ -72,10 +73,14 @@ describe('generateSchema — one declaration per param name', () => {
     // reached the schema. `type` and `enum` are dropped by the same line, so they are
     // checked here too.
     //
-    // The allowlist freezes each collision by FINGERPRINT of its losing text, not by
-    // param name: a name-keyed entry would permit a future third, materially different
-    // description for that same param forever. Change either side of a frozen pair and
-    // this fails, which is the point.
+    // The allowlist is empty (#161), so any collision fails here. It keys on a
+    // FINGERPRINT of the losing text rather than the param name, because a name-keyed
+    // entry would permit a future third, materially different description for that same
+    // param forever.
+    //
+    // The fix for a failure is to harmonize the description — ONE text naming the
+    // operations where meaning actually diverges, as every manifest now does — not to
+    // freeze the collision.
     const manifest = loadManifest();
     const conflicts: string[] = [];
 

--- a/src/__tests__/factory/known-param-collisions.txt
+++ b/src/__tests__/factory/known-param-collisions.txt
@@ -1,88 +1,15 @@
-# Frozen param-declaration collisions — generateSchema keeps only the FIRST declaration
-# of a param name across a service's operations and drops later ones silently
-# (src/factory/generator.ts). Each line fingerprints one specific losing declaration, so
-# changing either side of a frozen pair makes the test fail rather than pass quietly.
+# Frozen param-declaration collisions — DELIBERATELY EMPTY.
 #
-# These are NOT endorsed. Several drop something the model needs — calendar.attendees
-# loses update's warning that it REPLACES the entire attendee list; calendar.calendarId
-# loses freebusy's comma-separated form, a different TYPE of value under one name.
-# Tracked in #161. Fix them there; do not widen this list to make a new one pass.
+# generateSchema keeps only the FIRST declaration of a param name across a service's
+# operations and drops later ones silently (src/factory/generator.ts). Every param in
+# every manifest now carries one description covering all of its operations, so there is
+# nothing to freeze and the test in generator.test.ts is a hard gate.
 #
-# To regenerate after a legitimate fix, run the suite: failures print
-# "<fingerprint>  <message>" ready to paste.
-
-1f7ca80c5010  # calendar.calendarId.description (list vs agenda)
-14557f2ab640  # calendar.calendarId.description (list vs get)
-d17595105c58  # calendar.calendarId.description (list vs create)
-f98f7c320f9a  # calendar.calendarId.description (list vs quickAdd)
-fd732c45d54a  # calendar.calendarId.description (list vs update)
-da7c95935297  # calendar.eventId.description (get vs update)
-1708d1e2004e  # calendar.summary.description (create vs update)
-2176212cd700  # calendar.start.description (create vs update)
-866f624b587b  # calendar.end.description (create vs update)
-04a49ada8e2c  # calendar.description.description (create vs update)
-caeefdfb3eeb  # calendar.location.description (create vs update)
-39ff1ff58934  # calendar.attendees.description (create vs update)
-8508f227bcb8  # calendar.meet.description (create vs update)
-7fae86120ece  # calendar.calendarId.description (list vs delete)
-b8d797c22f61  # calendar.eventId.description (get vs delete)
-c613dcf2aab9  # calendar.timeMin.description (list vs freebusy)
-afb27c948d0a  # calendar.attendees.description (create vs freebusy)
-f27731c98472  # calendar.calendarId.description (list vs freebusy)
-1eb0ca4a75bf  # drive.fileId.description (get vs viewImage)
-b52de209766a  # drive.fileId.description (get vs download)
-0f7c47cae45d  # drive.fileId.description (get vs copy)
-0d39384c5a45  # drive.name.description (upload vs copy)
-0c9502761e90  # drive.parentFolderId.description (upload vs copy)
-055c02055f68  # drive.fileId.description (get vs update)
-d61f83488076  # drive.name.description (upload vs update)
-98e4e1adbf79  # drive.fileId.description (get vs delete)
-854474968735  # drive.fileId.description (get vs export)
-1b7856210b87  # drive.outputPath.description (download vs export)
-ae6a8c52f216  # drive.fileId.description (get vs share)
-a6e51b869fa3  # drive.commentId.description (getComment vs replyToComment)
-a38bf41fa9d2  # drive.content.description (addComment vs replyToComment)
-d8c6dcaff51e  # gmail.messageId.description (read vs reply)
-37c2d249504c  # gmail.body.description (send vs reply)
-cb518ee4eb42  # gmail.messageId.description (read vs replyAll)
-ed0f0d731e6f  # gmail.body.description (send vs replyAll)
-d95348ec4ab6  # gmail.cc.description (send vs replyAll)
-f7234910cf72  # gmail.messageId.description (read vs forward)
-3a5376490536  # gmail.body.description (send vs forward)
-a097425d0652  # gmail.messageId.description (read vs trash)
-4ede34ac28cf  # gmail.messageId.description (read vs untrash)
-129f0780b4c9  # gmail.messageId.description (read vs getAttachment)
-b3f8da626bbb  # gmail.messageId.description (read vs viewAttachment)
-2e2dac212b2d  # gmail.filename.description (getAttachment vs viewAttachment)
-32dd69ff4c9a  # gmail.messageId.description (read vs modify)
-a505e2f90cf2  # gmail.query.description (search vs threads)
-9499aa0e0932  # gmail.maxResults.description (search vs threads)
-85a362a1ac5c  # meet.conferenceId.description (getConference vs listParticipants)
-69cb338b461d  # meet.filter.description (listConferences vs listParticipants)
-4ef54ea23591  # meet.maxResults.description (listConferences vs listParticipants)
-cadc2dcf2537  # meet.conferenceId.description (getConference vs listTranscripts)
-bf0e93246cc2  # meet.transcriptName.description (getTranscript vs listTranscriptEntries)
-f6c899fdb645  # meet.maxResults.description (listConferences vs listTranscriptEntries)
-a209b54cc168  # meet.conferenceId.description (getConference vs listRecordings)
-a72abdedad56  # meet.conferenceId.description (getConference vs listSmartNotes)
-714f7d17fdff  # sheets.range.description (read vs append)
-c5f584c19a84  # sheets.range.description (read vs getValues)
-864e7b275ef4  # sheets.range.description (read vs updateValues)
-0641918de37f  # sheets.jsonValues.description (append vs updateValues)
-45909276e3d2  # sheets.range.description (read vs clearValues)
-732d96d54453  # sheets.title.description (create vs addSheet)
-b973b8ca7391  # sheets.title.description (create vs renameSheet)
-3d385ac6b92a  # sheets.sheetId.description (renameSheet vs deleteSheet)
-3393d10e4aa7  # sheets.sheetId.description (renameSheet vs duplicateSheet)
-cf56088f4b0c  # sheets.title.description (create vs duplicateSheet)
-173bc2197a05  # sheets.index.description (addSheet vs duplicateSheet)
-05d40faaa52b  # sheets.title.description (create vs renameSpreadsheet)
-573d30f9b996  # sheets.spreadsheetId.description (get vs copySheetTo)
-a63abf716700  # sheets.sheetId.description (renameSheet vs copySheetTo)
-86aa45ee323b  # tasks.taskListId.description (getTaskList vs deleteTaskList)
-8ccd7ebb2903  # tasks.taskListId.description (getTaskList vs list)
-2ad8360857ee  # tasks.title.description (createTaskList vs create)
-69f20484a57f  # tasks.title.description (createTaskList vs update)
-0277212e44df  # tasks.notes.description (create vs update)
-e95408a4cdfd  # tasks.due.description (create vs update)
-773c2abcf32c  # tasks.taskId.description (get vs delete)
+# The 75 entries that used to sit here were resolved in #161. Several were load-bearing:
+# calendar.attendees never told the model that `update` REPLACES the whole attendee list,
+# and calendar.calendarId hid that `freebusy` takes a comma-separated list rather than a
+# single id.
+#
+# If a collision ever appears again, the honest fix is to harmonize the description — one
+# text naming the operations where meaning diverges — not to add a line here. This file
+# exists so that adding one is a visible, deliberate act rather than a silent default.

--- a/src/factory/manifest/calendar.yaml
+++ b/src/factory/manifest/calendar.yaml
@@ -13,7 +13,7 @@ operations:
     params:
       calendarId:
         type: string
-        description: "Calendar ID (default: 'primary'). Use the `calendars` operation to list available IDs; required for events on shared calendars. On `freebusy`, a comma-separated list of calendar IDs to check IN ADDITION to your own. On `agenda`, a calendar name or ID to filter to."
+        description: "Calendar ID. Use the `calendars` operation to list available IDs; required for events on shared calendars. Defaults to 'primary' on the event operations (`list`, `get`, `create`, `quickAdd`, `update`, `delete`). On `agenda`, a calendar name or ID to filter to — OMIT it to span all calendars, and do not pass 'primary', which is an API alias rather than an id agenda matches on. On `freebusy`, a comma-separated list of calendar IDs to check IN ADDITION to your own."
       timeMin:
         type: string
         description: "Start of range (ISO 8601). On `list`, defaults to today."
@@ -40,7 +40,7 @@ operations:
     params:
       calendarId:
         type: string
-        description: "Calendar ID (default: 'primary'). Use the `calendars` operation to list available IDs; required for events on shared calendars. On `freebusy`, a comma-separated list of calendar IDs to check IN ADDITION to your own. On `agenda`, a calendar name or ID to filter to."
+        description: "Calendar ID. Use the `calendars` operation to list available IDs; required for events on shared calendars. Defaults to 'primary' on the event operations (`list`, `get`, `create`, `quickAdd`, `update`, `delete`). On `agenda`, a calendar name or ID to filter to — OMIT it to span all calendars, and do not pass 'primary', which is an API alias rather than an id agenda matches on. On `freebusy`, a comma-separated list of calendar IDs to check IN ADDITION to your own."
       days:
         type: number
         description: "Number of days ahead to show (default: today only)"
@@ -58,7 +58,7 @@ operations:
     params:
       calendarId:
         type: string
-        description: "Calendar ID (default: 'primary'). Use the `calendars` operation to list available IDs; required for events on shared calendars. On `freebusy`, a comma-separated list of calendar IDs to check IN ADDITION to your own. On `agenda`, a calendar name or ID to filter to."
+        description: "Calendar ID. Use the `calendars` operation to list available IDs; required for events on shared calendars. Defaults to 'primary' on the event operations (`list`, `get`, `create`, `quickAdd`, `update`, `delete`). On `agenda`, a calendar name or ID to filter to — OMIT it to span all calendars, and do not pass 'primary', which is an API alias rather than an id agenda matches on. On `freebusy`, a comma-separated list of calendar IDs to check IN ADDITION to your own."
       eventId:
         type: string
         description: "Event ID"
@@ -74,7 +74,7 @@ operations:
     params:
       calendarId:
         type: string
-        description: "Calendar ID (default: 'primary'). Use the `calendars` operation to list available IDs; required for events on shared calendars. On `freebusy`, a comma-separated list of calendar IDs to check IN ADDITION to your own. On `agenda`, a calendar name or ID to filter to."
+        description: "Calendar ID. Use the `calendars` operation to list available IDs; required for events on shared calendars. Defaults to 'primary' on the event operations (`list`, `get`, `create`, `quickAdd`, `update`, `delete`). On `agenda`, a calendar name or ID to filter to — OMIT it to span all calendars, and do not pass 'primary', which is an API alias rather than an id agenda matches on. On `freebusy`, a comma-separated list of calendar IDs to check IN ADDITION to your own."
       summary:
         type: string
         description: "Event title"
@@ -95,10 +95,10 @@ operations:
         description: "Event location"
       attendees:
         type: string
-        description: "Comma-separated email addresses. On `update` this REPLACES the entire attendee list (Google's events.patch overwrites arrays) — pass an empty string to clear all attendees. On `freebusy`, the addresses whose availability to check."
+        description: "Comma-separated email addresses. On `update`, whatever you pass REPLACES the existing list — addresses you leave out are removed, and an empty string clears everyone. OMIT the parameter to leave the attendee list untouched while changing other fields. On `freebusy`, the addresses whose availability to check."
       meet:
         type: boolean
-        description: "Add a Google Meet video conference link to the event. Google does NOT allow removing an existing link via `update` — omit it or set false to leave the link untouched."
+        description: "Add a Google Meet video conference link. On `update`, true adds a link and false REMOVES an existing one; omit it to leave the link as it is."
 
   quickAdd:
     type: action
@@ -107,7 +107,7 @@ operations:
     params:
       calendarId:
         type: string
-        description: "Calendar ID (default: 'primary'). Use the `calendars` operation to list available IDs; required for events on shared calendars. On `freebusy`, a comma-separated list of calendar IDs to check IN ADDITION to your own. On `agenda`, a calendar name or ID to filter to."
+        description: "Calendar ID. Use the `calendars` operation to list available IDs; required for events on shared calendars. Defaults to 'primary' on the event operations (`list`, `get`, `create`, `quickAdd`, `update`, `delete`). On `agenda`, a calendar name or ID to filter to — OMIT it to span all calendars, and do not pass 'primary', which is an API alias rather than an id agenda matches on. On `freebusy`, a comma-separated list of calendar IDs to check IN ADDITION to your own."
       text:
         type: string
         description: "Natural language event description"
@@ -122,7 +122,7 @@ operations:
     params:
       calendarId:
         type: string
-        description: "Calendar ID (default: 'primary'). Use the `calendars` operation to list available IDs; required for events on shared calendars. On `freebusy`, a comma-separated list of calendar IDs to check IN ADDITION to your own. On `agenda`, a calendar name or ID to filter to."
+        description: "Calendar ID. Use the `calendars` operation to list available IDs; required for events on shared calendars. Defaults to 'primary' on the event operations (`list`, `get`, `create`, `quickAdd`, `update`, `delete`). On `agenda`, a calendar name or ID to filter to — OMIT it to span all calendars, and do not pass 'primary', which is an API alias rather than an id agenda matches on. On `freebusy`, a comma-separated list of calendar IDs to check IN ADDITION to your own."
       eventId:
         type: string
         description: "Event ID"
@@ -144,10 +144,10 @@ operations:
         description: "Event location"
       attendees:
         type: string
-        description: "Comma-separated email addresses. On `update` this REPLACES the entire attendee list (Google's events.patch overwrites arrays) — pass an empty string to clear all attendees. On `freebusy`, the addresses whose availability to check."
+        description: "Comma-separated email addresses. On `update`, whatever you pass REPLACES the existing list — addresses you leave out are removed, and an empty string clears everyone. OMIT the parameter to leave the attendee list untouched while changing other fields. On `freebusy`, the addresses whose availability to check."
       meet:
         type: boolean
-        description: "Add a Google Meet video conference link to the event. Google does NOT allow removing an existing link via `update` — omit it or set false to leave the link untouched."
+        description: "Add a Google Meet video conference link. On `update`, true adds a link and false REMOVES an existing one; omit it to leave the link as it is."
     defaults:
       calendarId: primary
 
@@ -158,7 +158,7 @@ operations:
     params:
       calendarId:
         type: string
-        description: "Calendar ID (default: 'primary'). Use the `calendars` operation to list available IDs; required for events on shared calendars. On `freebusy`, a comma-separated list of calendar IDs to check IN ADDITION to your own. On `agenda`, a calendar name or ID to filter to."
+        description: "Calendar ID. Use the `calendars` operation to list available IDs; required for events on shared calendars. Defaults to 'primary' on the event operations (`list`, `get`, `create`, `quickAdd`, `update`, `delete`). On `agenda`, a calendar name or ID to filter to — OMIT it to span all calendars, and do not pass 'primary', which is an API alias rather than an id agenda matches on. On `freebusy`, a comma-separated list of calendar IDs to check IN ADDITION to your own."
       eventId:
         type: string
         description: "Event ID"
@@ -188,7 +188,7 @@ operations:
         required: true
       attendees:
         type: string
-        description: "Comma-separated email addresses. On `update` this REPLACES the entire attendee list (Google's events.patch overwrites arrays) — pass an empty string to clear all attendees. On `freebusy`, the addresses whose availability to check."
+        description: "Comma-separated email addresses. On `update`, whatever you pass REPLACES the existing list — addresses you leave out are removed, and an empty string clears everyone. OMIT the parameter to leave the attendee list untouched while changing other fields. On `freebusy`, the addresses whose availability to check."
       calendarId:
         type: string
-        description: "Calendar ID (default: 'primary'). Use the `calendars` operation to list available IDs; required for events on shared calendars. On `freebusy`, a comma-separated list of calendar IDs to check IN ADDITION to your own. On `agenda`, a calendar name or ID to filter to."
+        description: "Calendar ID. Use the `calendars` operation to list available IDs; required for events on shared calendars. Defaults to 'primary' on the event operations (`list`, `get`, `create`, `quickAdd`, `update`, `delete`). On `agenda`, a calendar name or ID to filter to — OMIT it to span all calendars, and do not pass 'primary', which is an API alias rather than an id agenda matches on. On `freebusy`, a comma-separated list of calendar IDs to check IN ADDITION to your own."

--- a/src/factory/manifest/calendar.yaml
+++ b/src/factory/manifest/calendar.yaml
@@ -13,10 +13,10 @@ operations:
     params:
       calendarId:
         type: string
-        description: "Calendar ID to query (default: 'primary'). Use 'calendars' operation to list available IDs."
+        description: "Calendar ID (default: 'primary'). Use the `calendars` operation to list available IDs; required for events on shared calendars. On `freebusy`, a comma-separated list of calendar IDs to check IN ADDITION to your own. On `agenda`, a calendar name or ID to filter to."
       timeMin:
         type: string
-        description: "Start of range (ISO 8601) — defaults to today"
+        description: "Start of range (ISO 8601). On `list`, defaults to today."
       timeMax:
         type: string
         description: "End of range (ISO 8601)"
@@ -40,7 +40,7 @@ operations:
     params:
       calendarId:
         type: string
-        description: "Filter to a specific calendar name or ID"
+        description: "Calendar ID (default: 'primary'). Use the `calendars` operation to list available IDs; required for events on shared calendars. On `freebusy`, a comma-separated list of calendar IDs to check IN ADDITION to your own. On `agenda`, a calendar name or ID to filter to."
       days:
         type: number
         description: "Number of days ahead to show (default: today only)"
@@ -58,7 +58,7 @@ operations:
     params:
       calendarId:
         type: string
-        description: "Calendar ID (default: 'primary'). Required for events on shared calendars."
+        description: "Calendar ID (default: 'primary'). Use the `calendars` operation to list available IDs; required for events on shared calendars. On `freebusy`, a comma-separated list of calendar IDs to check IN ADDITION to your own. On `agenda`, a calendar name or ID to filter to."
       eventId:
         type: string
         description: "Event ID"
@@ -74,7 +74,7 @@ operations:
     params:
       calendarId:
         type: string
-        description: "Calendar ID (default: 'primary')"
+        description: "Calendar ID (default: 'primary'). Use the `calendars` operation to list available IDs; required for events on shared calendars. On `freebusy`, a comma-separated list of calendar IDs to check IN ADDITION to your own. On `agenda`, a calendar name or ID to filter to."
       summary:
         type: string
         description: "Event title"
@@ -95,10 +95,10 @@ operations:
         description: "Event location"
       attendees:
         type: string
-        description: "Comma-separated attendee emails"
+        description: "Comma-separated email addresses. On `update` this REPLACES the entire attendee list (Google's events.patch overwrites arrays) — pass an empty string to clear all attendees. On `freebusy`, the addresses whose availability to check."
       meet:
         type: boolean
-        description: "Add a Google Meet video conference link to the event"
+        description: "Add a Google Meet video conference link to the event. Google does NOT allow removing an existing link via `update` — omit it or set false to leave the link untouched."
 
   quickAdd:
     type: action
@@ -107,7 +107,7 @@ operations:
     params:
       calendarId:
         type: string
-        description: "Calendar ID (default: 'primary')"
+        description: "Calendar ID (default: 'primary'). Use the `calendars` operation to list available IDs; required for events on shared calendars. On `freebusy`, a comma-separated list of calendar IDs to check IN ADDITION to your own. On `agenda`, a calendar name or ID to filter to."
       text:
         type: string
         description: "Natural language event description"
@@ -122,32 +122,32 @@ operations:
     params:
       calendarId:
         type: string
-        description: "Calendar ID (default: 'primary')"
+        description: "Calendar ID (default: 'primary'). Use the `calendars` operation to list available IDs; required for events on shared calendars. On `freebusy`, a comma-separated list of calendar IDs to check IN ADDITION to your own. On `agenda`, a calendar name or ID to filter to."
       eventId:
         type: string
-        description: "Event ID to update"
+        description: "Event ID"
         required: true
       summary:
         type: string
-        description: "Updated event title"
+        description: "Event title"
       start:
         type: string
-        description: "Updated start time (ISO 8601)"
+        description: "Start time (ISO 8601)"
       end:
         type: string
-        description: "Updated end time (ISO 8601)"
+        description: "End time (ISO 8601)"
       description:
         type: string
-        description: "Updated description"
+        description: "Event description or notes"
       location:
         type: string
-        description: "Updated location"
+        description: "Event location"
       attendees:
         type: string
-        description: "Comma-separated attendee emails. REPLACES the existing attendee list entirely (Google events.patch overwrites arrays). Pass an empty string to clear all attendees."
+        description: "Comma-separated email addresses. On `update` this REPLACES the entire attendee list (Google's events.patch overwrites arrays) — pass an empty string to clear all attendees. On `freebusy`, the addresses whose availability to check."
       meet:
         type: boolean
-        description: "Add a Google Meet video conference link. Note: Google Calendar does not allow removing an existing Meet link via patch; omit or set false to leave the link untouched."
+        description: "Add a Google Meet video conference link to the event. Google does NOT allow removing an existing link via `update` — omit it or set false to leave the link untouched."
     defaults:
       calendarId: primary
 
@@ -158,10 +158,10 @@ operations:
     params:
       calendarId:
         type: string
-        description: "Calendar ID (default: 'primary')"
+        description: "Calendar ID (default: 'primary'). Use the `calendars` operation to list available IDs; required for events on shared calendars. On `freebusy`, a comma-separated list of calendar IDs to check IN ADDITION to your own. On `agenda`, a calendar name or ID to filter to."
       eventId:
         type: string
-        description: "Event ID to delete"
+        description: "Event ID"
         required: true
     defaults:
       calendarId: primary
@@ -180,7 +180,7 @@ operations:
     params:
       timeMin:
         type: string
-        description: "Start of range (ISO 8601)"
+        description: "Start of range (ISO 8601). On `list`, defaults to today."
         required: true
       timeMax:
         type: string
@@ -188,7 +188,7 @@ operations:
         required: true
       attendees:
         type: string
-        description: "Comma-separated email addresses to check availability for"
+        description: "Comma-separated email addresses. On `update` this REPLACES the entire attendee list (Google's events.patch overwrites arrays) — pass an empty string to clear all attendees. On `freebusy`, the addresses whose availability to check."
       calendarId:
         type: string
-        description: "Comma-separated calendar IDs to check (in addition to own calendar)"
+        description: "Calendar ID (default: 'primary'). Use the `calendars` operation to list available IDs; required for events on shared calendars. On `freebusy`, a comma-separated list of calendar IDs to check IN ADDITION to your own. On `agenda`, a calendar name or ID to filter to."

--- a/src/factory/manifest/drive.yaml
+++ b/src/factory/manifest/drive.yaml
@@ -51,10 +51,10 @@ operations:
         required: true
       name:
         type: string
-        description: "File name in Drive (defaults to local name)"
+        description: "File name in Drive. On `upload`, defaults to the local file's name. On `copy`, the name for the copy — without it Drive names it 'Copy of <original>'. On `update`, the new name (a rename)."
       parentFolderId:
         type: string
-        description: "Destination folder ID"
+        description: "Destination folder ID. On `copy`, defaults to the source file's folder."
 
   viewImage:
     type: detail
@@ -63,7 +63,7 @@ operations:
     params:
       fileId:
         type: string
-        description: "File ID of the image to view"
+        description: "File ID"
         required: true
     defaults:
       supportsAllDrives: true
@@ -75,7 +75,7 @@ operations:
     params:
       fileId:
         type: string
-        description: "File ID to download"
+        description: "File ID"
         required: true
       outputPath:
         type: string
@@ -91,14 +91,14 @@ operations:
     params:
       fileId:
         type: string
-        description: "File ID to copy"
+        description: "File ID"
         required: true
       name:
         type: string
-        description: "Name for the copy (without it, Drive names it 'Copy of <original>')"
+        description: "File name in Drive. On `upload`, defaults to the local file's name. On `copy`, the name for the copy — without it Drive names it 'Copy of <original>'. On `update`, the new name (a rename)."
       parentFolderId:
         type: string
-        description: "Folder ID to place the copy in (defaults to the source's folder)"
+        description: "Destination folder ID. On `copy`, defaults to the source file's folder."
     defaults:
       supportsAllDrives: true
 
@@ -109,11 +109,11 @@ operations:
     params:
       fileId:
         type: string
-        description: "File ID to update"
+        description: "File ID"
         required: true
       name:
         type: string
-        description: "New file name (rename)"
+        description: "File name in Drive. On `upload`, defaults to the local file's name. On `copy`, the name for the copy — without it Drive names it 'Copy of <original>'. On `update`, the new name (a rename)."
       addParents:
         type: string
         description: "Comma-separated folder ID(s) to add as parents (move into a folder)"
@@ -130,7 +130,7 @@ operations:
     params:
       fileId:
         type: string
-        description: "File ID to delete"
+        description: "File ID"
         required: true
     defaults:
       supportsAllDrives: true
@@ -142,7 +142,7 @@ operations:
     params:
       fileId:
         type: string
-        description: "File ID to export"
+        description: "File ID"
         required: true
       mimeType:
         type: string
@@ -150,7 +150,7 @@ operations:
         required: true
       outputPath:
         type: string
-        description: "Local path to save exported file"
+        description: "Local path to save the file"
     defaults:
       supportsAllDrives: true
 
@@ -175,7 +175,7 @@ operations:
     params:
       fileId:
         type: string
-        description: "File ID to share"
+        description: "File ID"
         required: true
       shareEmail:
         type: string
@@ -258,7 +258,7 @@ operations:
         required: true
       content:
         type: string
-        description: "Comment text"
+        description: "Comment text. On `replyToComment`, the reply text."
         required: true
       quotedText:
         type: string
@@ -299,11 +299,11 @@ operations:
         required: true
       commentId:
         type: string
-        description: "Comment ID to reply to"
+        description: "Comment ID"
         required: true
       content:
         type: string
-        description: "Reply text"
+        description: "Comment text. On `replyToComment`, the reply text."
         required: true
     defaults:
       fields: "id, content, htmlContent, author(displayName), createdTime"

--- a/src/factory/manifest/gmail.yaml
+++ b/src/factory/manifest/gmail.yaml
@@ -60,14 +60,14 @@ operations:
         required: true
       body:
         type: string
-        description: "Email body text"
+        description: "Email body text. On `forward`, an optional note prepended ABOVE the forwarded message."
         required: true
       from:
         type: string
         description: "Sender email or RFC 2822 mailbox for a verified Gmail Send As alias"
       cc:
         type: string
-        description: "CC email(s), comma-separated"
+        description: "CC email(s), comma-separated. On `replyAll` these are ADDITIONAL — they do not replace the recipients already on the thread."
       bcc:
         type: string
         description: "BCC email(s), comma-separated"
@@ -87,11 +87,11 @@ operations:
     params:
       messageId:
         type: string
-        description: "Message ID to reply to"
+        description: "Email message ID"
         required: true
       body:
         type: string
-        description: "Reply body text"
+        description: "Email body text. On `forward`, an optional note prepended ABOVE the forwarded message."
         required: true
       attachments:
         type: string
@@ -109,15 +109,15 @@ operations:
     params:
       messageId:
         type: string
-        description: "Message ID to reply to"
+        description: "Email message ID"
         required: true
       body:
         type: string
-        description: "Reply body text"
+        description: "Email body text. On `forward`, an optional note prepended ABOVE the forwarded message."
         required: true
       cc:
         type: string
-        description: "Additional CC email(s), comma-separated"
+        description: "CC email(s), comma-separated. On `replyAll` these are ADDITIONAL — they do not replace the recipients already on the thread."
       attachments:
         type: string
         description: "Workspace filenames to attach, comma-separated (files must exist in workspace via manage_workspace). Creates draft when present."
@@ -134,7 +134,7 @@ operations:
     params:
       messageId:
         type: string
-        description: "Message ID to forward"
+        description: "Email message ID"
         required: true
       to:
         type: string
@@ -142,7 +142,7 @@ operations:
         required: true
       body:
         type: string
-        description: "Optional note to prepend above forwarded message"
+        description: "Email body text. On `forward`, an optional note prepended ABOVE the forwarded message."
 
   # --- Inbox management ---
 
@@ -165,7 +165,7 @@ operations:
     params:
       messageId:
         type: string
-        description: "Message ID to trash"
+        description: "Email message ID"
         required: true
         maps_to: id
     defaults:
@@ -178,7 +178,7 @@ operations:
     params:
       messageId:
         type: string
-        description: "Message ID to restore"
+        description: "Email message ID"
         required: true
         maps_to: id
     defaults:
@@ -191,11 +191,11 @@ operations:
     params:
       messageId:
         type: string
-        description: "Message ID containing the attachment"
+        description: "Email message ID"
         required: true
       filename:
         type: string
-        description: "Filename to save as (from the read response, e.g. 'invoice_template.md')"
+        description: "Attachment filename, exactly as it appears in the `read` response (e.g. 'invoice_template.md')"
         required: true
     defaults:
       userId: me
@@ -207,11 +207,11 @@ operations:
     params:
       messageId:
         type: string
-        description: "Message ID containing the attachment"
+        description: "Email message ID"
         required: true
       filename:
         type: string
-        description: "Image filename from the read response"
+        description: "Attachment filename, exactly as it appears in the `read` response (e.g. 'invoice_template.md')"
         required: true
     defaults:
       userId: me
@@ -223,7 +223,7 @@ operations:
     params:
       messageId:
         type: string
-        description: "Message ID to modify"
+        description: "Email message ID"
         required: true
         maps_to: id
       addLabelIds:
@@ -253,11 +253,11 @@ operations:
     params:
       query:
         type: string
-        description: "Gmail search query to filter threads"
+        description: "Gmail search query (e.g. \"from:alice subject:meeting has:attachment\")"
         maps_to: q
       maxResults:
         type: number
-        description: "Max threads to return (default: 10, max: 50)"
+        description: "Max results (default: 10, max: 50)"
         default: 10
         max: 50
     defaults:

--- a/src/factory/manifest/meet.yaml
+++ b/src/factory/manifest/meet.yaml
@@ -13,10 +13,10 @@ operations:
     params:
       filter:
         type: string
-        description: "EBNF filter (e.g. 'space.meeting_code = \"abc-mnop-xyz\"' or 'start_time>=\"2026-01-01T00:00:00Z\"')"
+        description: "EBNF filter. On `listConferences`, e.g. 'space.meeting_code = \"abc-mnop-xyz\"' or 'start_time>=\"2026-01-01T00:00:00Z\"'. On `listParticipants`, e.g. 'latest_end_time IS NULL' for active participants."
       maxResults:
         type: number
-        description: "Max conferences to return (default: 25, max: 100)"
+        description: "Max results per page. Default and ceiling differ by operation: `listConferences` 25/100, `listParticipants` 100/250, `listTranscriptEntries` 10/100."
         default: 25
         max: 100
         maps_to: pageSize
@@ -28,7 +28,7 @@ operations:
     params:
       conferenceId:
         type: string
-        description: "Conference record ID (from listConferences)"
+        description: "Conference record ID (from `listConferences`)"
         required: true
         maps_to: name
 
@@ -41,15 +41,15 @@ operations:
     params:
       conferenceId:
         type: string
-        description: "Conference record ID"
+        description: "Conference record ID (from `listConferences`)"
         required: true
         maps_to: parent
       filter:
         type: string
-        description: "Filter (e.g. 'latest_end_time IS NULL' for active participants)"
+        description: "EBNF filter. On `listConferences`, e.g. 'space.meeting_code = \"abc-mnop-xyz\"' or 'start_time>=\"2026-01-01T00:00:00Z\"'. On `listParticipants`, e.g. 'latest_end_time IS NULL' for active participants."
       maxResults:
         type: number
-        description: "Max participants (default: 100, max: 250)"
+        description: "Max results per page. Default and ceiling differ by operation: `listConferences` 25/100, `listParticipants` 100/250, `listTranscriptEntries` 10/100."
         default: 100
         max: 250
         maps_to: pageSize
@@ -63,7 +63,7 @@ operations:
     params:
       conferenceId:
         type: string
-        description: "Conference record ID"
+        description: "Conference record ID (from `listConferences`)"
         required: true
         maps_to: parent
 
@@ -74,7 +74,7 @@ operations:
     params:
       transcriptName:
         type: string
-        description: "Transcript resource name (from listTranscripts)"
+        description: "Transcript resource name (from `listTranscripts`, e.g. conferenceRecords/.../transcripts/...)"
         required: true
         maps_to: name
 
@@ -85,12 +85,12 @@ operations:
     params:
       transcriptName:
         type: string
-        description: "Transcript resource name (e.g. conferenceRecords/.../transcripts/...)"
+        description: "Transcript resource name (from `listTranscripts`, e.g. conferenceRecords/.../transcripts/...)"
         required: true
         maps_to: parent
       maxResults:
         type: number
-        description: "Max entries per page (default: 10, max: 100)"
+        description: "Max results per page. Default and ceiling differ by operation: `listConferences` 25/100, `listParticipants` 100/250, `listTranscriptEntries` 10/100."
         default: 100
         max: 100
         maps_to: pageSize
@@ -104,7 +104,7 @@ operations:
     params:
       conferenceId:
         type: string
-        description: "Conference record ID"
+        description: "Conference record ID (from `listConferences`)"
         required: true
         maps_to: parent
 
@@ -128,7 +128,7 @@ operations:
     params:
       conferenceId:
         type: string
-        description: "Conference record ID (from listConferences)"
+        description: "Conference record ID (from `listConferences`)"
         required: true
       pageToken:
         type: string
@@ -143,7 +143,7 @@ operations:
     params:
       conferenceId:
         type: string
-        description: "Conference record ID"
+        description: "Conference record ID (from `listConferences`)"
         required: true
         maps_to: parent
 

--- a/src/factory/manifest/meet.yaml
+++ b/src/factory/manifest/meet.yaml
@@ -16,7 +16,7 @@ operations:
         description: "EBNF filter. On `listConferences`, e.g. 'space.meeting_code = \"abc-mnop-xyz\"' or 'start_time>=\"2026-01-01T00:00:00Z\"'. On `listParticipants`, e.g. 'latest_end_time IS NULL' for active participants."
       maxResults:
         type: number
-        description: "Max results per page. Default and ceiling differ by operation: `listConferences` 25/100, `listParticipants` 100/250, `listTranscriptEntries` 10/100."
+        description: "Max results per page, as default/ceiling. Differs by operation: `listConferences` 25/100, `listParticipants` 100/250, `listTranscriptEntries` 100/100. (Google's own default for transcript entries is 10; this tool raises it.)"
         default: 25
         max: 100
         maps_to: pageSize
@@ -49,7 +49,7 @@ operations:
         description: "EBNF filter. On `listConferences`, e.g. 'space.meeting_code = \"abc-mnop-xyz\"' or 'start_time>=\"2026-01-01T00:00:00Z\"'. On `listParticipants`, e.g. 'latest_end_time IS NULL' for active participants."
       maxResults:
         type: number
-        description: "Max results per page. Default and ceiling differ by operation: `listConferences` 25/100, `listParticipants` 100/250, `listTranscriptEntries` 10/100."
+        description: "Max results per page, as default/ceiling. Differs by operation: `listConferences` 25/100, `listParticipants` 100/250, `listTranscriptEntries` 100/100. (Google's own default for transcript entries is 10; this tool raises it.)"
         default: 100
         max: 250
         maps_to: pageSize
@@ -90,7 +90,7 @@ operations:
         maps_to: parent
       maxResults:
         type: number
-        description: "Max results per page. Default and ceiling differ by operation: `listConferences` 25/100, `listParticipants` 100/250, `listTranscriptEntries` 10/100."
+        description: "Max results per page, as default/ceiling. Differs by operation: `listConferences` 25/100, `listParticipants` 100/250, `listTranscriptEntries` 100/100. (Google's own default for transcript entries is 10; this tool raises it.)"
         default: 100
         max: 100
         maps_to: pageSize

--- a/src/factory/manifest/sheets.yaml
+++ b/src/factory/manifest/sheets.yaml
@@ -11,7 +11,7 @@ operations:
     params:
       spreadsheetId:
         type: string
-        description: "Spreadsheet ID"
+        description: "Spreadsheet ID. On `copySheetTo`, the SOURCE spreadsheet."
         required: true
 
   create:
@@ -21,7 +21,7 @@ operations:
     params:
       title:
         type: string
-        description: "Spreadsheet title (defaults to 'Untitled spreadsheet')"
+        description: "On `create`, the spreadsheet title (defaults to 'Untitled spreadsheet'); on `renameSpreadsheet`, its new title. On `addSheet`, the name of the new TAB; on `renameSheet`, that tab's new title; on `duplicateSheet`, the name for the copy (defaults to 'Copy of <source>')."
 
   read:
     type: detail
@@ -30,11 +30,11 @@ operations:
     params:
       spreadsheetId:
         type: string
-        description: "Spreadsheet ID"
+        description: "Spreadsheet ID. On `copySheetTo`, the SOURCE spreadsheet."
         required: true
       range:
         type: string
-        description: "Range to read (e.g. 'Sheet1!A1:D10' or just 'Sheet1')"
+        description: "A1 notation range (e.g. 'Sheet1!A1:D10', or just 'Sheet1' for a whole tab). On `append`, the target tab — defaults to 'Sheet1'; use 'MyTab' or 'MyTab!A:Z' to append to a specific one."
         required: true
 
   append:
@@ -44,17 +44,17 @@ operations:
     params:
       spreadsheetId:
         type: string
-        description: "Spreadsheet ID"
+        description: "Spreadsheet ID. On `copySheetTo`, the SOURCE spreadsheet."
         required: true
       range:
         type: string
-        description: "Target range; defaults to 'Sheet1'. Use 'MyTab' or 'MyTab!A:Z' to append to a specific tab."
+        description: "A1 notation range (e.g. 'Sheet1!A1:D10', or just 'Sheet1' for a whole tab). On `append`, the target tab — defaults to 'Sheet1'; use 'MyTab' or 'MyTab!A:Z' to append to a specific one."
       values:
         type: string
         description: "Comma-separated values for a single row (e.g. 'Alice,100,true')"
       jsonValues:
         type: string
-        description: "JSON 2D array of rows for bulk insert (e.g. '[[\"a\",\"b\"],[\"c\",\"d\"]]')"
+        description: "JSON 2D array of rows (e.g. '[[\"a\",\"b\"],[\"c\",\"d\"]]'). Use for bulk and multi-row writes."
       valueInputOption:
         type: string
         description: "How input is interpreted: USER_ENTERED (default, parses formulas/types) or RAW"
@@ -68,11 +68,11 @@ operations:
     params:
       spreadsheetId:
         type: string
-        description: "Spreadsheet ID"
+        description: "Spreadsheet ID. On `copySheetTo`, the SOURCE spreadsheet."
         required: true
       range:
         type: string
-        description: "A1 notation range (e.g. 'Sheet1!A1:B10')"
+        description: "A1 notation range (e.g. 'Sheet1!A1:D10', or just 'Sheet1' for a whole tab). On `append`, the target tab — defaults to 'Sheet1'; use 'MyTab' or 'MyTab!A:Z' to append to a specific one."
         required: true
 
   updateValues:
@@ -82,18 +82,18 @@ operations:
     params:
       spreadsheetId:
         type: string
-        description: "Spreadsheet ID"
+        description: "Spreadsheet ID. On `copySheetTo`, the SOURCE spreadsheet."
         required: true
       range:
         type: string
-        description: "A1 notation range to write to"
+        description: "A1 notation range (e.g. 'Sheet1!A1:D10', or just 'Sheet1' for a whole tab). On `append`, the target tab — defaults to 'Sheet1'; use 'MyTab' or 'MyTab!A:Z' to append to a specific one."
         required: true
       values:
         type: string
         description: "Comma-separated values for a single row (e.g. 'Alice,100,true')"
       jsonValues:
         type: string
-        description: "JSON 2D array of rows (e.g. '[[\"a\",\"b\"],[\"c\",\"d\"]]'). Use for multi-row writes."
+        description: "JSON 2D array of rows (e.g. '[[\"a\",\"b\"],[\"c\",\"d\"]]'). Use for bulk and multi-row writes."
       valueInputOption:
         type: string
         description: "How input is interpreted: USER_ENTERED (default, parses formulas/types) or RAW"
@@ -107,11 +107,11 @@ operations:
     params:
       spreadsheetId:
         type: string
-        description: "Spreadsheet ID"
+        description: "Spreadsheet ID. On `copySheetTo`, the SOURCE spreadsheet."
         required: true
       range:
         type: string
-        description: "A1 notation range to clear"
+        description: "A1 notation range (e.g. 'Sheet1!A1:D10', or just 'Sheet1' for a whole tab). On `append`, the target tab — defaults to 'Sheet1'; use 'MyTab' or 'MyTab!A:Z' to append to a specific one."
         required: true
 
   addSheet:
@@ -121,11 +121,11 @@ operations:
     params:
       spreadsheetId:
         type: string
-        description: "Spreadsheet ID"
+        description: "Spreadsheet ID. On `copySheetTo`, the SOURCE spreadsheet."
         required: true
       title:
         type: string
-        description: "Name of the new sheet tab"
+        description: "On `create`, the spreadsheet title (defaults to 'Untitled spreadsheet'); on `renameSpreadsheet`, its new title. On `addSheet`, the name of the new TAB; on `renameSheet`, that tab's new title; on `duplicateSheet`, the name for the copy (defaults to 'Copy of <source>')."
         required: true
       index:
         type: number
@@ -144,15 +144,15 @@ operations:
     params:
       spreadsheetId:
         type: string
-        description: "Spreadsheet ID"
+        description: "Spreadsheet ID. On `copySheetTo`, the SOURCE spreadsheet."
         required: true
       sheetId:
         type: number
-        description: "Sheet ID of the tab to rename (from manage_sheets get)"
+        description: "Sheet ID of the tab, from `manage_sheets get`. On `duplicateSheet` and `copySheetTo`, the SOURCE tab to copy."
         required: true
       title:
         type: string
-        description: "New title for the tab"
+        description: "On `create`, the spreadsheet title (defaults to 'Untitled spreadsheet'); on `renameSpreadsheet`, its new title. On `addSheet`, the name of the new TAB; on `renameSheet`, that tab's new title; on `duplicateSheet`, the name for the copy (defaults to 'Copy of <source>')."
         required: true
 
   deleteSheet:
@@ -162,11 +162,11 @@ operations:
     params:
       spreadsheetId:
         type: string
-        description: "Spreadsheet ID"
+        description: "Spreadsheet ID. On `copySheetTo`, the SOURCE spreadsheet."
         required: true
       sheetId:
         type: number
-        description: "Sheet ID of the tab to delete"
+        description: "Sheet ID of the tab, from `manage_sheets get`. On `duplicateSheet` and `copySheetTo`, the SOURCE tab to copy."
         required: true
 
   duplicateSheet:
@@ -176,18 +176,18 @@ operations:
     params:
       spreadsheetId:
         type: string
-        description: "Spreadsheet ID"
+        description: "Spreadsheet ID. On `copySheetTo`, the SOURCE spreadsheet."
         required: true
       sheetId:
         type: number
-        description: "Source sheet ID (the tab to copy)"
+        description: "Sheet ID of the tab, from `manage_sheets get`. On `duplicateSheet` and `copySheetTo`, the SOURCE tab to copy."
         required: true
       title:
         type: string
-        description: "Name for the duplicated sheet (defaults to 'Copy of <source>')"
+        description: "On `create`, the spreadsheet title (defaults to 'Untitled spreadsheet'); on `renameSpreadsheet`, its new title. On `addSheet`, the name of the new TAB; on `renameSheet`, that tab's new title; on `duplicateSheet`, the name for the copy (defaults to 'Copy of <source>')."
       index:
         type: number
-        description: "Position to insert the duplicate (0-based)"
+        description: "Position among tabs (0-based). Appended at the end if omitted."
 
   renameSpreadsheet:
     type: action
@@ -196,11 +196,11 @@ operations:
     params:
       spreadsheetId:
         type: string
-        description: "Spreadsheet ID"
+        description: "Spreadsheet ID. On `copySheetTo`, the SOURCE spreadsheet."
         required: true
       title:
         type: string
-        description: "New spreadsheet title"
+        description: "On `create`, the spreadsheet title (defaults to 'Untitled spreadsheet'); on `renameSpreadsheet`, its new title. On `addSheet`, the name of the new TAB; on `renameSheet`, that tab's new title; on `duplicateSheet`, the name for the copy (defaults to 'Copy of <source>')."
         required: true
 
   copySheetTo:
@@ -210,11 +210,11 @@ operations:
     params:
       spreadsheetId:
         type: string
-        description: "Source spreadsheet ID"
+        description: "Spreadsheet ID. On `copySheetTo`, the SOURCE spreadsheet."
         required: true
       sheetId:
         type: number
-        description: "Source sheet ID (the tab to copy)"
+        description: "Sheet ID of the tab, from `manage_sheets get`. On `duplicateSheet` and `copySheetTo`, the SOURCE tab to copy."
         required: true
       destinationSpreadsheetId:
         type: string

--- a/src/factory/manifest/tasks.yaml
+++ b/src/factory/manifest/tasks.yaml
@@ -18,7 +18,7 @@ operations:
     params:
       taskListId:
         type: string
-        description: "Task list ID"
+        description: "Task list ID (use `listTaskLists` to find)"
         required: true
         maps_to: tasklist
 
@@ -32,7 +32,7 @@ operations:
     params:
       title:
         type: string
-        description: "Task list name"
+        description: "On `createTaskList`, the task list name. On `create` and `update`, the task title."
         required: true
 
   deleteTaskList:
@@ -42,7 +42,7 @@ operations:
     params:
       taskListId:
         type: string
-        description: "Task list ID to delete"
+        description: "Task list ID (use `listTaskLists` to find)"
         required: true
         maps_to: tasklist
 
@@ -55,7 +55,7 @@ operations:
     params:
       taskListId:
         type: string
-        description: "Task list ID (use listTaskLists to find)"
+        description: "Task list ID (use `listTaskLists` to find)"
         required: true
         maps_to: tasklist
       showCompleted:
@@ -74,7 +74,7 @@ operations:
     params:
       taskListId:
         type: string
-        description: "Task list ID"
+        description: "Task list ID (use `listTaskLists` to find)"
         required: true
         maps_to: tasklist
       taskId:
@@ -94,12 +94,12 @@ operations:
     params:
       taskListId:
         type: string
-        description: "Task list ID"
+        description: "Task list ID (use `listTaskLists` to find)"
         required: true
         maps_to: tasklist
       title:
         type: string
-        description: "Task title"
+        description: "On `createTaskList`, the task list name. On `create` and `update`, the task title."
         required: true
       notes:
         type: string
@@ -118,7 +118,7 @@ operations:
     params:
       taskListId:
         type: string
-        description: "Task list ID"
+        description: "Task list ID (use `listTaskLists` to find)"
         required: true
         maps_to: tasklist
       taskId:
@@ -128,13 +128,13 @@ operations:
         maps_to: task
       title:
         type: string
-        description: "New task title"
+        description: "On `createTaskList`, the task list name. On `create` and `update`, the task title."
       notes:
         type: string
-        description: "New task notes / details"
+        description: "Task notes / details"
       due:
         type: string
-        description: "New due date (RFC 3339)"
+        description: "Due date (RFC 3339, e.g. 2026-07-20T00:00:00.000Z — Google stores the date, not the time)"
       status:
         type: string
         description: "Task status"
@@ -147,7 +147,7 @@ operations:
     params:
       taskListId:
         type: string
-        description: "Task list ID"
+        description: "Task list ID (use `listTaskLists` to find)"
         required: true
         maps_to: tasklist
       taskId:
@@ -165,11 +165,11 @@ operations:
     params:
       taskListId:
         type: string
-        description: "Task list ID"
+        description: "Task list ID (use `listTaskLists` to find)"
         required: true
         maps_to: tasklist
       taskId:
         type: string
-        description: "Task ID to delete"
+        description: "Task ID"
         required: true
         maps_to: task

--- a/src/services/calendar/patch.ts
+++ b/src/services/calendar/patch.ts
@@ -185,6 +185,48 @@ function formatAgenda(events: AgendaEvent[], window: { timeMin: string; timeMax:
   };
 }
 
+/**
+ * Fields Google owns. events.update REPLACES the resource, so the existing event is read
+ * and echoed back — but these are server-generated and must not be echoed with it.
+ */
+const READ_ONLY_EVENT_FIELDS = [
+  'kind', 'etag', 'id', 'htmlLink', 'created', 'updated', 'iCalUID', 'sequence',
+  'creator', 'organizer', 'hangoutLink', 'conferenceData', 'eventType',
+];
+
+/**
+ * Remove an event's Meet link, preserving everything else about the event.
+ *
+ * The only call that removes a conference is a full events.update omitting
+ * conferenceData — patch accepts `null` and `{}` with a 200 and changes nothing
+ * (measured). A full update replaces the resource, so anything not echoed back is
+ * DESTROYED: read the event, drop the server-owned fields, layer the caller's changes on
+ * top, and send the result.
+ *
+ * `conferenceDataVersion: 1` is required for the omission to be honoured as a removal
+ * rather than ignored as an unmanaged field.
+ */
+async function removeMeetLink(
+  calendarId: string,
+  eventId: string,
+  changes: Record<string, unknown>,
+  account: string,
+): Promise<Record<string, unknown>> {
+  const existing = await call('calendar', 'events.get',
+    { calendarId, eventId }, { account }) as Record<string, unknown>;
+
+  const preserved: Record<string, unknown> = { ...existing };
+  for (const field of READ_ONLY_EVENT_FIELDS) delete preserved[field];
+
+  return await call('calendar', 'events.update', {
+    calendarId,
+    eventId,
+    conferenceDataVersion: 1,
+    ...preserved,
+    ...changes,
+  }, { account }) as Record<string, unknown>;
+}
+
 export const calendarPatch: ServicePatch = {
   beforeExecute: {
     // Default the range to "from the start of today" when the caller gave none.
@@ -405,9 +447,25 @@ export const calendarPatch: ServicePatch = {
       // Build --params: note the conferenceDataVersion=1 requirement when creating a Meet link.
       const queryParams: Record<string, unknown> = { calendarId, eventId };
 
-      // Optional Meet link attach. Google Calendar does not allow removing a Meet link
-      // via events.patch, so we only handle the "add" case.
-      if (params.meet) {
+      // Optional Meet link.
+      //
+      // ADDING is a patch: conferenceData.createRequest plus conferenceDataVersion=1.
+      //
+      // REMOVING is not, and the comment that used to sit here said Google forbids it.
+      // Measured against live Google, that is not what happens: events.patch with
+      // `conferenceData: null` returns 200 and leaves the link in place, and so does
+      // `conferenceData: {}`. Removal works only through a FULL events.update that omits
+      // conferenceData. Both silent-success shapes, indistinguishable from a refusal —
+      // which is presumably how the claim survived unchallenged.
+      //
+      // events.update REPLACES the resource, so the existing event has to be read and
+      // echoed back. Skipping that is not a style question: a naive update during this
+      // investigation wiped the probe event's `location` without a word.
+      //
+      // None of which the agent should have to know. `meet: false` removes the link;
+      // the read-modify-write lives here. See removeMeetLink below.
+      const removingMeet = params.meet === false;
+      if (params.meet === true) {
         const requestId = `meet-${eventId}-${Date.now()}`;
         body.conferenceData = {
           createRequest: {
@@ -418,16 +476,21 @@ export const calendarPatch: ServicePatch = {
         queryParams.conferenceDataVersion = 1;
       }
 
-      if (Object.keys(body).length === 0) {
+      // Removing the Meet link IS a change, even with no other field set. It used to
+      // fall through to this guard and report "no field to change" for a request that
+      // named one.
+      if (Object.keys(body).length === 0 && !removingMeet) {
         throw new Error(
           'update requires at least one field to change: summary, start, end, description, location, attendees, or meet',
         );
       }
 
-      const data = await call('calendar', 'events.patch', {
-        ...queryParams,
-        ...body,
-      }, { account }) as Record<string, unknown>;
+      const data = removingMeet
+        ? await removeMeetLink(calendarId, eventId, body, account)
+        : await call('calendar', 'events.patch', {
+          ...queryParams,
+          ...body,
+        }, { account }) as Record<string, unknown>;
 
       const changed = Object.keys(body);
       const meetLink = data.hangoutLink ? `\n**Meet:** ${data.hangoutLink}` : '';


### PR DESCRIPTION
## Description

`generateSchema` flattens every operation's params into one tool schema and keeps the **first** declaration of each name. Later ones are dropped with no warning, so a param used by several operations is described to the model exactly once — by whichever operation happens to appear first in the YAML.

75 declarations were being discarded across six services. Most were harmless drift (`"Event ID"` losing to `"Event ID to update"`). Several were not.

Fixes #161.

### What the model could not see

**`calendar.attendees` — silent data loss.** `update`'s declaration warned that passing it replaces the whole list. `create`'s wording won. **Verified live** (see below).

**`calendar.calendarId`** — `freebusy` takes a comma-separated *list* where every other operation takes a single id.

**`meet.maxResults`** — advertised `listConferences`' 25/100 for operations whose real ceilings are 100/250 and 100/100.

**`sheets.title`** — means five different things across `create` / `renameSpreadsheet` / `addSheet` / `renameSheet` / `duplicateSheet`.

Every param now carries one description covering all of its operations, naming the operation wherever meaning genuinely diverges. `known-param-collisions.txt` is **empty**, promoting the test added alongside #157 from a ratchet to a hard gate.

## Verifying the claims, not just merging them

Promoting a description into the shared slot makes it load-bearing for the first time, so the claims were tested rather than inherited.

**`calendar.attendees` — claim holds, wording was imprecise.** Live, against a throwaway event:

| Test | Result |
|---|---|
| patch `location`, **omit** `attendees` | both attendees **survived** |
| patch `attendees: "a@x"` with two on the event | the other was **removed** |
| patch `attendees: ""` | **all** removed |

Replacement happens when you *pass* the field. The old text — "On `update` this REPLACES the entire attendee list" — reads as though any update wipes attendees, which would steer an agent away from `update` on events with guests. Reworded to say that omitting the parameter is the safe path.

**`calendar.meet` — claim was false, and so was the code.** The description said *"Google does NOT allow removing an existing link via `update`"*. That sentence and the matching comment at `calendar/patch.ts` arrived together in `123258a` and had never been exercised: `if (params.meet)` is truthy-only, so `meet: false` never reached Google. Measured:

| Call | Result |
|---|---|
| `patch` + `conferenceData: null` | 200, **link persists** |
| `patch` + `conferenceData: {}` | 200, **link persists** |
| full `events.update`, conferenceData omitted | **link removed** |

Google permits removal; it needs `events.update`. Both patch attempts are silent successes, which is how the claim went four months unchallenged — and `generateSchema` was discarding the description anyway, so no agent ever read it to doubt it.

## Behavior change: `meet: false` now removes the link

Rather than documenting the limitation, the limitation is fixed, and the complexity stays inside the tool. The agent passes `meet: false`; it does not need to know about `conferenceDataVersion`, patch-versus-update, or which fields must be re-sent.

`events.update` **replaces** the resource, so removal reads the event, strips server-owned fields, layers the caller's changes on top, and sends the result. A version that skipped the read wiped the probe event's `location` without a word — the same silent-data-loss shape this PR is about.

`meet: false` alone also used to hit the *"requires at least one field to change"* guard, so the one request that could remove a link was rejected as empty.

Verified live: link removed; `location`, `description` and `attendees` all survived the replace.

## Review findings addressed

Both confirmed against the declarations and fixed:

1. **`meet.maxResults` said `listTranscriptEntries` 10/100.** The manifest declares `default: 100, max: 100`; 10 is Google's default, which this manifest overrides. Wrong before this branch — harmonizing copied it into a table that reads far more authoritatively than the drift it replaced.
2. **`calendar.calendarId` asserted `default: 'primary'` unconditionally.** `agenda` is a custom handler that spans all calendars when the param is omitted, and passing `'primary'` to it *fails* — an API alias, not an id it matches on. The text led the model into an error the operation's own description contradicted one line away.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (`meet: false` now removes a link; previously an error or a no-op)
- [x] Documentation update

## Testing Performed

1. Unit Tests:
   - [x] Added new tests for new functionality — five covering the read-then-update ordering, `conferenceDataVersion`, field preservation, server-owned field stripping, and combining removal with other edits
   - [x] All existing tests pass — `make check` green, **772 tests**
   - [x] The collision gate now runs with an empty allowlist

2. Integration Testing:
   - [x] Tested with real Google Workspace accounts — attendee replacement semantics, Meet removal across three API shapes, and field preservation through the full replace
   - [x] Verified against the built server's `tools/list`, the only view that shows what the model receives

All probe events were deleted.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Security Considerations

- [x] No sensitive information is exposed

`calendar.attendees` is the security-relevant half: an agent that cannot see the replace semantics destroys attendee lists it never meant to touch.

## Additional Notes

Filed from this review: **#165** — per-param `required: true` never reaches the generated schema, and a comment at `tasks/patch.ts:26` asserts the opposite. Same class as #161.

Not addressed: the collision gate compares `description`, `type` and `enum`, and finding 1 drifted on `default`/`max`, which legitimately differ per operation and so cannot join that loop. Worth a narrow assertion that numbers quoted in a description match the declarations they describe, if it drifts again.