### PR TITLE
feat(release): publish to npm from CI with trusted publishing (ADR-105)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,104 @@
+# Publish to npm with trusted publishing (OIDC). See ADR-105.
+#
+# THE FILENAME IS LOAD-BEARING. npmjs.com registers a trusted publisher against a
+# repository AND a workflow filename; this file is registered as `npm-publish.yml`.
+# Rename or move it and npm stops recognising the identity, with nothing in this repo
+# to explain why.
+#
+# There is deliberately no NPM_TOKEN, no NODE_AUTH_TOKEN, and no `registry-url:` on
+# setup-node — that input exists to write a token into .npmrc, which is what this
+# replaces. An earlier version of this workflow published from a long-lived token; it
+# expired in June 2026 and failed three consecutive releases (v3.0.0, v4.0.0, v4.0.1)
+# before being deleted in 2c5669c. OIDC has no secret to expire.
+name: Publish to npm
+
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write   # mints the OIDC token npm verifies. Without it, publish is unauthenticated.
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      # Node 22 ships npm 10.x, which predates trusted publishing entirely — it would
+      # look for a token, find none, and fail with a 401 that says nothing about OIDC.
+      - name: Upgrade npm past the trusted-publishing floor
+        run: |
+          npm install -g npm@latest
+          V=$(npm --version)
+          echo "npm $V"
+          node -e '
+            const v = process.argv[1];
+            const [maj, min, pat] = v.split(".").map(Number);
+            const ok = maj > 11 || (maj === 11 && (min > 5 || (min === 5 && pat >= 1)));
+            if (!ok) {
+              console.error(`npm ${v} is below the 11.5.1 trusted-publishing floor — publish would fall back to token auth and 401.`);
+              process.exit(1);
+            }
+          ' "$V"
+
+      - name: Install dependencies
+        run: npm ci
+
+      # The tag is not evidence that anything was checked. Run the gates against the
+      # commit actually being published, in a clean checkout.
+      - name: Test
+        run: npm test
+
+      - name: Type-check
+        run: npm run type-check
+
+      - name: Build
+        run: npm run build
+
+      # A PRE-RELEASE must not become `latest`. `npm publish` with no --tag publishes as
+      # `latest`, which every `npm install` and every `^x.y.z` range picks up — so an alpha
+      # published bare is not "available to those who want it", it is shipped to everyone.
+      # This mirrors the same derivation in `make publish-all`; both read the marker out of
+      # the version string.
+      - name: Determine npm dist-tag
+        id: npm-tag
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if echo "$VERSION" | grep -qE '(alpha|beta|rc)'; then
+            echo "tag=$(echo "$VERSION" | grep -oE '(alpha|beta|rc)')" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      # The tag names one version; package.json names another. Publishing on a mismatch
+      # ships whatever package.json says under a tag that claims something else.
+      - name: Check the tag matches package.json
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PKG_VERSION="${{ steps.npm-tag.outputs.version }}"
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "tag $GITHUB_REF_NAME says $TAG_VERSION, package.json says $PKG_VERSION."
+            exit 1
+          fi
+          echo "tag $GITHUB_REF_NAME matches package.json $PKG_VERSION"
+
+      # An npm version is permanent, so a re-run of this job on an already-published
+      # version must be a no-op rather than a red X on a release that actually succeeded.
+      - name: Publish to npm
+        run: |
+          PKG=$(node -p "require('./package.json').name")
+          VERSION="${{ steps.npm-tag.outputs.version }}"
+          if npm view "$PKG@$VERSION" version >/dev/null 2>&1; then
+            echo "$PKG@$VERSION is already on the registry — nothing to publish."
+            exit 0
+          fi
+          npm publish --provenance --access public --tag "${{ steps.npm-tag.outputs.tag }}"

--- a/Makefile
+++ b/Makefile
@@ -220,27 +220,42 @@ check-release-tag: ## Refuse to publish unless v$(VERSION) is tagged AT the comm
 	fi; \
 	echo "check-release-tag: $$tag -> $$(git log --oneline -1 $$tagged)"
 
-publish-all: check-release-tag mcpb ## Publish to npm, MCP Registry, GitHub Release
+# `read` is the ONLY thing here that needs a terminal. The hardware-key steps do not:
+# npm's 2FA and `mcp-publisher login github` print a URL and wait on the browser, which
+# works fine with no tty. So without YES=1 this target is unrunnable from anywhere that
+# lacks one — Claude Code's `!` prefix, a pipeline, CI — because `read` gets EOF, which
+# reads as "no" and aborts a publish that was never actually declined.
+#
+# YES=1 does not remove the confirmation, it moves it to the command line: typing it is
+# the affirmative act. Publishing is still a one-way door and nothing here defaults to it.
+publish-all: check-release-tag mcpb ## Publish to npm, MCP Registry, GitHub Release (YES=1 to skip prompts)
 	@echo ""
 	@echo "Publishing v$(VERSION) to all channels."
 	@echo "  1. npm (2FA in the browser — passkey/security key)"
 	@echo "  2. MCP Registry (requires GitHub auth)"
 	@echo "  3. GitHub Release (reconciles the one CI made on tag push)"
 	@echo ""
-	@read -p "Continue? [y/N] " confirm && [ "$$confirm" = "y" ] || (echo "Aborted." && exit 1)
+	@if [ -n "$(YES)" ]; then echo "YES=1 — confirmed on the command line, not prompting."; \
+	else read -p "Continue? [y/N] " confirm && [ "$$confirm" = "y" ] || { echo "Aborted."; exit 1; }; fi
 	@echo ""
 	@echo "── npm ──"
-	@who=$$(npm whoami 2>/dev/null) && echo "npm: logged in as $$who" || { \
-	  echo "npm: not logged in — starting 'npm login' (browser + security key)"; npm login; }
-	@# A PRE-RELEASE must not become `latest`.
-	@#
-	@# `npm publish` with no --tag publishes as `latest`, which every `npm install` and
-	@# every `^x.y.z` range picks up. So an alpha published bare is not "available to
-	@# people who want it" — it is shipped to everyone. This detection used to live in
-	@# the CI workflow; the workflow is gone, so it lives here, where the publish is.
-	@tag=$$(echo "$(VERSION)" | grep -oE 'alpha|beta|rc' || echo latest); \
+	@# .github/workflows/npm-publish.yml publishes on tag push via OIDC (ADR-105), so by
+	@# the time anyone runs this the version is usually already up. Skipping is the
+	@# correct outcome, not a failure: an npm version is permanent, and `npm publish`
+	@# over an existing one exits 403 — which would abort this target before the MCP
+	@# Registry step below, the half CI does NOT do.
+	@pkg=$$(node -p "require('./package.json').name"); \
+	if npm view "$$pkg@$(VERSION)" version >/dev/null 2>&1; then \
+	  echo "npm: $$pkg@$(VERSION) is already published — skipping (CI publishes on tag push)"; \
+	else \
+	  who=$$(npm whoami 2>/dev/null) && echo "npm: logged in as $$who" || { \
+	    echo "npm: not logged in — starting 'npm login' (browser + security key)"; npm login; }; \
+	  : "A PRE-RELEASE must not become 'latest' — bare `npm publish` ships an alpha to"; \
+	  : "everyone on ^x.y.z. Same derivation as npm-publish.yml, which explains it in full."; \
+	  tag=$$(echo "$(VERSION)" | grep -oE 'alpha|beta|rc' || echo latest); \
 	  echo "npm: publishing $(VERSION) under dist-tag '$$tag'"; \
-	  npm publish --access public --tag "$$tag"
+	  npm publish --access public --tag "$$tag"; \
+	fi
 	@echo ""
 	@echo "── MCP Registry ──"
 	mcp-publisher login github
@@ -267,7 +282,8 @@ publish-all: check-release-tag mcpb ## Publish to npm, MCP Registry, GitHub Rele
 	  echo "$$bundle holds v$$packed, but this is the v$(VERSION) publish."; \
 	  echo "  Attaching it would ship the wrong code under this tag. Rebuild: make mcpb"; exit 1; \
 	fi; \
-	read -p "Release notes (one line, or empty to keep the notes CI generated): " notes; \
+	if [ -n "$(YES)$(NOTES)" ]; then notes="$(NOTES)"; \
+	else read -p "Release notes (one line, or empty to keep the notes CI generated): " notes; fi; \
 	if gh release view "v$(VERSION)" >/dev/null 2>&1; then \
 	  echo "gh: v$(VERSION) already exists (CI creates it on tag push) — updating in place"; \
 	  if [ -n "$$notes" ]; then gh release edit "v$(VERSION)" --notes "$$notes"; fi; \

--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -25,6 +25,7 @@ _Architecture, tool design, executor patterns_
 | [ADR-102](./core/ADR-102-raise-the-node-floor-to-22-12-and-unpin-sanitize-html.md) | Raise the Node floor to 22.12 and unpin sanitize-html | Accepted |
 | [ADR-103](./core/ADR-103-generate-a-google-api-descriptor-retire-the-gws-facade.md) | Generate a Google API descriptor from Discovery; retire the gws facade | Accepted |
 | [ADR-104](./core/ADR-104-exit-when-the-mcp-client-goes-away.md) | Exit when the MCP client goes away | Draft |
+| [ADR-105](./core/ADR-105-publish-to-npm-from-ci-with-trusted-publishing-not-a-token-or-a-security-key.md) | Publish to npm from CI with trusted publishing, not a token or a security key | Proposed |
 
 ## Authentication
 _OAuth, credential management, multi-account_

--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -25,7 +25,7 @@ _Architecture, tool design, executor patterns_
 | [ADR-102](./core/ADR-102-raise-the-node-floor-to-22-12-and-unpin-sanitize-html.md) | Raise the Node floor to 22.12 and unpin sanitize-html | Accepted |
 | [ADR-103](./core/ADR-103-generate-a-google-api-descriptor-retire-the-gws-facade.md) | Generate a Google API descriptor from Discovery; retire the gws facade | Accepted |
 | [ADR-104](./core/ADR-104-exit-when-the-mcp-client-goes-away.md) | Exit when the MCP client goes away | Draft |
-| [ADR-105](./core/ADR-105-publish-to-npm-from-ci-with-trusted-publishing-not-a-token-or-a-security-key.md) | Publish to npm from CI with trusted publishing, not a token or a security key | Proposed |
+| [ADR-105](./core/ADR-105-publish-to-npm-from-ci-with-trusted-publishing-not-a-token-or-a-security-key.md) | Publish to npm from CI with trusted publishing, not a token or a security key | Accepted |
 
 ## Authentication
 _OAuth, credential management, multi-account_

--- a/docs/architecture/core/ADR-105-publish-to-npm-from-ci-with-trusted-publishing-not-a-token-or-a-security-key.md
+++ b/docs/architecture/core/ADR-105-publish-to-npm-from-ci-with-trusted-publishing-not-a-token-or-a-security-key.md
@@ -1,0 +1,112 @@
+---
+status: Proposed
+date: 2026-08-17
+deciders:
+  - aaronsb
+related: []
+---
+
+# ADR-105: Publish to npm from CI with trusted publishing, not a token or a security key
+
+## Context
+
+Commit `2c5669c` (2026-07-12) deleted `.github/workflows/npm-publish.yml` and moved
+publishing into `make publish-all`, run by hand. Its reasoning was sound and is quoted
+here because this ADR reverses only half of it:
+
+> The workflow published to npm from a long-lived NPM_TOKEN. The token expired in June and
+> the job has failed on three consecutive releases — v3.0.0, v4.0.0, v4.0.1 — while the
+> manual `make publish-all` did the actual publishing each time.
+>
+> A workflow that is always red is worse than no workflow … And the token itself is a
+> liability — it can publish the package at any time, from anywhere, with no human present.
+
+Both objections are about the **token**, not about CI. A stored `NPM_TOKEN` expires
+silently, is replayable by anyone who obtains it, and grants publish rights unbounded by
+time, repository, or workflow.
+
+The arrangement that replaced it has its own cost, and v4.3.0 measured it:
+
+- 2026-08-16: the release was written, reviewed and merged, then held unreleased overnight
+  because the maintainer was not near the security key.
+- 2026-08-17: two publish attempts failed before reaching any code. `make publish-all` read
+  EOF from `read -p` in a non-tty and recorded it as a declined confirmation; the retry
+  cleared that prompt and then died on `npm error code EOTP`, npm asking for a browser
+  round trip it had no terminal to hand off to.
+
+Neither failure was about the package. Both were about requiring a human, a browser and a
+tty at the moment of publish.
+
+npm's **trusted publishing** removes the token without restoring the liability. GitHub
+Actions presents an OIDC identity, npm verifies it against a publisher the package owner
+registered, and mints a credential that is short-lived and scoped to one workflow file in
+one repository. There is no secret in the repository, nothing to expire, and nothing to
+rotate. A stolen credential is worthless off that workflow.
+
+The trusted publisher for `@aaronsb/google-workspace-mcp` is already registered on
+npmjs.com, naming `npm-publish.yml`. Only the workflow file is missing.
+
+## Decision
+
+Publish the npm package from CI on tag push, authenticated by GitHub OIDC.
+
+1. Restore `.github/workflows/npm-publish.yml` at exactly that filename — the registered
+   trusted publisher names the file, so renaming it silently breaks authentication.
+2. Authenticate by OIDC alone. No `NODE_AUTH_TOKEN`, no `secrets.NPM_TOKEN`, and no
+   `registry-url:` on `setup-node` (which exists to write a token into `.npmrc`).
+3. Upgrade npm in the job before publishing. Trusted publishing requires npm >= 11.5.1 and
+   Node 22 ships npm 10.x, so without this step the job authenticates the old way and fails.
+4. Keep `--provenance`, which the deleted workflow already passed, and keep its dist-tag
+   derivation so a pre-release cannot land on `latest`.
+5. Run the gates in the job. The tag is not a promise that anything was checked.
+6. Make `make publish-all` skip a version already on the registry rather than fail on it,
+   so the manual path stays usable as a fallback without colliding with CI.
+
+`make publish-all` is retained. It is the path when npm's OIDC is unavailable or a publish
+must happen off a tag, and it is the only path for the MCP Registry until that half is
+converted too.
+
+## Consequences
+
+### Positive
+
+- A release no longer waits on one person holding one piece of hardware.
+- No publish secret exists in the repository or in GitHub, so none can expire mid-release
+  or leak. The failure that produced three consecutive red releases cannot recur in this
+  form.
+- Publishing runs the gates on the tagged commit, in a clean checkout, rather than from a
+  working tree that merely resembles it.
+- `--provenance` becomes reliable rather than dependent on the manual path being used.
+
+### Negative
+
+- Tag push now publishes to npm. Tagging was already a partial publish — it creates the
+  GitHub Release and uploads the bundle — and this widens it to the irreversible half, since
+  an npm version cannot be republished. The tag becomes the point of no return.
+- Authentication now depends on registry-side configuration that lives outside this repo and
+  is invisible to it. A trusted publisher edited or removed on npmjs.com breaks releases with
+  nothing in the codebase to show why. The workflow filename is load-bearing for the same
+  reason.
+- Two publish paths exist, and they can disagree about what has already shipped.
+
+### Neutral
+
+- The MCP Registry step still runs from `make publish-all` and still needs a human. This ADR
+  does not convert it.
+- The workflow must stay on a Node whose npm satisfies the trusted-publishing floor, which is
+  a second version coupling in CI alongside `engines-floor`.
+
+## Alternatives Considered
+
+- **Keep publishing by hand.** Rejected: it is what produced the v4.3.0 delay and both
+  failed attempts. The security-key ceremony protects against a stolen token, and under
+  trusted publishing there is no token to steal.
+- **A fresh long-lived NPM_TOKEN.** Rejected for the reasons in `2c5669c`, which have not
+  changed: it expires silently, and it publishes from anywhere with no human present.
+- **A granular token with a short expiry.** Rejected: it narrows the blast radius without
+  removing the secret, and a token that expires on a schedule fails on whichever release
+  happens to follow the expiry — the exact v3.0.0/v4.0.0/v4.0.1 failure, on a timer.
+- **Publish from CI on a manual `workflow_dispatch` instead of on tag.** Rejected: it keeps
+  a human in the loop for scheduling while removing them from the security decision, which
+  is the opposite of the split that matters. A dispatched run also uses the workflow file
+  from the dispatched ref, so it cannot publish a tag cut before the workflow existed.

--- a/docs/architecture/core/ADR-105-publish-to-npm-from-ci-with-trusted-publishing-not-a-token-or-a-security-key.md
+++ b/docs/architecture/core/ADR-105-publish-to-npm-from-ci-with-trusted-publishing-not-a-token-or-a-security-key.md
@@ -1,5 +1,5 @@
 ---
-status: Proposed
+status: Accepted
 date: 2026-08-17
 deciders:
   - aaronsb


### PR DESCRIPTION
## Description

Restores `.github/workflows/npm-publish.yml` so npm publishing happens in CI on tag push, authenticated by GitHub OIDC instead of a stored token. Decision recorded in **ADR-105**.

`2c5669c` deleted that workflow in July, and it was right about the **token**: a long-lived `NPM_TOKEN` expired silently in June and failed three consecutive releases (v3.0.0, v4.0.0, v4.0.1), and it could publish from anywhere with no human present. Trusted publishing removes the token without restoring the liability — GitHub mints a short-lived credential scoped to one workflow file in one repository. No secret in the repo, nothing to expire or rotate, and worthless off that workflow.

The trusted publisher is already registered on npmjs.com naming `npm-publish.yml`, so the workflow file was the only missing half.

### What the manual path cost, measured on v4.3.0

- **2026-08-16** — merged, notes written, then held unreleased overnight because the maintainer was not near the security key.
- **2026-08-17** — two publish attempts failed *before reaching any code*: `read -p` took EOF in a non-tty as a declined confirmation, and the retry died on `npm error code EOTP`, npm wanting a browser round trip with no terminal to hand off to.

Neither failure was about the package.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## What's here

**`.github/workflows/npm-publish.yml`** (new)
- **The filename is load-bearing** — npm registers the publisher against repo + workflow filename. Renaming it breaks auth with nothing in the repo to explain why. Called out in a comment at the top.
- No `NODE_AUTH_TOKEN`, no `secrets.NPM_TOKEN`, no `registry-url:` on `setup-node` (that input exists to write a token into `.npmrc`, which is what this replaces).
- Upgrades npm and asserts **>= 11.5.1**. Node 22 ships npm 10.x, which predates trusted publishing and would fail with a 401 that says nothing about OIDC.
- Runs test, type-check and build **on the tagged commit**. A tag is not evidence anything was checked.
- Refuses to publish when the tag and `package.json` name different versions.
- Re-running on an already-published version is a no-op, not a red X on a release that succeeded.
- Keeps `--provenance` and the dist-tag derivation, so a pre-release cannot land on `latest`.

**`Makefile`**
- `publish-all` now **skips** an npm version already on the registry. Publishing over one exits 403, which would abort the target before the MCP Registry step — the half CI does *not* do.
- Adds `YES=1` to bypass the two `read -p` prompts. Those reads were the only part needing a tty, so without it the target is unrunnable from anywhere lacking one, and EOF reads as "no" — aborting a publish nobody declined. It does not remove the confirmation, it moves it to the command line.
- `NOTES=` supplies the one-line release note non-interactively; empty preserves existing notes.

## Testing Performed

- [x] Both workflow files parse as YAML.
- [x] `make -n publish-all YES=1` — both prompts resolve to the bypass branch; `[ -n "1" ]` substitutes correctly.
- [x] Already-published detection exercised against the live registry: `4.2.1 -> skip`, `4.3.0 -> publish`.
- [x] `adr lint` — 0 errors, 0 warnings. `adr index -y` regenerated.
- [x] `make check` green (897 tests) before the branch was cut.

**Not yet exercised: the OIDC publish itself.** It cannot run until this is merged and a tag pushed, since a workflow only runs from a ref where it exists. v4.3.0 is tagged but not on npm, so merging this and moving the tag is the first real test.

## Security Considerations

- [x] Removes a credential class rather than adding one — no publish secret exists in the repo or in GitHub after this.
- [x] `permissions:` is minimal: `contents: read`, `id-token: write`.
- [x] The credential is short-lived and bound to this workflow in this repository.
- [x] **New external dependency, called out in ADR-105:** authentication now relies on registry-side configuration that lives outside this repo and is invisible to it. A trusted publisher edited or removed on npmjs.com breaks releases with nothing in the codebase to show why.
- [x] **Tag push is now fully irreversible.** It already created the GitHub Release and uploaded the bundle; it now also publishes to npm, which cannot be republished.

## Additional Notes

The MCP Registry step still runs from `make publish-all` and still needs a human. ADR-105 does not convert it — worth a follow-up, since `mcp-publisher` has a GitHub OIDC login for the same reason.

CHANGELOG is not updated: this repo tracks releases in `RELEASE-NOTES-v*.md`, and this is tooling rather than a shipped change.
