### PR TITLE
fix(scratchpad): route its Google writes through the safety layer (#171)

### DIFF
--- a/docs/architecture/auth/ADR-202-per-account-access-level-enforced-at-call-time.md
+++ b/docs/architecture/auth/ADR-202-per-account-access-level-enforced-at-call-time.md
@@ -135,22 +135,27 @@ scopes, no manifest info, unknown method. A safety check that blocks on its own 
 an outage, and each of these reaches Google, which refuses it independently if it should
 be refused.
 
-**The policy covers factory-generated handlers only, and that is not everything.** Code
-review found `manage_scratchpad` writing to Google outside this layer entirely: its send
-and sync adapters call `tasks.insert`, `events.insert`, `documents.create`,
+**Generated handlers are not everything, and the gap was real.** Code review found
+`manage_scratchpad` writing to Google outside this layer entirely: its send and sync
+adapters call `tasks.insert`, `events.insert`, `documents.create`,
 `documents.batchUpdate`, `spreadsheets.values.update` and `sendMail` directly, because the
-tool is hand-registered rather than generated. So a read-only account is refused
-`manage_docs write` with the sentence above and then writes the same content to the same
-document through `manage_scratchpad send` — getting the raw 403 this ADR exists to
-replace. The token is genuinely narrow, so Google still refuses; what leaks is the
-explanation.
+tool is hand-registered rather than generated. A read-only account refused `manage_docs
+write` could write the same content to the same document through `manage_scratchpad send`.
+The token is genuinely narrow, so Google still refused; what leaked was the explanation.
 
-The sharper half of the same gap does not have Google as a backstop: under
-`GWS_SAFETY_POLICY=draft-only-email`, an ordinary read/write account can still send mail
-through `manage_scratchpad`, and Google accepts it, because the token is legitimately
-broad. That bypass predates this ADR and is not created by it — but this ADR is what makes
-the layer load-bearing by default, so it is recorded here rather than left implicit.
-Tracked as its own issue.
+The sharper half had no Google backstop: under `GWS_SAFETY_POLICY=draft-only-email` an
+ordinary read/write account could still send mail through `manage_scratchpad`, and Google
+accepted it, because the token is legitimately broad. That bypass predated this ADR — but
+this ADR is what made the layer load-bearing by default, which is what turned a latent
+gap into one worth closing.
+
+Closed in #171. The eight write paths now consult `evaluatePolicies` through one table
+mapping each send target and sync binding to the Google method it really calls, checked at
+the single dispatch point. Two consequences worth stating: **every hand-registered tool
+that writes to Google must do this explicitly**, since nothing in the layer can enforce it
+from the outside — that is precisely how scratchpad went uncovered; and the sync
+write-backs check *before* applying the local mutation, so a refusal cannot leave the
+buffer holding a change the document will never receive.
 
 **Access is per service, and services overlap.** Docs and Sheets write methods list
 `drive` among the scopes Google accepts — `documents.batchUpdate` takes

--- a/src/__tests__/server/scratchpad/write-policy.test.ts
+++ b/src/__tests__/server/scratchpad/write-policy.test.ts
@@ -1,0 +1,141 @@
+/**
+ * manage_scratchpad writes go through the safety layer — issue #171.
+ *
+ * It is hand-registered rather than factory-generated, so none of its writes passed
+ * through `generateHandler` and therefore none reached `evaluatePolicies`. Two distinct
+ * failures came out of that, and only one of them had Google as a backstop:
+ *
+ *   1. A read-only account refused `manage_docs write` could write the same content via
+ *      `send`. The token is narrow, so Google refused — what was lost was the explanation.
+ *   2. With GWS_SAFETY_POLICY=draft-only-email, an ordinary read/write account could
+ *      still send mail through `send`, and GOOGLE ACCEPTED IT, because the token is
+ *      legitimately broad. Nothing refused that but the policy that was never consulted.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const readCredential = vi.hoisted(() => vi.fn());
+vi.mock('../../../accounts/credentials.js', () => ({ readCredential }));
+vi.mock('../../../google/client.js');
+vi.mock('../../../services/gmail/mail.js', () => ({ sendMail: vi.fn() }));
+
+const { handleScratchpad, getScratchpadManager } = await import('../../../server/scratchpad/handler.js');
+const { configurePolicies, accountAccess, draftOnlyEmail } = await import('../../../factory/safety.js');
+const { SERVICE_SCOPE_MAP, SERVICE_SCOPE_MAP_READONLY } = await import('../../../accounts/oauth.js');
+const { call } = await import('../../../google/client.js');
+const { sendMail } = await import('../../../services/gmail/mail.js');
+
+const ACCOUNT = 'someone@example.com';
+
+function grant(services: string[], level: 'read' | 'readwrite'): void {
+  const map = level === 'read' ? SERVICE_SCOPE_MAP_READONLY : SERVICE_SCOPE_MAP;
+  readCredential.mockResolvedValue({ scopes: services.flatMap((s) => map[s] ?? []) });
+}
+
+/** A scratchpad holding some content, ready to send. */
+function scratchpadWith(content: string): string {
+  const id = getScratchpadManager().create({ content });
+  return typeof id === 'string' ? id : (id as { id: string }).id;
+}
+
+beforeEach(() => {
+  vi.mocked(call).mockResolvedValue({} as never);
+  vi.mocked(sendMail).mockResolvedValue({ id: 'm1' } as never);
+});
+
+afterEach(() => {
+  configurePolicies([]);
+  readCredential.mockReset();
+  vi.mocked(call).mockReset();
+  vi.mocked(sendMail).mockReset();
+});
+
+describe('a read-only account', () => {
+  beforeEach(() => {
+    configurePolicies([accountAccess]);
+    grant(['docs', 'gmail', 'tasks', 'calendar', 'sheets'], 'read');
+  });
+
+  // One case per target that reaches Google. `workspace` is excluded on purpose: it
+  // writes a local file and touches no Google API.
+  const targets: Array<[string, Record<string, string>, string]> = [
+    ['email',          { to: 'a@b.com', subject: 's' },        'gmail'],
+    ['email_draft',    { to: 'a@b.com', subject: 's' },        'gmail'],
+    ['doc_create',     { title: 't' },                          'docs'],
+    ['doc_write',      { documentId: 'd1' },                    'docs'],
+    ['sheet_write',    { spreadsheetId: 's1', range: 'A1' },    'sheets'],
+    ['calendar_event', { summary: 'e', start: '2026-01-01T10:00:00Z', end: '2026-01-01T11:00:00Z' }, 'calendar'],
+    ['task_create',    { title: 't' },                          'tasks'],
+  ];
+
+  it.each(targets)('is refused on send target %s, naming %s', async (target, extra, service) => {
+    const id = scratchpadWith('content');
+    const result = await handleScratchpad({
+      operation: 'send', scratchpadId: id, target,
+      targetParams: { email: ACCOUNT, ...extra },
+    });
+
+    expect(result.text).toContain('Blocked by safety policy');
+    expect(result.text).toContain(`services:'${service}'`);
+    expect(result.text).toContain(ACCOUNT);
+    expect(call).not.toHaveBeenCalled();
+    expect(sendMail).not.toHaveBeenCalled();
+  });
+
+  it('leaves the workspace target alone — it writes no Google API', async () => {
+    const id = scratchpadWith('content');
+    const result = await handleScratchpad({
+      operation: 'send', scratchpadId: id, target: 'workspace',
+      targetParams: { email: ACCOUNT, filename: 'note.md' },
+    });
+    expect(result.text).not.toContain('Blocked by safety policy');
+  });
+});
+
+describe('a read/write account', () => {
+  beforeEach(() => {
+    configurePolicies([accountAccess]);
+    grant(['docs', 'gmail', 'tasks', 'calendar', 'sheets'], 'readwrite');
+  });
+
+  it('sends as before — the policy is a no-op', async () => {
+    const id = scratchpadWith('content');
+    const result = await handleScratchpad({
+      operation: 'send', scratchpadId: id, target: 'email',
+      targetParams: { email: ACCOUNT, to: 'a@b.com', subject: 's' },
+    });
+
+    expect(result.text).not.toContain('Blocked by safety policy');
+    expect(sendMail).toHaveBeenCalled();
+  });
+});
+
+describe('the draft-only-email bypass', () => {
+  // The half without a Google backstop. The account is fully authorized, so Google
+  // accepts the send; the ONLY thing that can refuse it is the policy that was never
+  // being consulted. `draft-only-email` exists precisely to stop an agent sending mail.
+  beforeEach(() => {
+    configurePolicies([draftOnlyEmail]);
+    grant(['gmail'], 'readwrite');
+  });
+
+  it('no longer lets scratchpad send mail the policy forbids', async () => {
+    const id = scratchpadWith('content');
+    const result = await handleScratchpad({
+      operation: 'send', scratchpadId: id, target: 'email',
+      targetParams: { email: ACCOUNT, to: 'a@b.com', subject: 's' },
+    });
+
+    expect(result.text).toContain('Blocked by safety policy');
+    expect(sendMail).not.toHaveBeenCalled();
+  });
+
+  it('still allows a draft, which is what the policy permits', async () => {
+    const id = scratchpadWith('content');
+    const result = await handleScratchpad({
+      operation: 'send', scratchpadId: id, target: 'email_draft',
+      targetParams: { email: ACCOUNT, to: 'a@b.com', subject: 's' },
+    });
+
+    expect(result.text).not.toContain('Blocked by safety policy');
+  });
+});

--- a/src/factory/safety.ts
+++ b/src/factory/safety.ts
@@ -21,10 +21,14 @@
  * choice the user made at consent time rather than a deployment-wide one, and it blocks
  * by returning a reason rather than throwing. See ADR-202.
  *
- * WHAT THIS LAYER DOES NOT COVER: only factory-generated handlers run it. The hand-coded
- * tools — manage_scratchpad in particular, whose send/sync adapters write to Gmail, Docs,
- * Sheets, Calendar and Tasks — reach Google without consulting any policy here. Tracked
- * separately; do not read the list above as exhaustive.
+ * WHO RUNS THIS: `generateHandler` calls it for every factory-generated operation, and
+ * `manage_scratchpad` calls it explicitly for its send and sync writes (#171) because it
+ * is hand-registered and gets no policy check for free. Any future hand-registered tool
+ * that writes to Google has to do the same — nothing enforces that from here, which is
+ * exactly how scratchpad went uncovered.
+ *
+ * `manage_accounts` and `manage_workspace` are also hand-registered and need no check:
+ * neither writes through a Google API.
  */
 
 import { readCredential } from '../accounts/credentials.js';

--- a/src/server/scratchpad/handler.ts
+++ b/src/server/scratchpad/handler.ts
@@ -12,9 +12,61 @@ import {
   importEmail, importDoc, importSheet, importDriveFile, importMeet,
 } from './adapters/index.js';
 import { call } from '../../google/client.js';
+import { evaluatePolicies, type OperationInfo } from '../../factory/safety.js';
 import { resolveWorkspacePath, verifyPathSafety } from '../../executor/workspace.js';
 import { lookupMimeType } from '../../services/gmail/mime.js';
 import type { HandlerResponse } from '../handler.js';
+
+/**
+ * What each write actually does to Google, so the safety layer can see it.
+ *
+ * manage_scratchpad is hand-registered rather than factory-generated, so nothing here
+ * passes through `generateHandler` — and therefore nothing reached `evaluatePolicies`.
+ * Every entry below was a write that bypassed the policy layer entirely (#171): a
+ * read-only account refused `manage_docs write` could write the same content through
+ * `send`, and with GWS_SAFETY_POLICY=draft-only-email an ordinary account could still
+ * send mail, which Google accepts because the token is legitimately broad.
+ *
+ * `operation` is chosen to match what the existing policies already look for — `send`
+ * so draft-only-email matches it, `create`/`write` for the rest. `resource` is the method
+ * the adapter really calls, verified against descriptor.json; a wrong one would make
+ * `requiredScopes` return [] and fail open silently.
+ *
+ * The `workspace` target is absent deliberately: it writes a local file and touches no
+ * Google API, so there is nothing to authorize.
+ */
+const WRITE_INTENT: Record<string, OperationInfo & { operation: string }> = {
+  email:          { operation: 'send',   service: 'gmail',    googleService: 'gmail',    resource: 'users.messages.send',        type: 'action' },
+  email_draft:    { operation: 'create', service: 'gmail',    googleService: 'gmail',    resource: 'users.drafts.create',        type: 'action' },
+  doc_create:     { operation: 'create', service: 'docs',     googleService: 'docs',     resource: 'documents.create',           type: 'action' },
+  doc_write:      { operation: 'write',  service: 'docs',     googleService: 'docs',     resource: 'documents.batchUpdate',      type: 'action' },
+  sheet_write:    { operation: 'write',  service: 'sheets',   googleService: 'sheets',   resource: 'spreadsheets.values.update', type: 'action' },
+  calendar_event: { operation: 'create', service: 'calendar', googleService: 'calendar', resource: 'events.insert',              type: 'action' },
+  task_create:    { operation: 'create', service: 'tasks',    googleService: 'tasks',    resource: 'tasks.insert',               type: 'action' },
+  // The live-binding sync write-backs, which are not send targets and reach Google from
+  // pushLiveDoc / pushLiveSheet rather than from the send switch.
+  doc_sync:       { operation: 'write',  service: 'docs',     googleService: 'docs',     resource: 'documents.batchUpdate',      type: 'action' },
+  sheet_sync:     { operation: 'write',  service: 'sheets',   googleService: 'sheets',   resource: 'spreadsheets.values.update', type: 'action' },
+};
+
+/**
+ * Run the safety policies for a scratchpad write. Returns a response to hand back when
+ * the write is refused, or null to proceed.
+ *
+ * Mirrors what generateHandler does for every generated operation.
+ */
+async function checkWritePolicy(intent: string, account: string): Promise<HandlerResponse | null> {
+  const op = WRITE_INTENT[intent];
+  if (!op || !account) return null;
+
+  const result = await evaluatePolicies([], { operation: op.operation, params: {}, account }, op.googleService, op);
+  if (result.action !== 'block') return null;
+
+  return {
+    text: `**Blocked by safety policy:** ${result.reason}`,
+    refs: { blocked: true, error: true, policy: result.reason },
+  };
+}
 
 const scratchpads = new ScratchpadManager();
 
@@ -321,6 +373,11 @@ async function maybeHandleDocsBoundMutation(
   const binding = scratchpads.getBinding(id);
   if (binding?.service !== 'docs') return null;
 
+  // Ahead of the local mutation, not just the API call. Refusing after applying it would
+  // leave the buffer holding a change the document will never receive.
+  const refused = await checkWritePolicy('doc_sync', binding.account);
+  if (refused) return refused;
+
   const before = scratchpads.getContent(id);
   if (before === null) return scratchpadNotFound(id);
 
@@ -398,6 +455,12 @@ async function reloadDocsBuffer(id: string, binding: LiveBinding): Promise<void>
 async function syncIfBound(id: string): Promise<HandlerResponse | null> {
   const binding = scratchpads.getBinding(id);
   if (!binding) return null;
+
+  // Only the sheets branch below reaches Google; the docs branch is handled upstream.
+  if (binding.service === 'sheets') {
+    const refused = await checkWritePolicy('sheet_sync', binding.account);
+    if (refused) return refused;
+  }
 
   const content = scratchpads.getContent(id);
   if (content === null) return null;
@@ -551,6 +614,10 @@ async function handleSend(params: Record<string, unknown>): Promise<HandlerRespo
 
   const targetParams = (params.targetParams ?? {}) as Record<string, string>;
   const keep = params.keep !== false; // default true
+
+  // Before the switch, so one check covers every target that reaches Google. #171.
+  const refused = await checkWritePolicy(target, targetParams.email);
+  if (refused) return refused;
 
   let result: HandlerResponse;
 


### PR DESCRIPTION
Closes #171.

## Description

`manage_scratchpad` is hand-registered rather than factory-generated, so none of its writes passed through `generateHandler` and none reached `evaluatePolicies`. **Eight paths wrote to Google with no policy consulted** — seven send targets plus the doc and sheet sync write-backs.

Found by code review of #170.

## Two failures, and only one had Google as a backstop

**1. The lost explanation.** A read-only account refused `manage_docs write` could write the same content to the same document through `manage_scratchpad send`. The token is genuinely narrow, so Google refused anyway — what was lost was the sentence naming the account and the fix, which is the entire point of ADR-202.

**2. The real bypass.** Under `GWS_SAFETY_POLICY=draft-only-email`, an ordinary read/write account could still send mail through scratchpad and **Google accepted it**, because the token is legitimately broad. A policy that exists specifically to stop an agent sending mail was one tool call from being bypassed. Nothing but the unconsulted policy could refuse it.

That second one predates ADR-202. Making the layer load-bearing by default is what turned it from latent into worth closing.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Approach

One table maps each target to the Google method its adapter really calls, checked once before the send `switch`:

| target | service | resource |
|---|---|---|
| `email` | gmail | `users.messages.send` |
| `email_draft` | gmail | `users.drafts.create` |
| `doc_create` | docs | `documents.create` |
| `doc_write` / `doc_sync` | docs | `documents.batchUpdate` |
| `sheet_write` / `sheet_sync` | sheets | `spreadsheets.values.update` |
| `calendar_event` | calendar | `events.insert` |
| `task_create` | tasks | `tasks.insert` |

**Every resource verified present in `descriptor.json`.** A wrong one makes `requiredScopes` return `[]` and fail open silently — the failure mode this area keeps producing.

Three details that matter:

- `operation` is chosen to match what the existing policies already look for — `send` for the email target so `draft-only-email` matches it without modification, `create`/`write` for the rest.
- The `workspace` target is **deliberately absent**: it writes a local file and touches no Google API.
- The sync write-backs check **before** applying the local mutation. Refusing afterwards would leave the buffer holding a change the document will never receive.

## Testing Performed

- [x] `make check` green — **938 tests**, up from 927.
- [x] 11 new tests: one per send target, the `workspace` exemption, the read/write no-op, and both halves of the `draft-only-email` case (send refused, draft still allowed).
- [x] **8 of the 11 fail with the gate removed** — verified by removing it and re-running.
- [x] Every resource in the table confirmed against `descriptor.json` with its HTTP verb.

## Security Considerations

- [x] Closes a genuine bypass of `draft-only-email` where Google would otherwise accept the call.
- [x] No new credential handling; reuses the existing policy layer unchanged.
- [x] The docblock now states that **any hand-registered tool writing to Google must do this explicitly** — nothing in the layer can enforce it from outside, which is exactly how scratchpad went uncovered.
- [x] `manage_accounts` and `manage_workspace` audited: neither writes through a Google API, so neither needs a check.

## Additional Notes

ADR-202's Update section is corrected — it previously described this as an open gap, and now records how it was closed and the constraint that generalises from it.