### PR TITLE
test(coverage): gate coverage-baseline.json against the committed descriptor

### DIFF
--- a/src/__tests__/coverage/baseline-drift.test.ts
+++ b/src/__tests__/coverage/baseline-drift.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Offline drift gate for coverage-baseline.json.
+ *
+ * `make coverage` reads Google's Discovery service over the network, so it cannot join
+ * `make check` — which has to stay offline and fast, because CI runs it on every push.
+ * Nothing else looked at the baseline, and it rotted for a month without a single failure:
+ * last written 2026-07-12, so it predated both the Meet space work and the whole contacts
+ * service, AND it still used a top-level key the code had renamed (`gwsVersion`, written
+ * as `apiSurface` since). Stale in shape as well as content, and silent.
+ *
+ * Everything below compares the baseline against artifacts already committed —
+ * descriptor.json and the manifests — so it needs no network. A baseline that disagrees
+ * with the descriptor is drift by definition; noticing that never required asking Google.
+ *
+ * When one of these fails the fix is `make coverage-update`, then read the diff.
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { loadManifest } from '../../factory/generator.js';
+import { loadDescriptor } from '../../google/descriptor.js';
+
+const baseline = JSON.parse(
+  readFileSync(new URL('../../../coverage-baseline.json', import.meta.url), 'utf-8'),
+) as {
+  apiSurface?: string;
+  generatedAt?: string;
+  services?: Record<string, { operations: Record<string, { status: string }> }>;
+};
+
+describe('coverage baseline', () => {
+  it('has the keys the writer actually writes', () => {
+    // The failure this exists for: analyze.js renamed `gwsVersion` to `apiSurface` and the
+    // committed file kept the old key. Every consumer read undefined and nothing objected.
+    expect(Object.keys(baseline).sort()).toEqual(['apiSurface', 'generatedAt', 'services']);
+    expect(typeof baseline.apiSurface).toBe('string');
+    expect(typeof baseline.generatedAt).toBe('string');
+  });
+
+  it('covers exactly the services the descriptor knows about', async () => {
+    // Catches a whole service missing, which is how `people` went unrecorded: contacts
+    // shipped, the headline percentage was computed without it, and it read as fine.
+    const descriptor = await loadDescriptor();
+    expect(Object.keys(baseline.services ?? {}).sort())
+      .toEqual(Object.keys(descriptor.services).sort());
+  });
+
+  it('lists exactly the operations Google declares, per service', async () => {
+    const descriptor = await loadDescriptor();
+    const drift: string[] = [];
+
+    for (const [service, svc] of Object.entries(descriptor.services)) {
+      const recorded = Object.keys(baseline.services?.[service]?.operations ?? {}).sort();
+      const declared = Object.keys(svc.methods).sort();
+      if (recorded.join() === declared.join()) continue;
+
+      const missing = declared.filter((m) => !recorded.includes(m));
+      const extra = recorded.filter((m) => !declared.includes(m));
+      drift.push(
+        `${service}: ${missing.length} not in the baseline${missing.length ? ` (${missing.slice(0, 3).join(', ')}…)` : ''}, ` +
+        `${extra.length} no longer declared by Google${extra.length ? ` (${extra.slice(0, 3).join(', ')}…)` : ''}`,
+      );
+    }
+
+    expect(drift, 'run `make coverage-update` and review the diff').toEqual([]);
+  });
+
+  it('marks an operation covered when, and only when, a manifest declares it', () => {
+    // The claim the baseline exists to make. Adding an operation to a manifest without
+    // regenerating leaves it recorded as a gap — the file then understates the tool and
+    // offers work that is already done.
+    const declared = new Set<string>();
+    for (const service of Object.values(loadManifest().services)) {
+      for (const op of Object.values(service.operations)) {
+        if (op.resource) declared.add(`${service.google_service}.${op.resource}`);
+      }
+    }
+
+    const wrong: string[] = [];
+    for (const [service, svc] of Object.entries(baseline.services ?? {})) {
+      for (const [path, op] of Object.entries(svc.operations)) {
+        const isDeclared = declared.has(`${service}.${path}`);
+        const saysCovered = op.status === 'covered';
+        if (isDeclared !== saysCovered) {
+          wrong.push(
+            `${service}.${path}: baseline says ${op.status}, ` +
+            `manifest ${isDeclared ? 'declares it' : 'does not declare it'}`,
+          );
+        }
+      }
+    }
+
+    expect(wrong, 'run `make coverage-update` and review the diff').toEqual([]);
+  });
+});


### PR DESCRIPTION
## Description

`coverage-baseline.json` rotted for a month with nothing failing. It was last written 2026-07-12, so it predated both the Meet space work and the entire contacts service — **and** it still used a top-level key the code had renamed (`gwsVersion`; `analyze.js` has written `apiSurface` for some time). Stale in shape as well as content, and completely silent.

## Why the obvious fix isn't the fix

`make coverage` reads Google's Discovery service over the network (`src/coverage/discover.ts`), so it can't join `make check` — that has to stay offline and fast because CI runs it on every push.

**Detecting drift never needed Google, though.** `descriptor.json` and the manifests are both committed and both regenerated deliberately, so a baseline that disagrees with them is drift by definition. This adds four offline assertions comparing the baseline to artifacts already in the repo.

## Type of Change

- [x] Test coverage improvement

## What it asserts

| Assertion | The failure it catches |
|---|---|
| Top-level keys are exactly what the writer writes | The `gwsVersion` → `apiSurface` rename — **this actually happened** |
| Baseline services == descriptor services | A whole service missing — **`people` actually was** |
| Per service, baseline operations == methods Google declares | Google's vendored surface moving without regeneration |
| Covered ⟺ a manifest declares it | An operation shipping without regeneration, so the baseline understates the tool and offers work that's already done |

That last one is the claim the file exists to make, and nothing checked it.

A test rather than a new Make target — it runs inside `make check` with no network, no new CI job, and nothing for anyone to remember.

## Testing Performed

- [x] `make check` green — **927 tests**, up from 923.
- [x] `check-test-gates` confirms the new file is collected by a gate.

**Each assertion proven by breaking it**, including both failures that actually occurred:

| Break | Result |
|---|---|
| Rename `apiSurface` back to `gwsVersion` | 1 failed |
| Delete the `people` service | 2 failed |
| Remove an operation Google declares | 1 failed |
| Mark a shipped operation as `gap` | 1 failed |

## Additional Notes

The remedy on failure is `make coverage-update`, then read the diff — named in the assertion messages so the fix is in the failure output rather than in someone's memory.