### PR TITLE
feat(tools): rename queue_operations to bulk_operations, keeping the old name (ADR-308)

### DIFF
--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -49,3 +49,4 @@ _MCP tools, schemas, progressive disclosure_
 | [ADR-305](./api/ADR-305-shared-html-sanitization-for-agent-facing-authoring.md) | Shared HTML sanitization for agent-facing authoring | Accepted |
 | [ADR-306](./api/ADR-306-tab-addressed-docs-reads-and-writes.md) | Tab-addressed Docs reads and writes | Accepted |
 | [ADR-307](./api/ADR-307-contacts-as-a-flat-surface-over-the-people-api.md) | Contacts as a flat surface over the People API | Accepted |
+| [ADR-308](./api/ADR-308-rename-queue-operations-to-bulk-operations-with-queue-and-batch-modes.md) | Rename queue_operations to bulk_operations, with queue and batch modes | Proposed |

--- a/docs/architecture/api/ADR-308-rename-queue-operations-to-bulk-operations-with-queue-and-batch-modes.md
+++ b/docs/architecture/api/ADR-308-rename-queue-operations-to-bulk-operations-with-queue-and-batch-modes.md
@@ -1,0 +1,199 @@
+---
+status: Proposed
+date: 2026-08-17
+deciders:
+  - aaronsb
+related:
+  - ADR-103
+  - ADR-300
+---
+
+# ADR-308: Rename queue_operations to bulk_operations, with queue and batch modes
+
+## Context
+
+`queue_operations` runs several tool calls in sequence, threading results between them with
+`$N.field` references. It is named after its **strategy** rather than its **purpose**: a
+queue is one way to do many things, and the tool exists to do many things.
+
+That naming stopped being cosmetic once the second strategy turned out to be available.
+Google publishes methods that perform one operation across many resources in a single HTTP
+request. Doing 200 contact deletions through the queue costs 200 round trips; Google offers
+to do it in one.
+
+### What Google actually publishes
+
+Measured across all eight services in `descriptor.json`. Every method with `batch` in its
+name falls into one of two groups, and only the second is a bulk *mode*:
+
+**Many edits to ONE resource** — already how these operations work, not a bulk mode:
+
+| Service | Method |
+|---|---|
+| docs | `documents.batchUpdate` |
+| sheets | `spreadsheets.batchUpdate`, `values.batchUpdate`, `values.batchClear`, `values.batchGet` (+ `ByDataFilter` variants) |
+
+`manage_docs write` and every `manage_sheets` write already call these. A caller asking for
+"batch" here would be asking for what they already have.
+
+**One operation across MANY resources** — the real bulk surface:
+
+| Service | Method | Verb |
+|---|---|---|
+| gmail | `users.messages.batchModify` | POST |
+| gmail | `users.messages.batchDelete` | POST |
+| people | `people.batchCreateContacts` | POST |
+| people | `people.batchUpdateContacts` | POST |
+| people | `people.batchDeleteContacts` | POST |
+| people | `people.getBatchGet` | GET |
+
+Six methods, two services. **All six are coverage gaps** — none appears in any manifest.
+`calendar`, `docs`, `drive`, `meet` and `tasks` publish no such method at all, so for those
+services a queue is not a fallback, it is the only thing there is.
+
+An earlier count of this surface said five methods and missed `people.getBatchGet`, which
+is a batch *read*. It also included `sheets.values.batchGet`, which belongs to the first
+group — many ranges within one spreadsheet. Both errors came from reading method names
+rather than what the methods address.
+
+## Decision
+
+Rename the tool to `bulk_operations` and give it a `mode` naming the strategy.
+
+```
+bulk_operations { mode: 'queue' | 'batch', ... }
+```
+
+`mode` defaults to `'queue'`, so every existing call behaves exactly as it does today.
+
+### queue — N operations, N calls, in order
+
+Unchanged. An `operations` array of `{tool, args}`, executed in sequence, with `$N.field`
+references threading a result into a later argument, `onError` of `bail` or `continue`, and
+nesting up to `MAX_QUEUE_DEPTH`. This is the general mechanism: it works for any tool, any
+operation, any mix.
+
+### batch — one call across many resources
+
+```
+bulk_operations {
+  mode: 'batch',
+  tool: 'manage_contacts',
+  operation: 'delete',
+  items: [ {contactId: 'people/c1'}, {contactId: 'people/c2'} ]
+}
+```
+
+One tool, one operation, many items, one HTTP request. Deliberately *not* the queue's
+`operations` array: a batch is a single call and cannot thread `$N` references between its
+items, so borrowing a shape that implies ordering and chaining would advertise semantics
+the mode does not have.
+
+Asking to batch something Google cannot batch fails with the list of what can:
+
+```
+manage_calendar 'delete' cannot be batched — Google publishes no batch method for it.
+Operations that can: manage_email modify, manage_email trash,
+manage_contacts create, manage_contacts update, manage_contacts delete, manage_contacts get.
+Use mode:'queue' instead, which works for every operation.
+```
+
+### Capability is declared in the manifest and checked against the descriptor
+
+An operation opts in by naming the Google method that batches it:
+
+```yaml
+delete:
+  type: action
+  resource: people.deleteContact
+  batch_resource: people.batchDeleteContacts
+```
+
+A test asserts every `batch_resource` resolves in `descriptor.json`, the same way `resource`
+is checked. The list of batchable operations is then *derived* from the manifest at
+startup, never hand-written.
+
+This matters because this repository has now produced the same defect three times: a
+hand-maintained list beside a generated one, drifting silently. `queue_operations`' own tool
+enum was hardcoded and omitted `manage_contacts` for an entire release; `coverage-baseline.json`
+sat a month stale, missing a whole service; and #161 was a hand-kept description diverging
+from what the model was told. A hardcoded list of batchable operations would be the fourth.
+
+### The old name keeps working for one minor release
+
+`queue_operations` stays registered as an alias, dispatching to the same handler, and its
+description says it is renamed. MCP client configurations and agent habits both reference
+it, and a tool that vanishes gives a caller no way to discover what replaced it.
+
+## Consequences
+
+### Positive
+
+- 200 contact deletions become one request instead of 200.
+- Six coverage gaps close, in the two services that publish batch methods.
+- The tool is named for what it does rather than for one of its two strategies.
+- `batch` failing loudly, with the batchable list, teaches the surface at the point of use.
+
+### Negative
+
+- A public tool is renamed. Every rename costs its callers something even with an alias,
+  and the alias has to be removed eventually.
+- Two modes with different input shapes in one tool. The alternative — one shape — was
+  rejected below, but the cost is real: a caller must read which fields go with which mode.
+- Per-item error reporting differs by method. `batchDelete` returns 204 with no body, so a
+  partial failure is not distinguishable per item; `batchCreateContacts` returns a result
+  per contact. The tool cannot present one uniform result shape without inventing detail
+  Google did not send.
+
+### Neutral
+
+- `batch` is narrow and will stay narrow. It covers what Google publishes, which is two
+  services. That is a property of Google's API surface, not of this design.
+- `people.batchUpdateContacts` requires each contact's current `etag`, exactly as the
+  single-contact `update` does. It can be satisfied with one `getBatchGet` followed by one
+  `batchUpdateContacts` — two calls for N contacts, still far better than N — but it is
+  the most involved of the six and lands in the second increment.
+
+## Alternatives Considered
+
+- **Keep the name `queue_operations` and add `mode`.** Rejected: it names the tool after
+  one of the two things it does, and the confusion compounds as soon as `mode: 'batch'`
+  exists inside something called a queue.
+- **Coalesce automatically** — keep the single `operations` array and merge consecutive
+  entries sharing a tool and operation into one batch call. Attractive because it keeps one
+  input shape and needs no new parameter. Rejected: it makes the number of HTTP requests a
+  silent function of argument order, so reordering a list changes cost and error reporting
+  with nothing in the call to say so. The caller should be able to see, in the call they
+  wrote, whether they asked for one request or two hundred.
+- **A separate `batch_operations` tool.** Rejected: two tools whose descriptions differ in
+  one clause is exactly the surface the agent has to disambiguate on every use, and
+  `tools/list` is served once per server, so both would always be advertised.
+- **Expose the batch methods as ordinary operations** — `manage_contacts batchDelete`.
+  Rejected: it spreads bulk semantics across every service's schema, and repeats the
+  `items` parameter in each. The generator flattens all operations into one schema per
+  service and keeps only the first declaration of a repeated parameter name, so per-service
+  `items` parameters would have to be described identically forever (the #161 shape).
+- **Ship the rename without batch.** Rejected as a release: a rename that adds no
+  capability spends the callers' migration cost and returns nothing for it.
+
+## Notes
+
+Delivered in two increments so each is reviewable, split so that nothing advertised is
+inert:
+
+1. **The rename alone** — `bulk_operations`, with `queue_operations` kept as an alias.
+   No behaviour change, no new parameter.
+2. **`mode` and batch** — the `mode` parameter, `batch_resource` in the manifest with its
+   descriptor check, batch execution, and the six methods.
+
+`mode` belongs to the second increment rather than the first. Shipping a `mode: 'batch'`
+the tool cannot execute would advertise a capability in `tools/list` — served once per
+server, to every caller — that answers with an apology. An agent has no way to tell an
+advertised-but-unimplemented option from a broken one.
+
+Both increments land before the release that carries the rename.
+
+Batch size limits are documented by Google as 200 for `batchUpdateContacts` and
+`batchCreateContacts`, 500 for `batchDeleteContacts`, and 1000 ids for the Gmail methods.
+These are to be **verified against live Google** before being enforced, not transcribed —
+this repository has twice found a documented value to be wrong on the wire.

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -85,8 +85,12 @@
       "description": "Manage files in the workspace sandbox — the exchange point for attachments, downloads, and exports"
     },
     {
+      "name": "bulk_operations",
+      "description": "Execute multiple operations in sequence, chaining results between steps"
+    },
+    {
       "name": "queue_operations",
-      "description": "Chain multiple operations sequentially with result references between steps"
+      "description": "RENAMED to bulk_operations — this name still works and will be removed in a future release"
     }
   ],
   "user_config": {

--- a/src/__tests__/server/handler.test.ts
+++ b/src/__tests__/server/handler.test.ts
@@ -44,15 +44,36 @@ describe('handleToolCall', () => {
     // a tool the server advertises.
     mockQueue.mockResolvedValue(stubResponse);
 
-    await handleToolCall('queue_operations', { operations: [] });
+    await handleToolCall('bulk_operations', { operations: [] });
 
     const [, handlers, depth] = mockQueue.mock.calls[0];
     expect(depth).toBe(1);
     expect(Object.keys(handlers)).toEqual(expect.arrayContaining([
-      'queue_operations', 'manage_contacts', 'manage_email', 'manage_accounts',
+      'bulk_operations', 'queue_operations', 'manage_contacts', 'manage_email', 'manage_accounts',
     ]));
 
     // The nested handler must recurse one level deeper, or the bound never bites.
+    await handlers.bulk_operations({ operations: [] });
+    expect(mockQueue.mock.calls[1][2]).toBe(2);
+  });
+
+  it('routes the queue_operations alias to the same handler (ADR-308)', async () => {
+    // Advertising the old name is not enough — it has to dispatch. A schema-only alias
+    // would list in tools/list and then answer "Unknown tool" when called.
+    mockQueue.mockResolvedValue(stubResponse);
+
+    await handleToolCall('queue_operations', { operations: [] });
+
+    expect(mockQueue).toHaveBeenCalledTimes(1);
+    expect(mockQueue.mock.calls[0][2]).toBe(1);
+  });
+
+  it('lets the old name nest too, so an agent that learned it is not broken one level down', async () => {
+    mockQueue.mockResolvedValue(stubResponse);
+
+    await handleToolCall('bulk_operations', { operations: [] });
+    const [, handlers] = mockQueue.mock.calls[0];
+
     await handlers.queue_operations({ operations: [] });
     expect(mockQueue.mock.calls[1][2]).toBe(2);
   });

--- a/src/__tests__/server/tools.test.ts
+++ b/src/__tests__/server/tools.test.ts
@@ -1,13 +1,15 @@
 import { describe, expect, it, vi, type Mock } from 'vitest';
 
 import { toolSchemas, getToolSchema } from '../../server/tools.js';
+import { BULK_TOOL_NAMES } from '../../server/handler.js';
 
 describe('tool registry', () => {
   it('has all expected tools', () => {
     const names = toolSchemas.map(t => t.name);
     // Hand-coded tools
     expect(names).toContain('manage_accounts');
-    expect(names).toContain('queue_operations');
+    expect(names).toContain('bulk_operations');
+    expect(names).toContain('queue_operations');  // the alias, ADR-308
     // Factory-generated tools
     expect(names).toContain('manage_email');
     expect(names).toContain('manage_calendar');
@@ -34,23 +36,26 @@ describe('tool registry', () => {
     }
   });
 
-  it('queue_operations can reach every tool the server advertises', () => {
+  it('bulk_operations can reach every tool the server advertises', () => {
     // This enum used to be written out by hand, so it silently omitted every tool added
     // after it. A new tool worked on its own and was unreachable from a queue, with
     // nothing anywhere to say why — the handler side never had the problem, because
     // domainHandlers is built from the registry. manage_contacts is what surfaced it.
-    const queue = getToolSchema('queue_operations')!;
-    const offered = (queue.inputSchema as any).properties.operations.items.properties.tool.enum as string[];
+    const bulk = getToolSchema('bulk_operations')!;
+    const offered = (bulk.inputSchema as any).properties.operations.items.properties.tool.enum as string[];
 
-    // Every tool, with no carve-out — including queue_operations itself. Nesting is
-    // bounded by depth in handleQueue, not by hiding the tool here.
+    // Every tool, with no carve-out — including bulk_operations itself and the alias.
+    // Nesting is bounded by depth in handleQueue, not by hiding the tool here.
     expect([...offered].sort()).toEqual([...toolSchemas.map(t => t.name)].sort());
     expect(offered).toContain('manage_contacts');
+    expect(offered).toContain('bulk_operations');
     expect(offered).toContain('queue_operations');
   });
 
   it('all domain tools require operation', () => {
-    const domainTools = toolSchemas.filter(t => t.name !== 'queue_operations');
+    // Derived, not listed: the bulk tool and its alias are the only tools with no
+    // `operation`, and hardcoding that exclusion is how the rename broke this test.
+    const domainTools = toolSchemas.filter(t => !BULK_TOOL_NAMES.includes(t.name));
     for (const tool of domainTools) {
       const required = (tool.inputSchema as Record<string, unknown>).required as string[];
       expect(required).toContain('operation');
@@ -98,8 +103,8 @@ describe('manage_calendar schema', () => {
   });
 });
 
-describe('queue_operations schema', () => {
-  const tool = getToolSchema('queue_operations')!;
+describe('bulk_operations schema', () => {
+  const tool = getToolSchema('bulk_operations')!;
   const props = (tool.inputSchema as any).properties;
 
   it('has operations array with maxItems', () => {
@@ -117,5 +122,27 @@ describe('queue_operations schema', () => {
     expect(toolEnum).toContain('manage_calendar');
     expect(toolEnum).toContain('manage_drive');
     expect(toolEnum).toContain('manage_accounts');
+  });
+});
+
+describe('the queue_operations alias', () => {
+  // ADR-308. Removing the old name outright would answer an established call with
+  // "Unknown tool" and no hint of what replaced it — MCP client configs and agent habits
+  // both name it. Remove after one minor release.
+  it('is still advertised', () => {
+    expect(getToolSchema('queue_operations')).toBeDefined();
+  });
+
+  it('says it was renamed, so a reader learns the new name from the tool list', () => {
+    const alias = getToolSchema('queue_operations')!;
+    expect(alias.description).toContain('RENAMED');
+    expect(alias.description).toContain('bulk_operations');
+  });
+
+  it('shares one schema object with bulk_operations, so the two cannot drift', () => {
+    // Identity, not equality. Two structurally equal copies would drift the moment
+    // either is edited — and the derived tool enum is written into one of them.
+    expect(getToolSchema('queue_operations')!.inputSchema)
+      .toBe(getToolSchema('bulk_operations')!.inputSchema);
   });
 });

--- a/src/factory/defaults.ts
+++ b/src/factory/defaults.ts
@@ -104,7 +104,7 @@ function formatDefaultAction(data: unknown): HandlerResponse {
   return {
     text: parts.join(''),
     // `id` stays populated whatever Google called the field, so next-steps and
-    // queue_operations references keep resolving.
+    // bulk_operations references keep resolving.
     refs: { id, ...extractScalarRefs(obj) },
   };
 }

--- a/src/server/handler.ts
+++ b/src/server/handler.ts
@@ -40,18 +40,28 @@ for (const tool of generatedTools) {
 }
 
 /**
- * What a queued operation may call: every tool, including `queue_operations`.
+ * The names that reach the bulk handler. `queue_operations` is the former name, kept
+ * working for one minor release — ADR-308. Both are advertised and both dispatch here.
+ */
+export const BULK_TOOL_NAMES = ['bulk_operations', 'queue_operations'];
+
+/**
+ * What a queued operation may call: every tool, including `bulk_operations` itself.
  *
- * A queue is a tool call like any other, so the set of things it can name is the set of
- * tools — no carve-out, and nothing for a caller to discover by being refused. Nesting is
- * bounded by depth inside handleQueue rather than by omission here, so the limit arrives
- * as a sentence saying what it is instead of an "Unknown tool" for something the server
- * plainly advertises.
+ * A bulk call is a tool call like any other, so the set of things it can name is the set
+ * of tools — no carve-out, and nothing for a caller to discover by being refused. Nesting
+ * is bounded by depth inside handleQueue rather than by omission here, so the limit
+ * arrives as a sentence saying what it is instead of an "Unknown tool" for something the
+ * server plainly advertises.
+ *
+ * The old name is queueable too. An agent that learned it before the rename should not
+ * find it working at the top level and failing one level down.
  */
 function queueableHandlers(depth: number): Record<string, ToolHandler> {
+  const nested: ToolHandler = (params) => handleQueue(params, queueableHandlers(depth + 1), depth + 1);
   return {
     ...domainHandlers,
-    queue_operations: (params) => handleQueue(params, queueableHandlers(depth + 1), depth + 1),
+    ...Object.fromEntries(BULK_TOOL_NAMES.map((name) => [name, nested])),
   };
 }
 
@@ -62,8 +72,8 @@ export async function handleToolCall(
   const currentEpoch = advanceEpoch();
   const tracker = getSessionTracker();
 
-  // Queue wraps the domain handlers (each queued op also advances the epoch)
-  if (toolName === 'queue_operations') {
+  // Bulk wraps the domain handlers (each queued op also advances the epoch)
+  if (BULK_TOOL_NAMES.includes(toolName)) {
     const result = await handleQueue(params, queueableHandlers(1), 1);
     const queueEmail = extractEmailFromQueue(params);
     if (queueEmail) {

--- a/src/server/queue.ts
+++ b/src/server/queue.ts
@@ -51,7 +51,7 @@ export async function handleQueue(
 ): Promise<HandlerResponse> {
   if (depth > MAX_QUEUE_DEPTH) {
     throw new Error(
-      `queue_operations nested more than ${MAX_QUEUE_DEPTH} deep. Each level multiplies the ` +
+      `bulk_operations nested more than ${MAX_QUEUE_DEPTH} deep. Each level multiplies the ` +
       `work — at 10 operations per queue that ceiling is already 1,000 calls. Flatten the ` +
       `inner queues into their parent.`,
     );

--- a/src/server/tools.ts
+++ b/src/server/tools.ts
@@ -113,7 +113,7 @@ const handCodedSchemas: ToolSchema[] = [
     },
   },
   {
-    name: 'queue_operations',
+    name: 'bulk_operations',
     description: 'Execute multiple operations in sequence. Operations run in order with result references ($0.field) to chain outputs. Use for multi-step workflows.',
     inputSchema: {
       type: 'object',
@@ -159,6 +159,30 @@ const handCodedSchemas: ToolSchema[] = [
   },
 ];
 
+/**
+ * The former name, still advertised and still working. ADR-308.
+ *
+ * Removing it outright would answer an established call with "Unknown tool" and no
+ * indication of what replaced it — MCP client configurations and agent habits both name
+ * it. The schema is shared by reference with `bulk_operations`, so the two cannot drift
+ * and the derived tool enum below fills both at once.
+ *
+ * Remove after one minor release.
+ */
+const DEPRECATED_ALIASES: Record<string, string> = {
+  queue_operations: 'bulk_operations',
+};
+
+for (const [oldName, newName] of Object.entries(DEPRECATED_ALIASES)) {
+  const target = handCodedSchemas.find((t) => t.name === newName);
+  if (!target) continue;
+  handCodedSchemas.push({
+    name: oldName,
+    description: `RENAMED to \`${newName}\`, which does the same thing. This name still works and will be removed in a future release. ${target.description}`,
+    inputSchema: target.inputSchema,
+  });
+}
+
 // Factory-generated schemas from the shared registry
 const factorySchemas: ToolSchema[] = generatedTools.map(t => t.schema);
 
@@ -179,9 +203,11 @@ export const toolSchemas: ToolSchema[] = [
  * what the limit is, rather than by omission here, which would answer a plainly
  * advertised tool with "Unknown tool".
  */
-const queueTool = handCodedSchemas.find(t => t.name === 'queue_operations');
-if (queueTool) {
-  const operations = (queueTool.inputSchema.properties as Record<string, { items: { properties: { tool: { enum: string[] } } } }>).operations;
+const bulkTool = handCodedSchemas.find(t => t.name === 'bulk_operations');
+if (bulkTool) {
+  const operations = (bulkTool.inputSchema.properties as Record<string, { items: { properties: { tool: { enum: string[] } } } }>).operations;
+  // The alias shares this inputSchema object by reference, so it is filled by the same
+  // assignment and cannot disagree about which tools exist.
   operations.items.properties.tool.enum = toolSchemas.map(t => t.name);
 }
 

--- a/src/services/docs/patch.ts
+++ b/src/services/docs/patch.ts
@@ -120,7 +120,7 @@ function flattenTabs(tabs: unknown, depth = 0): FlatTab[] {
  * Render one tab as a titled section, headed by the id that addresses it.
  *
  * The id goes in the TEXT, not just in `refs`. Only `result.text` is returned to the
- * model — `refs` is internal, read by queue_operations for chaining — so a tab id that
+ * model — `refs` is internal, read by bulk_operations for chaining — so a tab id that
  * lives only in refs cannot be used by the agent reading this. Telling a reader to "pass
  * the tabId" while keeping every tabId out of the response is #158's original complaint
  * with a new hiding place.


### PR DESCRIPTION
First of two increments for #10. **ADR-308** carries the design.

## Description

`queue_operations` is named after one of its strategies rather than after what it does. That was cosmetic until the second strategy turned out to exist: Google publishes methods performing one operation across many resources in a single request, so 200 contact deletions need not cost 200 round trips.

**This increment is the rename alone.** `mode` and batch execution follow in the next one — shipping a `mode: 'batch'` the tool cannot execute would advertise a capability in `tools/list` (served once per server, to every caller) that answers with an apology, and an agent has no way to tell advertised-but-unimplemented from broken.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## What the measurement corrected

Every method with `batch` in its name splits two ways, and only one is a bulk *mode*:

**Many edits to ONE resource** — already how these operations work, not a bulk mode:
`docs.documents.batchUpdate`, `sheets.spreadsheets.batchUpdate`, `sheets.values.batchUpdate/batchClear/batchGet` (+ `ByDataFilter`)

**One operation across MANY resources** — the real surface, **6 methods, 2 services, all coverage gaps**:
`gmail.users.messages.batchModify`, `gmail.users.messages.batchDelete`, `people.batchCreateContacts`, `people.batchUpdateContacts`, `people.batchDeleteContacts`, `people.getBatchGet`

An earlier tally said five: it **missed `people.getBatchGet`** (a batch read) and **included `sheets.values.batchGet`**, which is many ranges within one spreadsheet. Both errors came from reading method names instead of what the methods address. `calendar`, `docs`, `drive`, `meet` and `tasks` publish no such method at all — for those, a queue isn't a fallback, it's the only thing there is.

## The old name keeps working

`queue_operations` stays advertised and stays dispatched, for one minor release. Removing it would answer an established call with "Unknown tool" and no hint of what replaced it; MCP client configs and agent habits both name it.

- The alias shares the schema **object by reference**, so the derived tool enum fills both at once and the two cannot drift. Asserted by **identity, not equality** — two structurally equal copies drift the moment either is edited.
- **It nests too.** An agent that learned the old name shouldn't find it working at the top level and failing one level down.

## Also

- `tools.test.ts` excluded `queue_operations` **by name** and broke on the rename — it now derives the exclusion from the exported `BULK_TOOL_NAMES`. Same drift lesson as the hardcoded tool enum.
- The nesting-depth error message is agent-visible and said `queue_operations`; it says `bulk_operations` now.
- `mcpb/manifest.json` declares both — verified, **13 tools declared == served**.

## Testing Performed

- [x] `make check` green — **943 tests**, up from 938.
- [x] `make mcpb` — bundle manifest matches what the server serves.
- [x] **Advertising an alias is not dispatching one.** A schema-only alias would list in `tools/list` and then answer "Unknown tool". Proven by removing the name from `BULK_TOOL_NAMES` and watching **four tests go red**.

## Additional Notes

Next increment: `mode`, `batch_resource` in the manifest with its descriptor check, batch execution, and the six methods. Batch capability will be **derived** from the manifest, never hand-listed — this repo has now produced that defect three times (the hardcoded queue tool enum, the stale coverage baseline, and #161).

Batch size limits are documented by Google as 200/500/1000 depending on the method. Those will be **verified live** before being enforced, not transcribed — a documented value has been wrong on the wire twice here.