### PR TITLE
feat(auth): refuse writes from read-only accounts at call time (ADR-202)

### DIFF
--- a/docs/architecture/auth/ADR-202-per-account-access-level-enforced-at-call-time.md
+++ b/docs/architecture/auth/ADR-202-per-account-access-level-enforced-at-call-time.md
@@ -108,7 +108,15 @@ green while the server stopped enforcing anything.
 several calls — and six of the seven are writes (`gmail.send`, `reply`, `replyAll`,
 `forward`, `drive.upload`, `calendar.create`). Enforcing only where the descriptor has an
 entry would exempt exactly the operations most worth enforcing, so those fall back to the
-manifest's `type`, which the existing test already pins against `httpMethod`.
+manifest's `type`.
+
+That fallback was initially justified by saying the existing `type`-vs-`httpMethod` test
+already pins `type`. **It does not** — that test skips any operation with no descriptor
+method, which is these seven exactly, so `type` was unpinned precisely where it had become
+the sole enforcement input. Retyping `gmail.send` to `list` would have disabled
+enforcement for send, reply, replyAll and forward with the whole suite green. A second
+test now pins the resource-less set and their declared types by equality, so an eighth
+forces a decision instead of defaulting to unenforced.
 
 **Write scopes are the read/write set minus the read-only set,** not the read/write set.
 `contacts` and `meet` both carry read-only scopes *inside* their read/write set because
@@ -126,6 +134,31 @@ The policy **fails open** on every uncertainty: no credential, unreadable creden
 scopes, no manifest info, unknown method. A safety check that blocks on its own doubt is
 an outage, and each of these reaches Google, which refuses it independently if it should
 be refused.
+
+**The policy covers factory-generated handlers only, and that is not everything.** Code
+review found `manage_scratchpad` writing to Google outside this layer entirely: its send
+and sync adapters call `tasks.insert`, `events.insert`, `documents.create`,
+`documents.batchUpdate`, `spreadsheets.values.update` and `sendMail` directly, because the
+tool is hand-registered rather than generated. So a read-only account is refused
+`manage_docs write` with the sentence above and then writes the same content to the same
+document through `manage_scratchpad send` — getting the raw 403 this ADR exists to
+replace. The token is genuinely narrow, so Google still refuses; what leaks is the
+explanation.
+
+The sharper half of the same gap does not have Google as a backstop: under
+`GWS_SAFETY_POLICY=draft-only-email`, an ordinary read/write account can still send mail
+through `manage_scratchpad`, and Google accepts it, because the token is legitimately
+broad. That bypass predates this ADR and is not created by it — but this ADR is what makes
+the layer load-bearing by default, so it is recorded here rather than left implicit.
+Tracked as its own issue.
+
+**Access is per service, and services overlap.** Docs and Sheets write methods list
+`drive` among the scopes Google accepts — `documents.batchUpdate` takes
+`documents|drive|drive.file`. Because the check intersects against everything granted, an
+account authorized `drive` read/write *and* `docs` read-only may write documents. Google
+permits it, so the policy is right to; "read-only for docs" is nevertheless not honoured
+in that configuration. Per-service is the smallest unit Google sells, so this follows from
+the design rather than from the implementation.
 
 Still open: `confirmWriteAccess: true` can be sent on the first call, skipping the warning
 entirely, since nothing server-side remembers having warned. Note also that the gate is

--- a/docs/architecture/auth/ADR-202-per-account-access-level-enforced-at-call-time.md
+++ b/docs/architecture/auth/ADR-202-per-account-access-level-enforced-at-call-time.md
@@ -93,6 +93,46 @@ The manifest's `type:` is the declared intent; the descriptor's `httpMethod` and
 - **Enforce only at the token.** Simplest — let Google reject the call. Rejected because the agent gets a 403 with no idea which account, which scope, or how to fix it, and because the failure arrives after the request has left.
 - **Per-operation access levels.** More precise than per-service, and not something Google sells: its scopes cover whole services, so per-operation limits would be enforced entirely by us while the token stayed broad. The gap between what the token permits and what we enforce is exactly where a bypass lives.
 
+## Update — 2026-08-17: the call-time policy landed
+
+Four things the design above left open, settled by building it.
+
+**The policy is always on.** Every other policy in `src/factory/safety.ts` is an operator
+opt-in through `GWS_SAFETY_POLICY`. This one is not, because it enforces a choice the
+*user* already made at consent time — requiring a second opt-in to honour the first would
+make the first decorative. It is a no-op for read/write accounts, which is every account
+by default. A test pins the wiring, since deleting it would leave the policy's own tests
+green while the server stopped enforcing anything.
+
+**Seven of 95 operations have no `resource`,** because they are custom handlers that make
+several calls — and six of the seven are writes (`gmail.send`, `reply`, `replyAll`,
+`forward`, `drive.upload`, `calendar.create`). Enforcing only where the descriptor has an
+entry would exempt exactly the operations most worth enforcing, so those fall back to the
+manifest's `type`, which the existing test already pins against `httpMethod`.
+
+**Write scopes are the read/write set minus the read-only set,** not the read/write set.
+`contacts` and `meet` both carry read-only scopes *inside* their read/write set because
+the service needs them at either level. Without the subtraction, a read-only contacts
+account holding `directory.readonly` intersects `SERVICE_SCOPE_MAP.contacts` and a write
+is permitted. Found by writing the test, not by reading the code.
+
+**Measured, and it vindicates deriving from the descriptor:** across every action-typed
+operation, exactly one is satisfiable by a read-only token — `drive.export`, which is a
+GET the manifest labels an action. Google accepts `drive.readonly` for `files.export`, so
+allowing it is correct. A hand-kept list of write operations would have refused a read the
+token genuinely permits.
+
+The policy **fails open** on every uncertainty: no credential, unreadable credential, no
+scopes, no manifest info, unknown method. A safety check that blocks on its own doubt is
+an outage, and each of these reaches Google, which refuses it independently if it should
+be refused.
+
+Still open: `confirmWriteAccess: true` can be sent on the first call, skipping the warning
+entirely, since nothing server-side remembers having warned. Note also that the gate is
+currently unreachable from any real input — every service in the map now has a read-only
+scope, `meet` included via `meetings.space.readonly`. It guards the first service added
+without one.
+
 ## Notes
 
 Issue #130 proposed the consent half of this and its author offered a working branch. This ADR extends that proposal with the call-time half, which the tool-surface constraint forces. Credit for the original proposal and the `SERVICE_SCOPE_MAP_READONLY` shape is theirs.

--- a/src/__tests__/factory/account-access.test.ts
+++ b/src/__tests__/factory/account-access.test.ts
@@ -9,6 +9,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const readCredential = vi.hoisted(() => vi.fn());
 vi.mock('../../accounts/credentials.js', () => ({ readCredential }));
+vi.mock('../../google/client.js');
 
 const { configurePolicies, evaluatePolicies, accountAccess } = await import('../../factory/safety.js');
 const { SERVICE_SCOPE_MAP, SERVICE_SCOPE_MAP_READONLY, writeScopesFor, anyScopesFor } =
@@ -188,5 +189,85 @@ describe('writeScopesFor', () => {
   it('returns an empty list for a service that does not exist', async () => {
     expect(writeScopesFor('nonesuch')).toEqual([]);
     expect(anyScopesFor('nonesuch')).toEqual([]);
+  });
+});
+
+/**
+ * The wiring, not the policy.
+ *
+ * Everything above calls `evaluatePolicies` directly, so all of it stays green if the
+ * generator stops passing the service name — and then the policy is inert for all 95
+ * operations, because `op` arrives undefined and the first line allows. That is the same
+ * hole the server-side wiring test closes one layer up.
+ */
+describe('the generated handler actually consults the policy', () => {
+  it('blocks a write, names the manifest service, and never reaches Google', async () => {
+    const { loadManifest, generateHandler } = await import('../../factory/generator.js');
+    const { patches } = await import('../../factory/patches.js');
+    const { call } = await import('../../google/client.js');
+    const mockCall = vi.mocked(call);
+
+    grant(['contacts'], 'read');
+    const handler = generateHandler(loadManifest().services.contacts, patches.contacts, 'contacts');
+
+    const result = await handler({ operation: 'create', email: ACCOUNT, name: 'Ada Lovelace' });
+
+    expect(result.text).toContain('Blocked by safety policy');
+    expect(result.text).toContain(`services:'contacts'`);
+    // `people` is the Google API name. It must never appear in a remedy the user is
+    // expected to type, and it is what a plausible wrong wiring would produce.
+    expect(result.text).not.toContain(`services:'people'`);
+    expect(mockCall).not.toHaveBeenCalled();
+  });
+
+  // Through generateTools, not generateHandler. The test above passes the service name
+  // itself, so it survives generateTools dropping the argument — which is the one-line
+  // edit that makes the policy inert for all 95 operations.
+  it('survives the trip through generateTools', async () => {
+    const { loadManifest, generateTools } = await import('../../factory/generator.js');
+    const { patches } = await import('../../factory/patches.js');
+
+    grant(['contacts'], 'read');
+    const tool = generateTools(loadManifest(), patches).find((t) => t.schema.name === 'manage_contacts');
+    const result = await tool!.handler({ operation: 'create', email: ACCOUNT, name: 'Ada Lovelace' });
+
+    expect(result.text).toContain('Blocked by safety policy');
+    expect(result.text).toContain(`services:'contacts'`);
+  });
+
+  it('lets the same write through for a read/write account', async () => {
+    const { loadManifest, generateHandler } = await import('../../factory/generator.js');
+    const { patches } = await import('../../factory/patches.js');
+    const { call } = await import('../../google/client.js');
+    const mockCall = vi.mocked(call);
+    mockCall.mockResolvedValue({ resourceName: 'people/c1', etag: 'e' } as never);
+
+    grant(['contacts'], 'readwrite');
+    const handler = generateHandler(loadManifest().services.contacts, patches.contacts, 'contacts');
+
+    const result = await handler({ operation: 'create', email: ACCOUNT, name: 'Ada Lovelace' });
+
+    expect(result.text).not.toContain('Blocked by safety policy');
+    expect(mockCall).toHaveBeenCalled();
+  });
+});
+
+describe('every manifest service is in the scope map', () => {
+  // Without this, a new service added to the manifest but not to SERVICE_SCOPE_MAP gets
+  // writeScopesFor() === [] -> required.length === 0 -> allow, for every one of its
+  // operations, silently. The existing oauth test uses arrayContaining, which passes when
+  // a key is missing, so nothing else catches it.
+  //
+  // It also fails the other way: a service authorized at consent time that the manifest
+  // cannot use is a scope requested for nothing.
+  it('and every scope-map service is in the manifest', async () => {
+    const { loadManifest } = await import('../../factory/generator.js');
+    const manifest = Object.keys(loadManifest().services).sort();
+    const mapped = Object.keys(SERVICE_SCOPE_MAP).sort();
+
+    // `slides` is mapped and has no manifest yet — presentations.batchUpdate is an open
+    // coverage gap (issue #151). Named here so adding it is a deliberate act.
+    expect(mapped.filter((s) => s !== 'slides')).toEqual(manifest);
+    expect(Object.keys(SERVICE_SCOPE_MAP_READONLY).sort()).toEqual(mapped);
   });
 });

--- a/src/__tests__/factory/account-access.test.ts
+++ b/src/__tests__/factory/account-access.test.ts
@@ -1,0 +1,192 @@
+/**
+ * The call-time half of ADR-202: a write from an account authorized read-only is refused
+ * here, with a sentence, instead of by Google with a 403.
+ *
+ * Scope strings are imported from the maps rather than written out, so a test cannot pass
+ * by agreeing with a URL that the source has since changed.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const readCredential = vi.hoisted(() => vi.fn());
+vi.mock('../../accounts/credentials.js', () => ({ readCredential }));
+
+const { configurePolicies, evaluatePolicies, accountAccess } = await import('../../factory/safety.js');
+const { SERVICE_SCOPE_MAP, SERVICE_SCOPE_MAP_READONLY, writeScopesFor, anyScopesFor } =
+  await import('../../accounts/oauth.js');
+type OperationInfo = Parameters<typeof accountAccess.evaluate>[3];
+
+const ACCOUNT = 'someone@example.com';
+const ctx = (operation: string) => ({ operation, params: {}, account: ACCOUNT });
+
+/** The account holds exactly these services' scopes, at the given level. */
+function grant(services: string[], level: 'read' | 'readwrite'): void {
+  const map = level === 'read' ? SERVICE_SCOPE_MAP_READONLY : SERVICE_SCOPE_MAP;
+  readCredential.mockResolvedValue({ scopes: services.flatMap((s) => map[s] ?? []) });
+}
+
+const op = (o: Partial<OperationInfo> & Pick<NonNullable<OperationInfo>, 'service' | 'type'>) =>
+  ({ googleService: o.service, ...o }) as OperationInfo;
+
+beforeEach(() => configurePolicies([accountAccess]));
+afterEach(() => {
+  configurePolicies([]);
+  readCredential.mockReset();
+});
+
+describe('a read/write account', () => {
+  it('is unaffected — the policy is a no-op for the default access level', async () => {
+    grant(['contacts'], 'readwrite');
+    const result = await evaluatePolicies([], ctx('create'), 'people',
+      op({ service: 'contacts', googleService: 'people', resource: 'people.createContact', type: 'action' }));
+    expect(result.action).toBe('allow');
+  });
+});
+
+describe('a read-only account', () => {
+  beforeEach(() => grant(['contacts'], 'read'));
+
+  it('may still read', async () => {
+    const result = await evaluatePolicies([], ctx('list'), 'people',
+      op({ service: 'contacts', googleService: 'people', resource: 'people.connections.list', type: 'list' }));
+    expect(result.action).toBe('allow');
+  });
+
+  it('is blocked from writing', async () => {
+    const result = await evaluatePolicies([], ctx('create'), 'people',
+      op({ service: 'contacts', googleService: 'people', resource: 'people.createContact', type: 'action' }));
+    expect(result.action).toBe('block');
+  });
+
+  it('is told the account, the service, and the exact way out', async () => {
+    const { reason } = await evaluatePolicies([], ctx('create'), 'people',
+      op({ service: 'contacts', googleService: 'people', resource: 'people.createContact', type: 'action' }));
+    expect(reason).toContain(ACCOUNT);
+    expect(reason).toContain('read-only');
+    // The remedy must name `contacts` — the manifest service the user would re-consent —
+    // never `people`, which is a Google API name they never typed and cannot use here.
+    expect(reason).toContain(`services:'contacts'`);
+    expect(reason).not.toContain(`services:'people'`);
+  });
+});
+
+describe('a service the account never authorized', () => {
+  it('is blocked, and says so rather than claiming read-only', async () => {
+    grant(['gmail'], 'readwrite');
+    const { action, reason } = await evaluatePolicies([], ctx('get'), 'drive',
+      op({ service: 'drive', resource: 'files.get', type: 'detail' }));
+    expect(action).toBe('block');
+    expect(reason).toContain('never authorized');
+    expect(reason).not.toContain('read-only');
+  });
+});
+
+describe('operations with no `resource` — the pure custom handlers', () => {
+  // Six of the seven are writes (gmail send/reply/replyAll/forward, drive upload,
+  // calendar create). Enforcing only where a resource exists would exempt exactly the
+  // operations most worth enforcing, so these fall back to the manifest `type`.
+  it('blocks a write from a read-only account', async () => {
+    grant(['gmail'], 'read');
+    const result = await evaluatePolicies([], ctx('send'), 'gmail',
+      op({ service: 'gmail', type: 'action' }));
+    expect(result.action).toBe('block');
+  });
+
+  it('allows a read from a read-only account', async () => {
+    grant(['calendar'], 'read');
+    const result = await evaluatePolicies([], ctx('agenda'), 'calendar',
+      op({ service: 'calendar', type: 'list' }));
+    expect(result.action).toBe('allow');
+  });
+
+  it('allows a write from a read/write account', async () => {
+    grant(['gmail'], 'readwrite');
+    const result = await evaluatePolicies([], ctx('send'), 'gmail',
+      op({ service: 'gmail', type: 'action' }));
+    expect(result.action).toBe('allow');
+  });
+});
+
+describe('what the descriptor says, not what the manifest guessed', () => {
+  // MEASURED across every action-typed operation: `drive.export` is the only one a
+  // read-only token satisfies, because it is a GET that the manifest labels an action.
+  // Google accepts drive.readonly for files.export, so refusing it would deny a read the
+  // token genuinely permits. Deriving from the descriptor gets this right for free; a
+  // hand-kept list of "write operations" would have got it wrong.
+  it('allows drive.export under read-only access, because Google does', async () => {
+    grant(['drive'], 'read');
+    const result = await evaluatePolicies([], ctx('export'), 'drive',
+      op({ service: 'drive', resource: 'files.export', type: 'action' }));
+    expect(result.action).toBe('allow');
+  });
+});
+
+describe('failing open', () => {
+  // A safety check that blocks on its own uncertainty is an outage. Every one of these
+  // reaches Google, which refuses it independently if it should be refused.
+  it('allows when the account has no credential', async () => {
+    readCredential.mockRejectedValue(new Error('no credential'));
+    const result = await evaluatePolicies([], ctx('create'), 'people',
+      op({ service: 'contacts', googleService: 'people', resource: 'people.createContact', type: 'action' }));
+    expect(result.action).toBe('allow');
+  });
+
+  it('allows when the credential lists no scopes at all', async () => {
+    readCredential.mockResolvedValue({ scopes: [] });
+    const result = await evaluatePolicies([], ctx('create'), 'people',
+      op({ service: 'contacts', googleService: 'people', resource: 'people.createContact', type: 'action' }));
+    expect(result.action).toBe('allow');
+  });
+
+  it('allows when the manifest gave no operation info', async () => {
+    grant(['contacts'], 'read');
+    const result = await evaluatePolicies([], ctx('create'), 'people');
+    expect(result.action).toBe('allow');
+  });
+
+  it('allows when there is no account to check', async () => {
+    grant(['contacts'], 'read');
+    const result = await evaluatePolicies([], { operation: 'create', params: {}, account: '' }, 'people',
+      op({ service: 'contacts', googleService: 'people', resource: 'people.createContact', type: 'action' }));
+    expect(result.action).toBe('allow');
+  });
+
+  it('allows when the resource is not in the descriptor', async () => {
+    grant(['contacts'], 'read');
+    const result = await evaluatePolicies([], ctx('create'), 'people',
+      op({ service: 'contacts', googleService: 'people', resource: 'people.noSuchMethod', type: 'action' }));
+    expect(result.action).toBe('allow');
+  });
+});
+
+describe('writeScopesFor', () => {
+  // The subtraction that makes the read-only case work at all. Two services carry
+  // read-only scopes INSIDE their read/write set because they need them either way, so
+  // treating the read/write set as "the write scopes" would find one of those on a
+  // read-only account and wave the write through.
+  it('excludes read-only scopes that also appear in the read/write set', async () => {
+    for (const service of ['contacts', 'meet']) {
+      const write = writeScopesFor(service);
+      for (const readonly of SERVICE_SCOPE_MAP_READONLY[service]) {
+        expect(write).not.toContain(readonly);
+      }
+      expect(write.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('leaves a service whose sets are disjoint unchanged', async () => {
+    expect(writeScopesFor('gmail')).toEqual(SERVICE_SCOPE_MAP.gmail);
+  });
+
+  it('never grants a write scope to any read-only grant', async () => {
+    // The property the block depends on, across every service at once.
+    for (const service of Object.keys(SERVICE_SCOPE_MAP)) {
+      const held = new Set(SERVICE_SCOPE_MAP_READONLY[service] ?? []);
+      expect(writeScopesFor(service).some((s) => held.has(s))).toBe(false);
+    }
+  });
+
+  it('returns an empty list for a service that does not exist', async () => {
+    expect(writeScopesFor('nonesuch')).toEqual([]);
+    expect(anyScopesFor('nonesuch')).toEqual([]);
+  });
+});

--- a/src/__tests__/factory/generator.test.ts
+++ b/src/__tests__/factory/generator.test.ts
@@ -106,6 +106,44 @@ describe('manifest type vs the HTTP verb Google uses', () => {
     expect(disagreements).toEqual([]);
   });
 
+  /**
+   * The operations the test above cannot check, pinned by hand — because `type` is their
+   * ONLY enforcement input.
+   *
+   * They declare no `resource`: each is a custom handler making several calls, so there is
+   * no single descriptor method to compare against and the loop above skips them on
+   * `if (!method) continue`. That skip lands precisely where the access policy has nothing
+   * else to go on (src/factory/safety.ts, requiredScopes), so `type: action` here is what
+   * stands between a read-only account and a send.
+   *
+   * Changing gmail.send to `type: list` would otherwise disable enforcement for
+   * send/reply/replyAll/forward with the whole suite still green.
+   */
+  const RESOURCE_LESS: Record<string, 'list' | 'detail' | 'action'> = {
+    'calendar.agenda': 'list',
+    'calendar.create': 'action',
+    'drive.upload': 'action',
+    'gmail.send': 'action',
+    'gmail.reply': 'action',
+    'gmail.replyAll': 'action',
+    'gmail.forward': 'action',
+  };
+
+  it('pins the type of every operation with no resource behind it', () => {
+    const manifest = loadManifest();
+    const found: Record<string, string> = {};
+
+    for (const [serviceName, service] of Object.entries(manifest.services)) {
+      for (const [opName, op] of Object.entries(service.operations)) {
+        if (!op.resource) found[`${serviceName}.${opName}`] = op.type;
+      }
+    }
+
+    // Equality, not containment. A NEW resource-less operation has to be added here
+    // deliberately — with its type stated — rather than defaulting to unenforced.
+    expect(found).toEqual(RESOURCE_LESS);
+  });
+
   it('keeps every exception real', async () => {
     // An exception left behind after its operation changed would quietly excuse a genuine
     // disagreement. Each one has to still be a disagreement.

--- a/src/__tests__/factory/safety.test.ts
+++ b/src/__tests__/factory/safety.test.ts
@@ -17,38 +17,38 @@ describe('draftOnlyEmail', () => {
   beforeAll(() => configurePolicies([draftOnlyEmail]));
   afterAll(() => configurePolicies([]));
 
-  it('blocks send', () => {
-    const result = evaluatePolicies([], ctx('send'), 'gmail');
+  it('blocks send', async () => {
+    const result = await evaluatePolicies([], ctx('send'), 'gmail');
     expect(result.action).toBe('block');
     expect(result.reason).toContain('draft-only');
   });
 
-  it('blocks reply', () => {
-    expect(evaluatePolicies([], ctx('reply'), 'gmail').action).toBe('block');
+  it('blocks reply', async () => {
+    expect((await evaluatePolicies([], ctx('reply'), 'gmail')).action).toBe('block');
   });
 
-  it('blocks replyAll', () => {
-    expect(evaluatePolicies([], ctx('replyAll'), 'gmail').action).toBe('block');
+  it('blocks replyAll', async () => {
+    expect((await evaluatePolicies([], ctx('replyAll'), 'gmail')).action).toBe('block');
   });
 
-  it('blocks forward', () => {
-    expect(evaluatePolicies([], ctx('forward'), 'gmail').action).toBe('block');
+  it('blocks forward', async () => {
+    expect((await evaluatePolicies([], ctx('forward'), 'gmail')).action).toBe('block');
   });
 
-  it('allows search', () => {
-    expect(evaluatePolicies([], ctx('search'), 'gmail').action).toBe('allow');
+  it('allows search', async () => {
+    expect((await evaluatePolicies([], ctx('search'), 'gmail')).action).toBe('allow');
   });
 
-  it('allows triage', () => {
-    expect(evaluatePolicies([], ctx('triage'), 'gmail').action).toBe('allow');
+  it('allows triage', async () => {
+    expect((await evaluatePolicies([], ctx('triage'), 'gmail')).action).toBe('allow');
   });
 
-  it('allows read', () => {
-    expect(evaluatePolicies([], ctx('read'), 'gmail').action).toBe('allow');
+  it('allows read', async () => {
+    expect((await evaluatePolicies([], ctx('read'), 'gmail')).action).toBe('allow');
   });
 
-  it('does not apply to other services', () => {
-    expect(evaluatePolicies([], ctx('delete'), 'drive').action).toBe('allow');
+  it('does not apply to other services', async () => {
+    expect((await evaluatePolicies([], ctx('delete'), 'drive')).action).toBe('allow');
   });
 });
 
@@ -56,30 +56,30 @@ describe('noDelete', () => {
   beforeAll(() => configurePolicies([noDelete]));
   afterAll(() => configurePolicies([]));
 
-  it('blocks drive delete', () => {
-    const result = evaluatePolicies([], ctx('delete'), 'drive');
+  it('blocks drive delete', async () => {
+    const result = await evaluatePolicies([], ctx('delete'), 'drive');
     expect(result.action).toBe('block');
     expect(result.reason).toContain('no-delete');
   });
 
-  it('blocks calendar delete', () => {
-    expect(evaluatePolicies([], ctx('delete'), 'calendar').action).toBe('block');
+  it('blocks calendar delete', async () => {
+    expect((await evaluatePolicies([], ctx('delete'), 'calendar')).action).toBe('block');
   });
 
-  it('blocks task delete', () => {
-    expect(evaluatePolicies([], ctx('delete'), 'tasks').action).toBe('block');
+  it('blocks task delete', async () => {
+    expect((await evaluatePolicies([], ctx('delete'), 'tasks')).action).toBe('block');
   });
 
-  it('blocks deleteTaskList', () => {
-    expect(evaluatePolicies([], ctx('deleteTaskList'), 'tasks').action).toBe('block');
+  it('blocks deleteTaskList', async () => {
+    expect((await evaluatePolicies([], ctx('deleteTaskList'), 'tasks')).action).toBe('block');
   });
 
-  it('allows gmail trash (reversible)', () => {
-    expect(evaluatePolicies([], ctx('trash'), 'gmail').action).toBe('allow');
+  it('allows gmail trash (reversible)', async () => {
+    expect((await evaluatePolicies([], ctx('trash'), 'gmail')).action).toBe('allow');
   });
 
-  it('allows search', () => {
-    expect(evaluatePolicies([], ctx('search'), 'drive').action).toBe('allow');
+  it('allows search', async () => {
+    expect((await evaluatePolicies([], ctx('search'), 'drive')).action).toBe('allow');
   });
 });
 
@@ -87,32 +87,32 @@ describe('readOnly', () => {
   beforeAll(() => configurePolicies([readOnly]));
   afterAll(() => configurePolicies([]));
 
-  it('allows search', () => {
-    expect(evaluatePolicies([], ctx('search'), 'gmail').action).toBe('allow');
+  it('allows search', async () => {
+    expect((await evaluatePolicies([], ctx('search'), 'gmail')).action).toBe('allow');
   });
 
-  it('allows list', () => {
-    expect(evaluatePolicies([], ctx('list'), 'calendar').action).toBe('allow');
+  it('allows list', async () => {
+    expect((await evaluatePolicies([], ctx('list'), 'calendar')).action).toBe('allow');
   });
 
-  it('allows triage', () => {
-    expect(evaluatePolicies([], ctx('triage'), 'gmail').action).toBe('allow');
+  it('allows triage', async () => {
+    expect((await evaluatePolicies([], ctx('triage'), 'gmail')).action).toBe('allow');
   });
 
-  it('blocks send', () => {
-    expect(evaluatePolicies([], ctx('send'), 'gmail').action).toBe('block');
+  it('blocks send', async () => {
+    expect((await evaluatePolicies([], ctx('send'), 'gmail')).action).toBe('block');
   });
 
-  it('blocks create', () => {
-    expect(evaluatePolicies([], ctx('create'), 'calendar').action).toBe('block');
+  it('blocks create', async () => {
+    expect((await evaluatePolicies([], ctx('create'), 'calendar')).action).toBe('block');
   });
 
-  it('blocks delete', () => {
-    expect(evaluatePolicies([], ctx('delete'), 'drive').action).toBe('block');
+  it('blocks delete', async () => {
+    expect((await evaluatePolicies([], ctx('delete'), 'drive')).action).toBe('block');
   });
 
-  it('blocks upload', () => {
-    expect(evaluatePolicies([], ctx('upload'), 'drive').action).toBe('block');
+  it('blocks upload', async () => {
+    expect((await evaluatePolicies([], ctx('upload'), 'drive')).action).toBe('block');
   });
 });
 
@@ -120,18 +120,18 @@ describe('policy composition', () => {
   beforeAll(() => configurePolicies([auditLog, draftOnlyEmail, noDelete]));
   afterAll(() => configurePolicies([]));
 
-  it('audit allows but draftOnly blocks send', () => {
-    const result = evaluatePolicies([], ctx('send'), 'gmail');
+  it('audit allows but draftOnly blocks send', async () => {
+    const result = await evaluatePolicies([], ctx('send'), 'gmail');
     expect(result.action).toBe('block');
   });
 
-  it('audit allows and noDelete blocks drive delete', () => {
-    const result = evaluatePolicies([], ctx('delete'), 'drive');
+  it('audit allows and noDelete blocks drive delete', async () => {
+    const result = await evaluatePolicies([], ctx('delete'), 'drive');
     expect(result.action).toBe('block');
   });
 
-  it('all allow search', () => {
-    const result = evaluatePolicies([], ctx('search'), 'gmail');
+  it('all allow search', async () => {
+    const result = await evaluatePolicies([], ctx('search'), 'gmail');
     expect(result.action).toBe('allow');
   });
 });
@@ -139,8 +139,8 @@ describe('policy composition', () => {
 describe('no policies configured', () => {
   beforeAll(() => configurePolicies([]));
 
-  it('allows everything', () => {
-    expect(evaluatePolicies([], ctx('send'), 'gmail').action).toBe('allow');
-    expect(evaluatePolicies([], ctx('delete'), 'drive').action).toBe('allow');
+  it('allows everything', async () => {
+    expect((await evaluatePolicies([], ctx('send'), 'gmail')).action).toBe('allow');
+    expect((await evaluatePolicies([], ctx('delete'), 'drive')).action).toBe('allow');
   });
 });

--- a/src/__tests__/server/queue.test.ts
+++ b/src/__tests__/server/queue.test.ts
@@ -315,3 +315,40 @@ describe('handleQueue', () => {
     });
   });
 });
+
+describe('a blocked operation is a failure, not a success', () => {
+  // Policies decline by RETURNING a response, not by throwing, so the queue's catch never
+  // sees them. Before this, a queue of two writes on a read-only account reported
+  // "2/2 succeeded" while writing nothing, and `onError: 'bail'` ran the rest anyway.
+  const blockingHandler = async () => ({
+    text: '**Blocked by safety policy:** not allowed',
+    refs: { blocked: true, policy: 'not allowed' },
+  });
+
+  it('counts as failed rather than succeeded', async () => {
+    const result = await handleQueue(
+      { operations: [{ tool: 'manage_contacts', args: { operation: 'create' } }] },
+      { manage_contacts: blockingHandler },
+    );
+    expect(result.text).toContain('0/1 succeeded');
+  });
+
+  it('bails the rest of the queue under onError: bail', async () => {
+    let secondRan = false;
+    const result = await handleQueue(
+      {
+        operations: [
+          { tool: 'manage_contacts', args: { operation: 'create' } },
+          { tool: 'manage_email', args: { operation: 'send' } },
+        ],
+        onError: 'bail',
+      },
+      {
+        manage_contacts: blockingHandler,
+        manage_email: async () => { secondRan = true; return { text: 'sent', refs: {} }; },
+      },
+    );
+    expect(secondRan).toBe(false);
+    expect(result.text).toContain('0/2 succeeded');
+  });
+});

--- a/src/__tests__/server/server.test.ts
+++ b/src/__tests__/server/server.test.ts
@@ -41,6 +41,7 @@ vi.mock('@modelcontextprotocol/sdk/types.js', () => ({
 vi.mock('../../server/handler.js');
 
 import { createServer } from '../../server/server.js';
+import { getActivePolicies } from '../../factory/safety.js';
 import { handleToolCall } from '../../server/handler.js';
 import { GoogleApiError } from '../../google/errors.js';
 import type { HandlerResponse } from '../../server/handler.js';
@@ -68,6 +69,16 @@ describe('createServer', () => {
   it('registers ListTools and CallTool handlers', () => {
     expect(listToolsHandler).toBeInstanceOf(Function);
     expect(callToolHandler).toBeInstanceOf(Function);
+  });
+
+  // Pins the wiring, not the policy. account-access enforces the access level the USER
+  // chose at consent time (ADR-202), so it is the one policy that must be active with no
+  // GWS_SAFETY_POLICY set — otherwise a read-only account silently keeps full authority
+  // and the consent half becomes decorative. Nothing else fails if this line is deleted:
+  // the policy's own tests configure it directly and stay green.
+  it('activates account-access with no GWS_SAFETY_POLICY set', () => {
+    expect(process.env.GWS_SAFETY_POLICY).toBeFalsy();
+    expect(getActivePolicies().map((p) => p.name)).toContain('account-access');
   });
 
   describe('ListTools handler', () => {

--- a/src/accounts/oauth.ts
+++ b/src/accounts/oauth.ts
@@ -114,6 +114,32 @@ export interface ResolvedScopes {
 }
 
 /**
+ * The scopes that grant WRITE access to a service: its read/write set minus anything
+ * that also appears in its read-only set.
+ *
+ * The subtraction is the whole point. Two services list read-only scopes inside their
+ * read/write set, because the service genuinely needs them either way — `contacts`
+ * carries `contacts.other.readonly` and `directory.readonly`, and `meet` carries
+ * `meetings.space.readonly`. Treating the read/write set as "the write scopes" would
+ * therefore find `directory.readonly` on a read-only contacts account, call that an
+ * intersection, and permit a write it should have refused.
+ *
+ * Returns an empty array for a service with no read/write scopes declared at all.
+ */
+export function writeScopesFor(service: string): string[] {
+  const readonly = new Set(SERVICE_SCOPE_MAP_READONLY[service] ?? []);
+  return (SERVICE_SCOPE_MAP[service] ?? []).filter((scope) => !readonly.has(scope));
+}
+
+/** Every scope that grants a service at any access level, read-only and read/write alike. */
+export function anyScopesFor(service: string): string[] {
+  return [...new Set([
+    ...(SERVICE_SCOPE_MAP[service] ?? []),
+    ...(SERVICE_SCOPE_MAP_READONLY[service] ?? []),
+  ])];
+}
+
+/**
  * Convert comma-separated service names to deduplicated scope URLs.
  * Always includes base scopes (openid, userinfo.email).
  *

--- a/src/factory/generator.ts
+++ b/src/factory/generator.ts
@@ -108,7 +108,7 @@ export function generateTools(
   for (const [serviceName, serviceDef] of Object.entries(manifest.services)) {
     const patch = patches?.[serviceName];
     const schema = generateSchema(serviceDef);
-    const handler = generateHandler(serviceDef, patch);
+    const handler = generateHandler(serviceDef, patch, serviceName);
     tools.push({ schema, handler });
   }
 
@@ -171,6 +171,13 @@ export function generateSchema(service: ServiceDef): GeneratedToolSchema {
 export function generateHandler(
   service: ServiceDef,
   patch?: ServicePatch,
+  /**
+   * The manifest key for this service — `contacts`, not `people`. Scope maps are keyed by
+   * it, so the access policy cannot resolve a service without it. Optional because tests
+   * construct ServiceDefs directly; when absent the policy has nothing to look up and
+   * allows, which is the same fail-open stance it takes everywhere else.
+   */
+  serviceName?: string,
 ): GeneratedHandler {
   // Map tool_name to the next-steps domain key
   const domainMap: Record<string, string> = {
@@ -192,7 +199,12 @@ export function generateHandler(
 
     // Safety policies — run before anything else, including custom handlers.
     // A blocked operation never reaches the handler or Google.
-    const policyResult = evaluatePolicies([], ctx, service.google_service);
+    const policyResult = await evaluatePolicies([], ctx, service.google_service, serviceName ? {
+      service: serviceName,
+      googleService: service.google_service,
+      resource: opDef.resource,
+      type: opDef.type,
+    } : undefined);
     if (policyResult.action === 'block') {
       return {
         text: `**Blocked by safety policy:** ${policyResult.reason}`,

--- a/src/factory/safety.ts
+++ b/src/factory/safety.ts
@@ -19,6 +19,9 @@
  * - "Audit mode" — log all write operations to stderr
  */
 
+import { readCredential } from '../accounts/credentials.js';
+import { anyScopesFor, writeScopesFor } from '../accounts/oauth.js';
+import { loadDescriptor } from '../google/descriptor.js';
 import type { PatchContext } from './types.js';
 
 /** Policy decision: what to do with an intercepted operation. */
@@ -32,14 +35,44 @@ export interface PolicyResult {
   replacementArgs?: string[];
 }
 
+/**
+ * What the manifest knows about the operation being evaluated.
+ *
+ * `service` and `googleService` differ for exactly one service and that difference
+ * matters: contacts is declared in `contacts.yaml` but calls `people`. Scope maps are
+ * keyed by the manifest name, the descriptor by the Google name, so a policy consulting
+ * both needs both.
+ */
+export interface OperationInfo {
+  /** Manifest service name — the key in SERVICE_SCOPE_MAP (e.g. 'contacts'). */
+  service: string;
+  /** Google API service — the key in descriptor.json (e.g. 'people'). */
+  googleService: string;
+  /** Google method path (e.g. 'people.createContact'). Absent on pure custom handlers. */
+  resource?: string;
+  /** The manifest's declared intent. */
+  type: 'list' | 'detail' | 'action';
+}
+
 /** A safety policy that evaluates an operation before execution. */
 export interface SafetyPolicy {
   name: string;
   description: string;
   /** Which service.operation combinations this policy applies to. */
   applies: (service: string, operation: string) => boolean;
-  /** Evaluate the operation and return a policy decision. */
-  evaluate: (args: string[], ctx: PatchContext, service: string) => PolicyResult;
+  /**
+   * Evaluate the operation and return a policy decision.
+   *
+   * May be async: `account-access` reads the caller's credential file. Policies that
+   * need neither `op` nor async can keep ignoring both — a narrower implementation
+   * still satisfies this type.
+   */
+  evaluate: (
+    args: string[],
+    ctx: PatchContext,
+    service: string,
+    op?: OperationInfo,
+  ) => PolicyResult | Promise<PolicyResult>;
 }
 
 // ── Built-in policies ────────────────────────────────────────────────
@@ -137,6 +170,91 @@ export const readOnly: SafetyPolicy = {
 };
 
 /**
+ * Access policy — refuse a write from an account that was authorized read-only, and say
+ * so in a sentence, before the request leaves. ADR-202.
+ *
+ * This is the enforcement half of per-account access. The consent half narrows the token;
+ * this half explains what happened when the narrowed token is asked to do more. Without
+ * it Google still refuses — with a 403 that names neither the account, nor the scope, nor
+ * the way out.
+ *
+ * UNLIKE EVERY OTHER POLICY HERE, this one is always on. The others express a deployment
+ * choice an operator opts into with GWS_SAFETY_POLICY. This one enforces a choice the
+ * *user* already made at consent time, so requiring a second opt-in to honour it would
+ * make the first one decorative.
+ *
+ * It fails OPEN in every case where it cannot be sure: an account with no credential, an
+ * unreadable credential file, a service with no scope map, an unknown method. A safety
+ * check that blocks on its own uncertainty stops being a safety check and becomes an
+ * outage — and the operations at issue are ones Google will independently refuse anyway.
+ */
+export const accountAccess: SafetyPolicy = {
+  name: 'account-access',
+  description: 'Refuse writes from a read-only account, naming the account and the fix',
+  applies: () => true,
+  evaluate: async (_args, ctx, _service, op) => {
+    // No account (a service that needs none) or no manifest info: nothing to check against.
+    if (!ctx.account || !op) return { action: 'allow' };
+
+    let granted: Set<string>;
+    try {
+      const cred = await readCredential(ctx.account);
+      granted = new Set(cred.scopes ?? []);
+    } catch {
+      // Not authenticated, or the credential is unreadable. The auth path already has a
+      // good error for that; inventing a second one here would only obscure it.
+      return { action: 'allow' };
+    }
+    if (granted.size === 0) return { action: 'allow' };
+
+    const required = await requiredScopes(op);
+    if (required.length === 0) return { action: 'allow' };
+    if (required.some((scope) => granted.has(scope))) return { action: 'allow' };
+
+    // Nothing the operation accepts was granted. Two different causes, two different fixes.
+    const holdsSomething = anyScopesFor(op.service).some((scope) => granted.has(scope));
+    const reconsent =
+      `manage_accounts {operation:'scopes', email:'${ctx.account}', ` +
+      `services:'${op.service}', access:'readwrite'}`;
+
+    return {
+      action: 'block',
+      reason: holdsSomething
+        ? `'${ctx.operation}' needs write access to ${op.service}. ` +
+          `Account ${ctx.account} was authorized read-only for ${op.service}. ` +
+          `Re-authorize with ${reconsent}, or use an account that already has it.`
+        : `'${ctx.operation}' needs access to ${op.service}, which account ${ctx.account} ` +
+          `has never authorized. Grant it with ${reconsent}, or use an account that already has it.`,
+    };
+  },
+};
+
+/**
+ * The scopes Google will accept for this operation.
+ *
+ * Prefers the descriptor, which is Google's own per-method scope list (ADR-103) and so
+ * cannot drift from what Google actually enforces. A hand-kept table of write operations
+ * would be a second source of truth — the #161 failure.
+ *
+ * Seven of 95 operations declare no `resource` because they are pure custom handlers that
+ * make several calls (`gmail.send`, `drive.upload`, `calendar.create` and friends), and
+ * six of those seven are writes. Leaving them unenforced would exempt exactly the
+ * operations most worth enforcing, so they fall back to the manifest's declared `type`,
+ * which a test already pins against the descriptor's httpMethod.
+ */
+async function requiredScopes(op: OperationInfo): Promise<string[]> {
+  if (op.resource) {
+    const descriptor = await loadDescriptor();
+    const method = descriptor.services[op.googleService]?.methods?.[op.resource];
+    // An unknown method means the manifest and the descriptor disagree. That is a bug
+    // worth failing on, but not here, at the cost of the user's request.
+    if (method?.scopes?.length) return method.scopes;
+    return [];
+  }
+  return op.type === 'action' ? writeScopesFor(op.service) : anyScopesFor(op.service);
+}
+
+/**
  * Audit policy — allows everything but logs destructive operations to stderr.
  * Useful for monitoring what an agent does without blocking it.
  */
@@ -180,15 +298,16 @@ export function getActivePolicies(): SafetyPolicy[] {
  * Run all active policies against an operation.
  * First block wins. Returns the most restrictive result.
  */
-export function evaluatePolicies(
+export async function evaluatePolicies(
   args: string[],
   ctx: PatchContext,
   service: string,
-): PolicyResult {
+  op?: OperationInfo,
+): Promise<PolicyResult> {
   for (const policy of activePolicies) {
     if (!policy.applies(service, ctx.operation)) continue;
 
-    const result = policy.evaluate(args, ctx, service);
+    const result = await policy.evaluate(args, ctx, service, op);
     if (result.action === 'block') {
       process.stderr.write(
         `[google-workspace-mcp] safety: BLOCKED ${service}.${ctx.operation} by ${policy.name}: ${result.reason}\n`,

--- a/src/factory/safety.ts
+++ b/src/factory/safety.ts
@@ -11,12 +11,20 @@
  * - Log/audit destructive actions
  *
  * Policies are composable — multiple can apply to the same operation.
- * They're configured per-deployment, not per-service.
  *
- * Example use cases:
+ * Most are configured per-deployment via GWS_SAFETY_POLICY:
  * - "Draft-only mode" — agents can read email but not send
  * - "No-delete mode" — prevent permanent deletion across all services
  * - "Audit mode" — log all write operations to stderr
+ *
+ * `account-access` is the exception and is always active. It enforces a per-ACCOUNT
+ * choice the user made at consent time rather than a deployment-wide one, and it blocks
+ * by returning a reason rather than throwing. See ADR-202.
+ *
+ * WHAT THIS LAYER DOES NOT COVER: only factory-generated handlers run it. The hand-coded
+ * tools — manage_scratchpad in particular, whose send/sync adapters write to Gmail, Docs,
+ * Sheets, Calendar and Tasks — reach Google without consulting any policy here. Tracked
+ * separately; do not read the list above as exhaustive.
  */
 
 import { readCredential } from '../accounts/credentials.js';
@@ -200,9 +208,17 @@ export const accountAccess: SafetyPolicy = {
     try {
       const cred = await readCredential(ctx.account);
       granted = new Set(cred.scopes ?? []);
-    } catch {
+    } catch (err) {
       // Not authenticated, or the credential is unreadable. The auth path already has a
       // good error for that; inventing a second one here would only obscure it.
+      //
+      // Say so on stderr regardless. Blocks are logged; a silent allow is not, so a
+      // truncated credential file would otherwise disable enforcement for that account
+      // with no signal anywhere — the failure mode you least want to be quiet.
+      process.stderr.write(
+        `[google-workspace-mcp] safety: account-access NOT enforcing for ${ctx.account} — ` +
+        `could not read its credential (${err instanceof Error ? err.message : String(err)})\n`,
+      );
       return { action: 'allow' };
     }
     if (granted.size === 0) return { action: 'allow' };

--- a/src/server/queue.ts
+++ b/src/server/queue.ts
@@ -99,6 +99,17 @@ export async function handleQueue(
       advanceEpoch(); // Each queued operation is a logical tool call
       const response = await handler(resolvedArgs);
       const text = stripNextSteps(response.text);
+
+      // A safety policy declines by RETURNING, not by throwing, so the catch below never
+      // sees it. Counting that as a success made a queue report "2/2 succeeded" having
+      // written nothing, and left `onError: 'bail'` running the rest of a queue whose
+      // first step was refused.
+      if (response.refs?.blocked) {
+        results.push({ index: i, tool: op.tool, status: 'error', error: text });
+        if (errorStrategy === 'bail') bailedAt = i;
+        continue;
+      }
+
       results.push({ index: i, tool: op.tool, status: 'success', text, refs: response.refs });
       lastSuccessText = response.text; // keep next-steps from last success
     } catch (err) {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -17,6 +17,7 @@ import { VERSION } from '../version.js';
 import {
   configurePolicies,
   getActivePolicies,
+  accountAccess,
   draftOnlyEmail,
   noDelete,
   readOnly,
@@ -28,10 +29,22 @@ function log(msg: string): void {
   process.stderr.write(`[google-workspace-mcp] ${msg}\n`);
 }
 
-/** Configure safety policies from the GWS_SAFETY_POLICY env var. */
+/**
+ * Configure safety policies.
+ *
+ * `account-access` is always active and is not in the map below — it is not a deployment
+ * choice. It enforces the access level the USER chose when they authorized the account
+ * (ADR-202), so gating it behind an operator opt-in would make that choice decorative.
+ * It is a no-op for read/write accounts, which is every account by default.
+ *
+ * Everything else is opt-in through GWS_SAFETY_POLICY.
+ */
 function initSafetyPolicies(): void {
   const policyEnv = process.env.GWS_SAFETY_POLICY || '';
-  if (!policyEnv) return;
+  if (!policyEnv) {
+    configurePolicies([accountAccess]);
+    return;
+  }
 
   const policyMap: Record<string, SafetyPolicy> = {
     'draft-only-email': draftOnlyEmail,
@@ -50,8 +63,7 @@ function initSafetyPolicies(): void {
     );
   }
 
-  const policies = names.map(name => policyMap[name]);
-  configurePolicies(policies);
+  configurePolicies([accountAccess, ...names.map(name => policyMap[name])]);
 }
 
 export function createServer(): Server {


### PR DESCRIPTION
## Description

The **enforcement half** of ADR-202. The consent half shipped in v4.3.0 and narrows the token; until now a read-only account calling a write got Google's raw 403, naming neither the account, nor the scope, nor the way out. This closes that gap, and it's what issue #130 is currently waiting on.

```
'create' needs write access to contacts. Account someone@example.com was authorized
read-only for contacts. Re-authorize with manage_accounts {operation:'scopes',
email:'someone@example.com', services:'contacts', access:'readwrite'}, or use an
account that already has it.
```

The remedy names `contacts` — the manifest service a user would re-consent — never `people`, the Google API name they never typed and cannot use. That's why the policy needs both names, and it's asserted.

**It is always on**, unlike every other policy in this layer. The others are operator opt-ins via `GWS_SAFETY_POLICY`. This one enforces a choice the *user* already made at consent time, so gating it behind a second opt-in would make the first decorative. It's a no-op for read/write accounts, which is every account by default.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Three things found by building it

**1. Write scopes are the read/write set MINUS the read-only set.** `contacts` and `meet` both carry read-only scopes *inside* their read/write set, because the service needs them at either level. Without the subtraction, a read-only contacts account holding `directory.readonly` intersects `SERVICE_SCOPE_MAP.contacts` and the write is permitted. Found by writing the test, not by reading the code.

**2. Seven of 95 operations declare no `resource`** — pure custom handlers that make several calls — and **six of them are writes**: `gmail.send/reply/replyAll/forward`, `drive.upload`, `calendar.create`. Enforcing only where the descriptor has an entry would have exempted exactly the operations most worth enforcing. Those fall back to the manifest's `type`, which an existing test already pins against `httpMethod`.

**3. Measured across every action-typed operation:** exactly one is satisfiable by a read-only token — `drive.export`, a GET the manifest labels an action. Google accepts `drive.readonly` for `files.export`, so allowing it is **correct**. A hand-maintained list of write operations would have refused a read the token genuinely permits. ADR-103's argument arriving on its own.

## Fail-open, deliberately

No credential, unreadable credential, no scopes, no manifest info, unknown method — all allow. A safety check that blocks on its own uncertainty is an outage, and every one of these reaches Google, which refuses it independently if it should be refused.

## Interface changes, both additive

`SafetyPolicy.evaluate` may now be async and receives the operation's manifest info as an optional 4th argument. A narrower implementation still satisfies the type, so `draft-only-email`, `no-delete`, `read-only` and `audit` are untouched.

`generateHandler` takes an optional `serviceName` — the manifest key, which is the only way to reach the scope maps (`contacts`, not `people`).

## Testing Performed

- [x] 916 tests pass (was 897). 18 new in `account-access.test.ts`, plus a wiring assertion in `server.test.ts`.
- [x] Scope strings in tests are **imported from the maps**, not written out, so a test can't pass by agreeing with a URL the source has since changed.
- [x] `make check` green — typecheck, lint, gates, node-floor, build, smoke.

**Each guard proven by breaking it and watching the suite go red, then restored:**

| Break | Test that caught it |
|---|---|
| Drop the read-only subtraction in `writeScopesFor` | 2 failed — `excludes read-only scopes…`, `never grants a write scope…` |
| Drop the resource-less fallback | 1 failed — `blocks a write from a read-only account` |
| Fail *closed* on an unknown descriptor method | 1 failed — `allows when the resource is not in the descriptor` |
| Remove the always-on wiring from `server.ts` | 1 failed — `activates account-access with no GWS_SAFETY_POLICY set` |

That last one matters: without it, deleting one line in `server.ts` leaves the policy's own tests green while the server enforces nothing.

**Not yet exercised against live Google.** The policy is unit-tested with a mocked credential store; no real read-only account has hit it. That's the next task, using `aaron@bockelie.com` — and it's the honest caveat I posted on #130.

## Security Considerations

- [x] Enforcement derives from `descriptor.json` — Google's own per-method scope list — not a hand-kept table that drifts.
- [x] Fail-open is deliberate and enumerated above; none of the fail-open paths grant access Google wouldn't independently allow.
- [x] Also closes a pre-existing gap: an account that never authorized a service now gets a sentence saying so, instead of an opaque 403.
- [x] The policy reads the credential file per intercepted operation. Uncached, as ADR-202 anticipated.

## Additional Notes

ADR-202 gets a dated Update section recording what building it settled — the always-on decision, the resource-less fallback, the scope subtraction, and the `drive.export` measurement — rather than editing its original reasoning.

Still open, unchanged by this PR: `confirmWriteAccess: true` can be sent on the first call, skipping the warning, since nothing server-side remembers having warned. Worth noting the gate is currently unreachable from real input anyway — every service in the map now has a read-only scope, `meet` included via `meetings.space.readonly`. It guards the first service added without one.
