### PR TITLE
feat(release): publish the MCP Registry from CI by OIDC, and modernise the actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v7
+    - uses: actions/setup-node@v7
       with:
-        node-version: '22'
+        node-version: '24'
         cache: 'npm'
     - run: npm ci
     # Every test file must be run by some gate. `npm test` uses an allowlist of
@@ -32,10 +32,10 @@ jobs:
     # ts-jest used to cover this on every `npm test`; nothing else does now.
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v7
+    - uses: actions/setup-node@v7
       with:
-        node-version: '22'
+        node-version: '24'
         cache: 'npm'
     - run: npm ci
     - run: npm run type-check
@@ -43,10 +43,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v7
+    - uses: actions/setup-node@v7
       with:
-        node-version: '22'
+        node-version: '24'
         cache: 'npm'
     - run: npm ci
     - run: npm run build
@@ -70,14 +70,14 @@ jobs:
     # installs, and all a consumer gets.
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v7
+    - uses: actions/setup-node@v7
       with:
-        node-version: '22'
+        node-version: '24'
         cache: 'npm'
     - run: npm ci
     - run: npm run build
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v7
       with:
         node-version: '22.12.0'   # == engines.node in package.json. Keep in sync.
     - run: rm -rf node_modules && npm ci --omit=dev
@@ -101,14 +101,14 @@ jobs:
     # protects the dynamic import.
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v7
+    - uses: actions/setup-node@v7
       with:
-        node-version: '22'
+        node-version: '24'
         cache: 'npm'
     - run: npm ci
     - run: npm run build
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v7
       with:
         node-version: '20.19.0'   # deliberately BELOW the floor — that is the point
     - run: rm -rf node_modules && npm ci --omit=dev
@@ -129,10 +129,10 @@ jobs:
     # never the one under test. Verified to fail against the pre-fix entrypoint.
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v7
+    - uses: actions/setup-node@v7
       with:
-        node-version: '22'
+        node-version: '24'
         cache: 'npm'
     - run: npm ci
     - run: npm run build
@@ -141,10 +141,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v7
+    - uses: actions/setup-node@v7
       with:
-        node-version: '22'
+        node-version: '24'
         cache: 'npm'
     - run: npm ci
     - run: npm run lint

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,6 +1,7 @@
-# Publish to npm with trusted publishing (OIDC). See ADR-105.
+# Publish to npm and the MCP Registry, both by OIDC. See ADR-105.
 #
-# THE FILENAME IS LOAD-BEARING. npmjs.com registers a trusted publisher against a
+# THE FILENAME IS LOAD-BEARING, and is why a file that now publishes two channels is
+# still called npm-publish.yml. npmjs.com registers a trusted publisher against a
 # repository AND a workflow filename; this file is registered as `npm-publish.yml`.
 # Rename or move it and npm stops recognising the identity, with nothing in this repo
 # to explain why.
@@ -10,7 +11,13 @@
 # replaces. An earlier version of this workflow published from a long-lived token; it
 # expired in June 2026 and failed three consecutive releases (v3.0.0, v4.0.0, v4.0.1)
 # before being deleted in 2c5669c. OIDC has no secret to expire.
-name: Publish to npm
+#
+# The two channels differ in how the identity is granted. npm matches a publisher the
+# package owner registered on npmjs.com. The MCP Registry reads the `repository_owner`
+# claim out of the OIDC token and grants `io.github.<owner>/*` from that alone — so it
+# needs no registry-side configuration, and equally offers no registry-side protection
+# if this repository's owner ever changes.
+name: Publish to npm and the MCP Registry
 
 on:
   push:
@@ -24,16 +31,19 @@ jobs:
       contents: read
       id-token: write   # mints the OIDC token npm verifies. Without it, publish is unauthenticated.
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
 
-      # Node 22 ships npm 10.x, which predates trusted publishing entirely — it would
-      # look for a token, find none, and fail with a 401 that says nothing about OIDC.
+      # Node 24 ships an npm 11.x that is usually new enough, and Node 22 shipped npm 10.x
+      # which is not. Neither is a promise: the bundled npm moves with the Node patch the
+      # runner happens to have. An npm below the floor does not report a missing feature —
+      # it looks for a token, finds none, and fails with a 401 that says nothing about OIDC.
+      # So upgrade, then assert, rather than trusting what the image came with.
       - name: Upgrade npm past the trusted-publishing floor
         run: |
           npm install -g npm@latest
@@ -102,3 +112,69 @@ jobs:
             exit 0
           fi
           npm publish --provenance --access public --tag "${{ steps.npm-tag.outputs.tag }}"
+
+  mcp-registry:
+    name: Publish to the MCP Registry
+    runs-on: ubuntu-latest
+    # server.json advertises the npm package AT THIS VERSION, so publishing the registry
+    # entry first would point people at a tarball that does not exist yet. `needs` is the
+    # ordering; it is not decoration.
+    needs: publish
+    permissions:
+      contents: read
+      id-token: write   # same OIDC token as the npm job; mcp-publisher reads it from the runner
+    steps:
+      - uses: actions/checkout@v7
+
+      # Pinned deliberately. This runs on tag push, where a surprise upstream change
+      # breaks a release at the worst possible moment and there is no green build to
+      # compare against. Bump it on purpose, not by drifting onto `latest`.
+      - name: Install mcp-publisher
+        env:
+          MCP_PUBLISHER_VERSION: '1.8.1'
+        run: |
+          curl -fsSL -o mcp-publisher.tar.gz \
+            "https://github.com/modelcontextprotocol/registry/releases/download/v${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz"
+          tar -xzf mcp-publisher.tar.gz mcp-publisher
+          ./mcp-publisher --version
+
+      # server.json carries the version TWICE — once for the server entry and once for the
+      # npm package it points at — and `make version-sync` writes only what it knows about.
+      # A mismatch here publishes a registry entry naming the wrong tarball, which no
+      # amount of npm-side checking would catch.
+      - name: Check server.json agrees with the tag
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          SERVER_VERSION=$(node -p "require('./server.json').version")
+          PKG_VERSION=$(node -p "require('./server.json').packages[0].version")
+          fail=0
+          [ "$SERVER_VERSION" = "$TAG_VERSION" ] || { echo "server.json version is $SERVER_VERSION, tag says $TAG_VERSION"; fail=1; }
+          [ "$PKG_VERSION" = "$TAG_VERSION" ] || { echo "server.json packages[0].version is $PKG_VERSION, tag says $TAG_VERSION"; fail=1; }
+          [ "$fail" = 0 ] || { echo "Run 'make version-sync' and commit the result."; exit 1; }
+          echo "server.json and its npm package both say $TAG_VERSION"
+
+      - name: Authenticate by GitHub OIDC
+        # No secret. The registry validates the token's issuer and audience, then grants
+        # io.github.<repository_owner>/* from the `repository_owner` claim.
+        run: ./mcp-publisher login github-oidc
+
+      # Same reasoning as the npm step: a re-run on an already-published version must be a
+      # no-op rather than a red X on a release that already succeeded.
+      - name: Publish to the MCP Registry
+        run: |
+          NAME=$(node -p "require('./server.json').name")
+          VERSION="${GITHUB_REF_NAME#v}"
+          published=$(curl -fsSL "https://registry.modelcontextprotocol.io/v0/servers?search=${NAME}&limit=100" \
+            | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{
+                const j=JSON.parse(s);
+                const vs=(j.servers||[]).map(x=>x.version||(x.server&&x.server.version)).filter(Boolean);
+                console.log(vs.join(" "));
+              })')
+          echo "already on the registry: ${published:-<none>}"
+          for v in $published; do
+            if [ "$v" = "$VERSION" ]; then
+              echo "$NAME $VERSION is already published — nothing to do."
+              exit 0
+            fi
+          done
+          ./mcp-publisher publish server.json

--- a/.github/workflows/release-mcpb.yml
+++ b/.github/workflows/release-mcpb.yml
@@ -18,12 +18,12 @@ jobs:
     permissions:
       contents: write  # needed for gh release upload
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies

--- a/Makefile
+++ b/Makefile
@@ -258,8 +258,18 @@ publish-all: check-release-tag mcpb ## Publish to npm, MCP Registry, GitHub Rele
 	fi
 	@echo ""
 	@echo "── MCP Registry ──"
-	mcp-publisher login github
-	mcp-publisher publish server.json
+	@# npm-publish.yml publishes this on tag push too (ADR-105), so skip a version already
+	@# there — same reasoning as the npm step above. `mcp-publisher login github` is a
+	@# device flow needing a tty, so the skip also keeps this target runnable without one
+	@# when the registry is already current.
+	@name=$$(node -p "require('./server.json').name"); \
+	published=$$(curl -fsSL "https://registry.modelcontextprotocol.io/v0/servers?search=$$name&limit=100" 2>/dev/null \
+	  | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{const j=JSON.parse(s);console.log((j.servers||[]).map(x=>x.version||(x.server&&x.server.version)).filter(Boolean).join(" "))}catch(e){console.log("")}})'); \
+	if echo " $$published " | grep -q " $(VERSION) "; then \
+	  echo "mcp: $$name $(VERSION) is already on the registry — skipping"; \
+	else \
+	  mcp-publisher login github && mcp-publisher publish server.json; \
+	fi
 	@echo ""
 	@echo "── GitHub Release ──"
 	@# RECONCILE, not create. The tag push already triggered release-mcpb.yml, which

--- a/docs/architecture/core/ADR-105-publish-to-npm-from-ci-with-trusted-publishing-not-a-token-or-a-security-key.md
+++ b/docs/architecture/core/ADR-105-publish-to-npm-from-ci-with-trusted-publishing-not-a-token-or-a-security-key.md
@@ -96,6 +96,31 @@ converted too.
 - The workflow must stay on a Node whose npm satisfies the trusted-publishing floor, which is
   a second version coupling in CI alongside `engines-floor`.
 
+## Update — 2026-08-17: the MCP Registry half also converted
+
+Written above: *"The MCP Registry step still runs from `make publish-all` and still needs a
+human. This ADR does not convert it."* It does now, in the same workflow file, as a second
+job gated on the npm job by `needs:`.
+
+Two things settled it. `mcp-publisher` already ships a `github-oidc` login mode, and the
+registry derives authority differently from npm: it reads the `repository_owner` claim out
+of the OIDC token and grants `io.github.<owner>/*` from that alone. No registry-side
+configuration exists to set up — and equally, none exists to protect the namespace if this
+repository's owner ever changes.
+
+The evidence that the manual step was worth removing was already on the registry: it held
+2.7.1, 3.0.0, 4.0.0, 4.0.1, 4.2.0 and 4.2.1 — **v4.1.0 was skipped entirely and nothing
+noticed**, because the step depended on someone remembering it. That is the same argument
+this ADR made about the expired token, arriving by a different route.
+
+Ordering is load-bearing: `server.json` advertises the npm package at the version being
+released, so publishing the registry entry before npm would point people at a tarball that
+does not exist. The registry job also asserts `server.json`'s two version fields against the
+tag, since `version-sync` writing them and the tag naming them are separate facts.
+
+`make publish-all` remains the fallback for both channels, and its registry step now skips a
+version already published, matching what its npm step does.
+
 ## Alternatives Considered
 
 - **Keep publishing by hand.** Rejected: it is what produced the v4.3.0 delay and both


### PR DESCRIPTION
## Description

Completes the follow-up **ADR-105** named for itself: the MCP Registry now publishes from CI by GitHub OIDC, alongside npm. Recorded as a dated Update section in ADR-105 rather than by editing its original reasoning.

`mcp-publisher` already ships a `github-oidc` login mode, and the registry grants authority differently from npm — it reads the `repository_owner` claim out of the OIDC token and grants `io.github.<owner>/*` from that alone (verified in the registry's own `internal/api/handlers/v0/auth/github_oidc.go`). So there is **no registry-side setup** to do, and equally **no registry-side protection** if this repo's owner ever changes.

### Why this was worth doing

The evidence was already public on the registry: it held 2.7.1, 3.0.0, 4.0.0, 4.0.1, 4.2.0, 4.2.1 — **v4.1.0 was skipped entirely and nothing noticed.** A release step that depends on someone remembering it eventually doesn't happen. Same argument ADR-105 made about the expired token, arriving by a different route.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## What's here

**Registry job in `npm-publish.yml`** — a second job, not a second file. The filename is pinned by npm's trusted publisher, and the two jobs need `needs:` ordering regardless.

- **The ordering is load-bearing.** `server.json` advertises the npm package *at the version being released*, so publishing the registry entry first points people at a tarball that doesn't exist yet.
- Asserts `server.json`'s **two** version fields against the tag. `version-sync` writing them and the tag naming them are separate facts; a mismatch publishes an entry pointing at the wrong tarball, which no npm-side check would catch.
- Skips a version already on the registry — a re-run is a no-op, not a red X on a release that succeeded.
- Pins `mcp-publisher` 1.8.1. This runs on tag push, where drifting onto `latest` breaks a release at the worst moment with no green build to compare against.

**`Makefile`** — `publish-all`'s registry step now skips an already-published version, matching what its npm step does. That also keeps the target runnable without a tty when the registry is already current, since `mcp-publisher login github` is a device flow.

**Action upgrades**, prompted by the deprecation warning on the v4.3.0 publish run:

- `actions/checkout` and `actions/setup-node` v4 → **v7**. They were three majors behind and still targeting the retired Node 20 runtime.
- Build/test jobs move to **Node 24**.
- **Two pinned versions deliberately untouched:** `22.12.0` in `engines-floor` because it must equal `engines.node`, and `20.19.0` in `engines-floor-reject` because being below the floor is that job's entire point.
- The npm-floor assertion stays rather than trusting Node 24's bundled npm — the bundled version moves with whatever patch the runner image has, and an npm below 11.5.1 fails with a 401 that says nothing about OIDC.

## Testing Performed

- [x] `make check` green — 897 tests, build, smoke-start, smoke-orphan.
- [x] All three workflow files parse as YAML; job graph verified (`mcp-registry` `needs: publish`, both with `id-token: write`).
- [x] Registry skip logic run against the **live** registry: `4.3.0 -> skip`, `4.3.2 -> publish`.
- [x] Confirmed `version-sync.cjs:18` writes `packages[].version`, so the new assertion holds after a sync rather than blocking releases.
- [x] `adr lint` — 0 errors, 0 warnings.

**Not yet exercised: the OIDC registry publish itself**, for the same reason as #168 — it can only run from a tag pushed at a ref where the job exists. The v4.3.2 release is its first real test. The action upgrades are exercised by this PR's own CI run.

## Security Considerations

- [x] No secret added; `permissions:` on the new job is `contents: read` + `id-token: write`.
- [x] `mcp-publisher` pinned to a known version rather than fetched from a moving target.
- [x] Namespace authority derives from the `repository_owner` claim, which is called out in both the workflow comment and ADR-105 as having no registry-side guard.

## Additional Notes

v4.1.0 is still missing from the registry. Deliberately not backfilled here — worth deciding on separately.