### PR TITLE
feat(tools): batch mode — one Google request across many resources (ADR-308)

### DIFF
--- a/docs/architecture/api/ADR-308-rename-queue-operations-to-bulk-operations-with-queue-and-batch-modes.md
+++ b/docs/architecture/api/ADR-308-rename-queue-operations-to-bulk-operations-with-queue-and-batch-modes.md
@@ -26,15 +26,25 @@ to do it in one.
 Measured across all eight services in `descriptor.json`. Every method with `batch` in its
 name falls into one of two groups, and only the second is a bulk *mode*:
 
-**Many edits to ONE resource** — already how these operations work, not a bulk mode:
+**Many edits to ONE resource** — a second axis, and not the one this ADR builds:
 
 | Service | Method |
 |---|---|
 | docs | `documents.batchUpdate` |
 | sheets | `spreadsheets.batchUpdate`, `values.batchUpdate`, `values.batchClear`, `values.batchGet` (+ `ByDataFilter` variants) |
 
-`manage_docs write` and every `manage_sheets` write already call these. A caller asking for
-"batch" here would be asking for what they already have.
+An earlier draft of this ADR said these operations "already work this way". **They do not.**
+`manage_docs` and `manage_sheets` do call `batchUpdate`, but each tool call sends
+`requests: [ …exactly one request… ]` (`src/services/docs/patch.ts`,
+`src/services/sheets/patch.ts`). Google's `batchUpdate` accepts an array, so five edits to
+one document currently cost five HTTP calls carrying one request each, where they could
+cost one carrying five.
+
+That is a real, unused capability on a different axis, and the call shape designed below
+would serve it unchanged — the shared `documentId` at the top level, the individual edits
+as `items`. It is not built here, and the refusal message deliberately does not claim
+"Google publishes no batch method", because for docs and sheets that would be false.
+Tracked separately.
 
 **One operation across MANY resources** — the real bulk surface:
 

--- a/docs/architecture/api/ADR-308-rename-queue-operations-to-bulk-operations-with-queue-and-batch-modes.md
+++ b/docs/architecture/api/ADR-308-rename-queue-operations-to-bulk-operations-with-queue-and-batch-modes.md
@@ -51,6 +51,34 @@ Six methods, two services. **All six are coverage gaps** — none appears in any
 `calendar`, `docs`, `drive`, `meet` and `tasks` publish no such method at all, so for those
 services a queue is not a fallback, it is the only thing there is.
 
+**Five of the six are batchable here. `users.messages.batchDelete` is not**, and the reason
+is a scope rather than an omission:
+
+```
+users.messages.trash        ["https://mail.google.com/", ".../gmail.modify"]
+users.messages.batchDelete  ["https://mail.google.com/"]
+users.messages.delete       ["https://mail.google.com/"]
+```
+
+Gmail's delete is immediate and permanent — it does not route through the trash, which is
+why `trash` accepts `gmail.modify` and delete accepts only `https://mail.google.com/`, the
+broadest scope Gmail publishes. This server requests `gmail.modify` and nothing wider, and
+`manage_email` deliberately exposes no permanent delete at all (`safety.ts` records
+`gmail: []` in `permanentDeletes` with the note that trash is reversible).
+
+Batching it would therefore mean widening every Gmail account to full mailbox authority
+and re-consenting all of them, to gain an operation whose only advantage over `trash` is
+irreversibility. The capability is not really lost: `batchModify` with
+`addLabelIds: ['TRASH']` trashes many messages in one request, reversibly, on the scope
+already held.
+
+Noted while measuring this, and worth fixing on its own: the call-time access policy models
+two cases — narrowed to read-only, and never authorized — but not a third, *this operation
+requires a scope the server never requests*. An operation like `users.messages.delete`
+would be refused with "was authorized read-only for gmail" to an account holding full
+`gmail.modify`, which is simply false. No operation in any manifest currently requires an
+unrequested scope, so the case is unreachable today; a guard belongs with the policy.
+
 An earlier count of this surface said five methods and missed `people.getBatchGet`, which
 is a batch *read*. It also included `sheets.values.batchGet`, which belongs to the first
 group — many ranges within one spreadsheet. Both errors came from reading method names
@@ -106,11 +134,31 @@ An operation opts in by naming the Google method that batches it:
 delete:
   type: action
   resource: people.deleteContact
-  batch_resource: people.batchDeleteContacts
+  batch:
+    resource: people.batchDeleteContacts
 ```
 
-A test asserts every `batch_resource` resolves in `descriptor.json`, the same way `resource`
-is checked. The list of batchable operations is then *derived* from the manifest at
+The batch method is not always the same method pluralised. Gmail has no bulk trash; the
+way to trash many messages is `batchModify` adding the `TRASH` label. The agent should not
+have to know that, so the manifest carries the translation and `defaults` supplies the
+fixed part of the body — the same mechanism that keeps field masks and source constants
+out of the schema (ADR-300):
+
+```yaml
+trash:
+  type: action
+  resource: users.messages.trash
+  batch:
+    resource: users.messages.batchModify
+    defaults:
+      addLabelIds: ['TRASH']
+```
+
+`bulk_operations {mode:'batch', tool:'manage_email', operation:'trash', items:[…]}` then
+trashes many messages in one request, reversibly, and the caller never sees a label.
+
+A test asserts every batch `resource` resolves in `descriptor.json`, the same way
+`resource` is checked. The list of batchable operations is *derived* from the manifest at
 startup, never hand-written.
 
 This matters because this repository has now produced the same defect three times: a

--- a/src/__tests__/factory/generator.test.ts
+++ b/src/__tests__/factory/generator.test.ts
@@ -838,3 +838,34 @@ describe('generateHandler — custom-handler next-steps wrapping', () => {
     expect(matches.length).toBe(1);
   });
 });
+
+describe('batch declarations', () => {
+  // Same discipline as `resource`: a batch resource that does not exist in the descriptor
+  // is a method we would call and Google would reject, discoverable only live. ADR-308.
+  it('every batch resource is a method Google declares', async () => {
+    const manifest = loadManifest();
+    const descriptor = await loadDescriptor();
+    const bad: string[] = [];
+
+    for (const [serviceName, service] of Object.entries(manifest.services)) {
+      for (const [opName, op] of Object.entries(service.operations)) {
+        if (!op.batch) continue;
+        const method = descriptor.services[service.google_service]?.methods?.[op.batch.resource];
+        if (!method) bad.push(`${serviceName}.${opName}: no such method ${op.batch.resource}`);
+      }
+    }
+
+    expect(bad).toEqual([]);
+  });
+
+  it('only declares batch where the operation itself exists', () => {
+    // A batch block on an operation with no `resource` would be a bulk form of something
+    // that has no singular form — nothing for a caller to graduate from.
+    const manifest = loadManifest();
+    for (const service of Object.values(manifest.services)) {
+      for (const [opName, op] of Object.entries(service.operations)) {
+        if (op.batch) expect(op.resource, `${opName} declares batch but no resource`).toBeTruthy();
+      }
+    }
+  });
+});

--- a/src/__tests__/factory/generator.test.ts
+++ b/src/__tests__/factory/generator.test.ts
@@ -869,3 +869,34 @@ describe('batch declarations', () => {
     }
   });
 });
+
+describe('batch declarations supply what Google requires', () => {
+  // Found live: users.messages.batchModify takes a `userId` PATH parameter, and batch
+  // mode reads only the batch block's defaults — not the operation's. The call failed
+  // with "missing required path param 'userId'" after passing every offline test.
+  //
+  // Derived from the descriptor rather than listed, so a new batch method with a required
+  // path parameter is caught before it reaches Google.
+  it('every required path param of a batch method has a default', async () => {
+    const manifest = loadManifest();
+    const descriptor = await loadDescriptor();
+    const missing: string[] = [];
+
+    for (const [serviceName, service] of Object.entries(manifest.services)) {
+      for (const [opName, op] of Object.entries(service.operations)) {
+        if (!op.batch) continue;
+        const method = descriptor.services[service.google_service]?.methods?.[op.batch.resource];
+        if (!method) continue;   // covered by the resource-resolves test
+
+        for (const [param, def] of Object.entries(method.parameters ?? {})) {
+          if (def.location !== 'path' || !def.required) continue;
+          if (op.batch.defaults?.[param] === undefined) {
+            missing.push(`${serviceName}.${opName}: ${op.batch.resource} needs path param '${param}'`);
+          }
+        }
+      }
+    }
+
+    expect(missing).toEqual([]);
+  });
+});

--- a/src/__tests__/server/batch.test.ts
+++ b/src/__tests__/server/batch.test.ts
@@ -73,21 +73,64 @@ describe('the body Google receives', () => {
     expect(body().resourceNames).toEqual(['people/c1', 'people/c2']);
   });
 
-  it('batchUpdateContacts keys contacts by resource name, not an array', async () => {
+  it('batchUpdateContacts fetches etags first, then keys contacts by resource name', async () => {
+    // MEASURED live: without an etag per person Google answers FAILED_PRECONDITION. So an
+    // update is a read-modify-write — one getBatchGet, one batchUpdateContacts. Two calls
+    // for N contacts, against the 2N a queue would make.
+    mockCall.mockResolvedValueOnce({
+      responses: [
+        { person: { resourceName: 'people/c1', etag: 'etag-1' } },
+        { person: { resourceName: 'people/c2', etag: 'etag-2' } },
+      ],
+    } as never);
+    mockCall.mockResolvedValueOnce({} as never);
+
     await handleBatch({
       mode: 'batch', tool: 'manage_contacts', operation: 'update', email: 'u@t.com',
-      updateMask: 'names',
       items: [
-        { contactId: 'people/c1', person: { names: [{ givenName: 'Ada' }] } },
-        { contactId: 'people/c2', person: { names: [{ givenName: 'Grace' }] } },
+        { contactId: 'people/c1', name: 'Ada Lovelace' },
+        { contactId: 'people/c2', name: 'Grace Hopper' },
       ],
     });
 
-    expect(body().contacts).toEqual({
-      'people/c1': { names: [{ givenName: 'Ada' }] },
-      'people/c2': { names: [{ givenName: 'Grace' }] },
+    expect(mockCall).toHaveBeenCalledTimes(2);
+    expect(mockCall.mock.calls[0][1]).toBe('people.getBatchGet');
+    expect(mockCall.mock.calls[1][1]).toBe('people.batchUpdateContacts');
+
+    const sentBody = mockCall.mock.calls[1][2] as Record<string, any>;
+    expect(Object.keys(sentBody.contacts)).toEqual(['people/c1', 'people/c2']);
+    expect(sentBody.contacts['people/c1'].etag).toBe('etag-1');
+    expect(sentBody.contacts['people/c2'].etag).toBe('etag-2');
+    // Flat fields converted the same way single `update` converts them.
+    expect(sentBody.contacts['people/c1'].names).toEqual([{ givenName: 'Ada', familyName: 'Lovelace' }]);
+    // updateMask derived from what the caller actually supplied, not a fixed list —
+    // naming a field with no value in the body CLEARS it.
+    expect(sentBody.updateMask).toBe('names');
+  });
+
+  it('refuses to update a contact that does not exist, rather than sending a bad etag', async () => {
+    mockCall.mockResolvedValueOnce({ responses: [] } as never);
+
+    const result = await handleBatch({
+      mode: 'batch', tool: 'manage_contacts', operation: 'update', email: 'u@t.com',
+      items: [{ contactId: 'people/cGone', name: 'Nobody' }],
     });
-    expect(body().updateMask).toBe('names');
+
+    expect(result.text).toContain('No contact found');
+    expect(mockCall).toHaveBeenCalledTimes(1);   // the read only; nothing was written
+  });
+
+  it('batchCreateContacts takes the same flat fields as single create', async () => {
+    // Live, passing flat fields straight through was a 400 from Google: the raw People
+    // shape is parallel arrays of objects, which manage_contacts exists to hide.
+    await handleBatch({
+      mode: 'batch', tool: 'manage_contacts', operation: 'create', email: 'u@t.com',
+      items: [{ name: 'Ada Lovelace', contactEmail: 'ada@example.com' }],
+    });
+
+    const contacts = body().contacts as any[];
+    expect(contacts[0].contactPerson.names).toEqual([{ givenName: 'Ada', familyName: 'Lovelace' }]);
+    expect(contacts[0].contactPerson.emailAddresses).toEqual([{ value: 'ada@example.com' }]);
   });
 
   it('getBatchGet sends resourceNames and a field mask', async () => {
@@ -124,6 +167,9 @@ describe('shared arguments versus per-item arguments', () => {
 
     expect(sent()[1]).toBe('users.messages.batchModify');
     expect(body()).toEqual({
+      // A required PATH parameter, from the batch block's defaults. Omitting it failed
+      // live with "missing required path param 'userId'" after passing every mocked test.
+      userId: 'me',
       ids: ['m1', 'm2', 'm3'],
       addLabelIds: ['STARRED'],
       removeLabelIds: ['UNREAD'],
@@ -150,7 +196,7 @@ describe('bulk trash', () => {
     });
 
     expect(sent()[1]).toBe('users.messages.batchModify');
-    expect(body()).toEqual({ ids: ['m1', 'm2'], addLabelIds: ['TRASH'] });
+    expect(body()).toEqual({ userId: 'me', ids: ['m1', 'm2'], addLabelIds: ['TRASH'] });
   });
 
   it('is one request regardless of how many messages', async () => {
@@ -214,5 +260,80 @@ describe('batch goes through the safety layer', () => {
       configurePolicies([]);
       spy.mockRestore();
     }
+  });
+});
+
+describe('rendering results the agent can use', () => {
+  // `refs` never reaches the model — the server returns result.text only. Live, batch
+  // `get` answered "2 results returned" and threw the two people away, which makes a
+  // batch READ pointless.
+  it('prints the people a batch get returned', async () => {
+    mockCall.mockResolvedValue({
+      responses: [
+        { person: { resourceName: 'people/c1', names: [{ displayName: 'Ada Lovelace' }], emailAddresses: [{ value: 'ada@example.com' }] } },
+        { person: { resourceName: 'people/c2', names: [{ displayName: 'Grace Hopper' }] } },
+      ],
+    } as never);
+
+    const result = await handleBatch({
+      mode: 'batch', tool: 'manage_contacts', operation: 'get', email: 'u@t.com',
+      items: [{ contactId: 'people/c1' }, { contactId: 'people/c2' }],
+    });
+
+    expect(result.text).toContain('people/c1');
+    expect(result.text).toContain('Ada Lovelace');
+    expect(result.text).toContain('ada@example.com');
+    expect(result.text).toContain('Grace Hopper');
+  });
+
+  it('prints what a batch create created, so the ids can be acted on', async () => {
+    mockCall.mockResolvedValue({
+      createdPeople: [{ httpStatusCode: 200, person: { resourceName: 'people/cNew', names: [{ displayName: 'Ada Lovelace' }] } }],
+    } as never);
+
+    const result = await handleBatch({
+      mode: 'batch', tool: 'manage_contacts', operation: 'create', email: 'u@t.com',
+      items: [{ name: 'Ada Lovelace' }],
+    });
+
+    expect(result.text).toContain('people/cNew');
+    expect(result.text).toContain('Ada Lovelace');
+  });
+});
+
+describe('low-friction item forms', () => {
+  // The standing rule: a tool call should be easy to write, with sensible defaults doing
+  // the work. A caller holding a list of ids should be able to pass a list of ids.
+  it('accepts bare id strings', async () => {
+    await handleBatch({
+      mode: 'batch', tool: 'manage_contacts', operation: 'delete', email: 'u@t.com',
+      items: ['people/c1', 'people/c2'],
+    });
+    expect(body().resourceNames).toEqual(['people/c1', 'people/c2']);
+  });
+
+  it('accepts bare message ids for trash', async () => {
+    await handleBatch({
+      mode: 'batch', tool: 'manage_email', operation: 'trash', email: 'u@t.com',
+      items: ['m1', 'm2'],
+    });
+    expect(body()).toEqual({ userId: 'me', ids: ['m1', 'm2'], addLabelIds: ['TRASH'] });
+  });
+
+  it('adds the people/ prefix a caller left off, as the single operations do', async () => {
+    await handleBatch({
+      mode: 'batch', tool: 'manage_contacts', operation: 'delete', email: 'u@t.com',
+      items: ['c1', { contactId: 'c2' }],
+    });
+    expect(body().resourceNames).toEqual(['people/c1', 'people/c2']);
+  });
+
+  it('still takes the object form when items carry more than an id', async () => {
+    await handleBatch({
+      mode: 'batch', tool: 'manage_contacts', operation: 'create', email: 'u@t.com',
+      items: [{ name: 'Ada Lovelace', contactEmail: 'ada@example.com' }],
+    });
+    const contacts = body().contacts as any[];
+    expect(contacts[0].contactPerson.names).toEqual([{ givenName: 'Ada', familyName: 'Lovelace' }]);
   });
 });

--- a/src/__tests__/server/batch.test.ts
+++ b/src/__tests__/server/batch.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Batch mode — one Google request across many resources. ADR-308.
+ *
+ * The assertions that matter are about the BODY that goes on the wire, because that is
+ * Google's shape rather than ours and there is no type protecting it.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../google/client.js');
+const { call } = await import('../../google/client.js');
+const { handleBatch, batchableOperations } = await import('../../server/batch.js');
+
+const mockCall = vi.mocked(call);
+const sent = () => mockCall.mock.calls[0];
+const body = () => mockCall.mock.calls[0][2] as Record<string, unknown>;
+
+beforeEach(() => mockCall.mockResolvedValue({} as never));
+afterEach(() => mockCall.mockReset());
+
+describe('which operations batch', () => {
+  it('is derived from the manifest, not listed anywhere', () => {
+    const keys = [...batchableOperations().keys()].sort();
+    expect(keys).toEqual([
+      'manage_contacts.create',
+      'manage_contacts.delete',
+      'manage_contacts.get',
+      'manage_contacts.update',
+      'manage_email.modify',
+      'manage_email.trash',
+    ]);
+  });
+});
+
+describe('refusing what cannot batch', () => {
+  it('names the operations that can, rather than saying no', async () => {
+    const result = await handleBatch({
+      mode: 'batch', tool: 'manage_calendar', operation: 'delete',
+      email: 'u@t.com', items: [{ eventId: 'e1' }],
+    });
+
+    expect(result.text).toContain('cannot be batched');
+    expect(result.text).toContain('manage_contacts delete');
+    expect(result.text).toContain("mode:'queue'");
+    expect(mockCall).not.toHaveBeenCalled();
+  });
+
+  it('refuses an empty items list', async () => {
+    const result = await handleBatch({
+      mode: 'batch', tool: 'manage_contacts', operation: 'delete', email: 'u@t.com', items: [],
+    });
+    expect(result.text).toContain('non-empty');
+    expect(mockCall).not.toHaveBeenCalled();
+  });
+
+  it('refuses without an account', async () => {
+    const result = await handleBatch({
+      mode: 'batch', tool: 'manage_contacts', operation: 'delete', items: [{ contactId: 'people/c1' }],
+    });
+    expect(result.text).toContain('email');
+    expect(mockCall).not.toHaveBeenCalled();
+  });
+});
+
+describe('the body Google receives', () => {
+  it('batchDeleteContacts takes resourceNames', async () => {
+    await handleBatch({
+      mode: 'batch', tool: 'manage_contacts', operation: 'delete', email: 'u@t.com',
+      items: [{ contactId: 'people/c1' }, { contactId: 'people/c2' }],
+    });
+
+    expect(sent()[0]).toBe('people');
+    expect(sent()[1]).toBe('people.batchDeleteContacts');
+    expect(body().resourceNames).toEqual(['people/c1', 'people/c2']);
+  });
+
+  it('batchUpdateContacts keys contacts by resource name, not an array', async () => {
+    await handleBatch({
+      mode: 'batch', tool: 'manage_contacts', operation: 'update', email: 'u@t.com',
+      updateMask: 'names',
+      items: [
+        { contactId: 'people/c1', person: { names: [{ givenName: 'Ada' }] } },
+        { contactId: 'people/c2', person: { names: [{ givenName: 'Grace' }] } },
+      ],
+    });
+
+    expect(body().contacts).toEqual({
+      'people/c1': { names: [{ givenName: 'Ada' }] },
+      'people/c2': { names: [{ givenName: 'Grace' }] },
+    });
+    expect(body().updateMask).toBe('names');
+  });
+
+  it('getBatchGet sends resourceNames and a field mask', async () => {
+    await handleBatch({
+      mode: 'batch', tool: 'manage_contacts', operation: 'get', email: 'u@t.com',
+      items: [{ contactId: 'people/c1' }],
+    });
+
+    expect(sent()[1]).toBe('people.getBatchGet');
+    expect(body().resourceNames).toEqual(['people/c1']);
+    expect(body().personFields).toBeTruthy();
+  });
+
+  it('batchCreateContacts wraps each item as a contactPerson', async () => {
+    await handleBatch({
+      mode: 'batch', tool: 'manage_contacts', operation: 'create', email: 'u@t.com',
+      items: [{ person: { names: [{ givenName: 'Ada' }] } }],
+    });
+
+    expect(body().contacts).toEqual([{ contactPerson: { names: [{ givenName: 'Ada' }] } }]);
+    expect(body().readMask).toBeTruthy();
+  });
+});
+
+describe('shared arguments versus per-item arguments', () => {
+  // The rule that lets one shape serve five Google methods: top-level args are shared,
+  // items carry what differs. A parameter that varies per item is not a batch.
+  it('takes label changes from the top level and ids from items', async () => {
+    await handleBatch({
+      mode: 'batch', tool: 'manage_email', operation: 'modify', email: 'u@t.com',
+      addLabelIds: 'STARRED', removeLabelIds: 'UNREAD',
+      items: [{ messageId: 'm1' }, { messageId: 'm2' }, { messageId: 'm3' }],
+    });
+
+    expect(sent()[1]).toBe('users.messages.batchModify');
+    expect(body()).toEqual({
+      ids: ['m1', 'm2', 'm3'],
+      addLabelIds: ['STARRED'],
+      removeLabelIds: ['UNREAD'],
+    });
+  });
+
+  it('accepts a comma string or an array for labels', async () => {
+    await handleBatch({
+      mode: 'batch', tool: 'manage_email', operation: 'modify', email: 'u@t.com',
+      addLabelIds: ['STARRED', 'IMPORTANT'], items: [{ messageId: 'm1' }],
+    });
+    expect(body().addLabelIds).toEqual(['STARRED', 'IMPORTANT']);
+  });
+});
+
+describe('bulk trash', () => {
+  // Gmail publishes no bulk trash. Trashing many messages is batchModify adding the TRASH
+  // label — reversible, and on the gmail.modify scope already held. The manifest carries
+  // that translation so the caller asks to trash and never sees a label.
+  it('routes trash through batchModify with the TRASH label', async () => {
+    await handleBatch({
+      mode: 'batch', tool: 'manage_email', operation: 'trash', email: 'u@t.com',
+      items: [{ messageId: 'm1' }, { messageId: 'm2' }],
+    });
+
+    expect(sent()[1]).toBe('users.messages.batchModify');
+    expect(body()).toEqual({ ids: ['m1', 'm2'], addLabelIds: ['TRASH'] });
+  });
+
+  it('is one request regardless of how many messages', async () => {
+    await handleBatch({
+      mode: 'batch', tool: 'manage_email', operation: 'trash', email: 'u@t.com',
+      items: Array.from({ length: 200 }, (_, i) => ({ messageId: `m${i}` })),
+    });
+
+    expect(mockCall).toHaveBeenCalledTimes(1);
+    expect((body().ids as string[]).length).toBe(200);
+  });
+});
+
+describe('reporting what Google actually said', () => {
+  it('does not invent per-item status when Google returns no body', async () => {
+    mockCall.mockResolvedValue({} as never);
+    const result = await handleBatch({
+      mode: 'batch', tool: 'manage_email', operation: 'trash', email: 'u@t.com',
+      items: [{ messageId: 'm1' }],
+    });
+
+    // batchModify answers 204 with nothing. Claiming "1 succeeded" would be fabrication.
+    expect(result.text).toContain('does not report per-item status');
+  });
+
+  it('reports the count when Google does return results', async () => {
+    mockCall.mockResolvedValue({ createContacts: [{}, {}] } as never);
+    const result = await handleBatch({
+      mode: 'batch', tool: 'manage_contacts', operation: 'create', email: 'u@t.com',
+      items: [{ person: {} }, { person: {} }],
+    });
+
+    expect(result.text).toContain('2 results returned');
+  });
+});
+
+describe('batch goes through the safety layer', () => {
+  // Batch reaches Google without passing through generateHandler, so it gets no policy
+  // check for free — the same defect as manage_scratchpad (#171), in newer code. Doing
+  // many writes at once is the last place to skip it: a read-only account refused one
+  // contact deletion must not be permitted two hundred.
+  it('refuses a read-only account, and never calls Google', async () => {
+    const { configurePolicies, accountAccess } = await import('../../factory/safety.js');
+    const { SERVICE_SCOPE_MAP_READONLY } = await import('../../accounts/oauth.js');
+    const creds = await import('../../accounts/credentials.js');
+    const spy = vi.spyOn(creds, 'readCredential').mockResolvedValue(
+      { scopes: SERVICE_SCOPE_MAP_READONLY.contacts } as never,
+    );
+    configurePolicies([accountAccess]);
+
+    try {
+      const result = await handleBatch({
+        mode: 'batch', tool: 'manage_contacts', operation: 'delete', email: 'u@t.com',
+        items: [{ contactId: 'people/c1' }, { contactId: 'people/c2' }],
+      });
+
+      expect(result.text).toContain('Blocked by safety policy');
+      expect(result.text).toContain("services:'contacts'");
+      expect(mockCall).not.toHaveBeenCalled();
+    } finally {
+      configurePolicies([]);
+      spy.mockRestore();
+    }
+  });
+});

--- a/src/__tests__/server/batch.test.ts
+++ b/src/__tests__/server/batch.test.ts
@@ -39,6 +39,10 @@ describe('refusing what cannot batch', () => {
     });
 
     expect(result.text).toContain('cannot be batched');
+    // Must not claim Google publishes no batch method: docs and sheets publish
+    // batchUpdate, which batches many edits to ONE document. A refusal should not teach
+    // the caller something false about the API.
+    expect(result.text).not.toContain('publishes no batch method');
     expect(result.text).toContain('manage_contacts delete');
     expect(result.text).toContain("mode:'queue'");
     expect(mockCall).not.toHaveBeenCalled();

--- a/src/factory/manifest/contacts.yaml
+++ b/src/factory/manifest/contacts.yaml
@@ -70,6 +70,8 @@ operations:
     type: detail
     description: "get one person in full — addresses, birthday, notes, relations"
     resource: people.get
+    batch:
+      resource: people.getBatchGet
     params:
       contactId:
         type: string
@@ -89,6 +91,8 @@ operations:
     type: action
     description: "create a new contact"
     resource: people.createContact
+    batch:
+      resource: people.batchCreateContacts
     params:
       name:
         type: string
@@ -124,6 +128,8 @@ operations:
     type: action
     description: "change an existing contact (only the fields you pass; pass an empty string to clear one)"
     resource: people.updateContact
+    batch:
+      resource: people.batchUpdateContacts
     params:
       contactId:
         type: string
@@ -155,6 +161,8 @@ operations:
     type: action
     description: "delete a contact"
     resource: people.deleteContact
+    batch:
+      resource: people.batchDeleteContacts
     params:
       contactId:
         type: string

--- a/src/factory/manifest/gmail.yaml
+++ b/src/factory/manifest/gmail.yaml
@@ -162,6 +162,13 @@ operations:
     type: action
     description: "move a message to trash"
     resource: users.messages.trash
+    # Gmail publishes no bulk trash. Trashing many messages is batchModify adding the
+    # TRASH label — reversible, and on the gmail.modify scope we already hold. The caller
+    # asks to trash; the label is ours to know. (ADR-308)
+    batch:
+      resource: users.messages.batchModify
+      defaults:
+        addLabelIds: ['TRASH']
     params:
       messageId:
         type: string
@@ -220,6 +227,8 @@ operations:
     type: action
     description: "add or remove labels on a message (e.g. archive, mark read/unread)"
     resource: users.messages.modify
+    batch:
+      resource: users.messages.batchModify
     params:
       messageId:
         type: string

--- a/src/factory/manifest/gmail.yaml
+++ b/src/factory/manifest/gmail.yaml
@@ -168,6 +168,10 @@ operations:
     batch:
       resource: users.messages.batchModify
       defaults:
+        # Required PATH parameter. The single operations each carry their own `userId`,
+        # and batch reads only this block — so omitting it here failed live with
+        # "missing required path param 'userId'".
+        userId: me
         addLabelIds: ['TRASH']
     params:
       messageId:
@@ -229,6 +233,8 @@ operations:
     resource: users.messages.modify
     batch:
       resource: users.messages.batchModify
+      defaults:
+        userId: me
     params:
       messageId:
         type: string

--- a/src/factory/types.ts
+++ b/src/factory/types.ts
@@ -42,6 +42,22 @@ export interface OperationDef {
   description: string;
   /** Google resource path (e.g. "users.messages.list"). */
   resource?: string;
+  /**
+   * How this operation is done for many resources in ONE request. ADR-308.
+   *
+   * Present only where Google publishes such a method — six operations across two
+   * services. Its absence is what makes an operation unbatchable, so the batchable set is
+   * derived from the manifest and never listed anywhere else.
+   *
+   * `resource` here is not always the singular method pluralised: Gmail has no bulk
+   * trash, so `trash` batches through `users.messages.batchModify` with `defaults`
+   * supplying the TRASH label. `defaults` is merged into the request body and never
+   * enters the generated schema, exactly as the operation-level `defaults` does.
+   */
+  batch?: {
+    resource: string;
+    defaults?: Record<string, unknown>;
+  };
   /** Named parameters the caller can provide. */
   params?: Record<string, ParamDef>;
   /** Default values merged into the params sent to Google. */

--- a/src/server/batch.ts
+++ b/src/server/batch.ts
@@ -1,0 +1,211 @@
+/**
+ * Batch mode for `bulk_operations` — one Google request across many resources. ADR-308.
+ *
+ * The rule that makes one shape serve five different Google methods: **top-level
+ * arguments are shared across the batch, `items` carry what differs**. A batch is one
+ * call with one set of parameters applied to many resources, so a parameter that varies
+ * per item is not a batch — it is a queue.
+ *
+ * Which operations can batch is DERIVED from the manifest's `batch:` blocks. Nothing here
+ * lists them. This repository has produced the hand-maintained-list-beside-a-generated-one
+ * defect three times (the hardcoded queue tool enum, the stale coverage baseline, #161),
+ * and a list of batchable operations would be the fourth.
+ */
+import { loadManifest } from '../factory/generator.js';
+import { evaluatePolicies } from '../factory/safety.js';
+import { call } from '../google/client.js';
+import type { GoogleService, ServiceMethods } from '../google/methods.js';
+import type { HandlerResponse } from './formatting/markdown.js';
+
+/** One batchable operation, as the manifest declares it. */
+export interface BatchableOp {
+  tool: string;
+  operation: string;
+  service: string;
+  googleService: string;
+  resource: string;
+  defaults: Record<string, unknown>;
+  type: 'list' | 'detail' | 'action';
+}
+
+/** Every operation the manifest says can batch, keyed `tool.operation`. */
+export function batchableOperations(): Map<string, BatchableOp> {
+  const out = new Map<string, BatchableOp>();
+  for (const [service, def] of Object.entries(loadManifest().services)) {
+    for (const [operation, op] of Object.entries(def.operations)) {
+      if (!op.batch) continue;
+      out.set(`${def.tool_name}.${operation}`, {
+        tool: def.tool_name,
+        operation,
+        service,
+        googleService: def.google_service,
+        resource: op.batch.resource,
+        defaults: op.batch.defaults ?? {},
+        type: op.type,
+      });
+    }
+  }
+  return out;
+}
+
+/** `manage_email modify, manage_contacts create, …` — for telling a caller what does batch. */
+function batchableList(): string {
+  return [...batchableOperations().values()]
+    .map((b) => `${b.tool} ${b.operation}`)
+    .join(', ');
+}
+
+/**
+ * Turn the shared arguments and the per-item arguments into the body Google wants.
+ *
+ * Keyed by the Google method rather than by our operation name, because the body shape is
+ * Google's, and two of our operations (`modify` and `trash`) share one method.
+ *
+ * Every builder here was written against Google's declared request shape. None of them is
+ * verified live yet — see the note on limits at the end of ADR-308.
+ */
+type BodyBuilder = (shared: Record<string, unknown>, items: Record<string, unknown>[]) => Record<string, unknown>;
+
+const BODY_BUILDERS: Record<string, BodyBuilder> = {
+  // ids + the label changes, which are shared by definition: one call sets one label set.
+  'users.messages.batchModify': (shared, items) => ({
+    ids: items.map((i) => str(i.messageId)),
+    ...(shared.addLabelIds ? { addLabelIds: list(shared.addLabelIds) } : {}),
+    ...(shared.removeLabelIds ? { removeLabelIds: list(shared.removeLabelIds) } : {}),
+  }),
+
+  // Each contact is different, so the whole payload comes from items.
+  'people.batchCreateContacts': (shared, items) => ({
+    contacts: items.map((i) => ({ contactPerson: i.person ?? i })),
+    readMask: shared.readMask ?? 'names,emailAddresses,phoneNumbers,organizations,metadata',
+  }),
+
+  'people.batchDeleteContacts': (_shared, items) => ({
+    resourceNames: items.map((i) => str(i.contactId ?? i.resourceName)),
+  }),
+
+  // A map keyed by resource name rather than an array — Google's shape, not ours.
+  'people.batchUpdateContacts': (shared, items) => ({
+    contacts: Object.fromEntries(
+      items.map((i) => [str(i.contactId ?? i.resourceName), i.person ?? i]),
+    ),
+    updateMask: shared.updateMask,
+    readMask: shared.readMask ?? 'names,emailAddresses,phoneNumbers,organizations,metadata',
+  }),
+
+  // A GET: resourceNames is a repeated QUERY parameter, not a body.
+  'people.getBatchGet': (shared, items) => ({
+    resourceNames: items.map((i) => str(i.contactId ?? i.resourceName)),
+    personFields: shared.personFields ?? 'names,emailAddresses,phoneNumbers,organizations,metadata',
+  }),
+};
+
+function str(v: unknown): string {
+  return typeof v === 'string' ? v : String(v ?? '');
+}
+
+/** Accept `'A,B'` or `['A','B']` — Google always wants the array. */
+function list(v: unknown): string[] {
+  if (Array.isArray(v)) return v.map(str);
+  return str(v).split(',').map((s) => s.trim()).filter(Boolean);
+}
+
+/**
+ * Run one batch call.
+ *
+ * Refusing is as important as running: an operation with no `batch:` block cannot be
+ * batched, and saying so with the list of what can turns a dead end into the answer.
+ */
+export async function handleBatch(params: Record<string, unknown>): Promise<HandlerResponse> {
+  const tool = params.tool as string | undefined;
+  const operation = params.operation as string | undefined;
+  const items = params.items as Record<string, unknown>[] | undefined;
+
+  if (!tool || !operation) {
+    return err(`mode:'batch' needs \`tool\` and \`operation\`. Operations that batch: ${batchableList()}.`);
+  }
+  if (!Array.isArray(items) || items.length === 0) {
+    return err(`mode:'batch' needs a non-empty \`items\` array — one entry per resource to act on.`);
+  }
+
+  const batchable = batchableOperations();
+  const spec = batchable.get(`${tool}.${operation}`);
+  if (!spec) {
+    return err(
+      `${tool} '${operation}' cannot be batched — Google publishes no batch method for it. ` +
+      `Operations that can: ${batchableList()}. ` +
+      `Use mode:'queue' instead, which works for every operation.`,
+    );
+  }
+
+  const build = BODY_BUILDERS[spec.resource];
+  if (!build) {
+    // A manifest declared a batch resource this file cannot build a body for. That is a
+    // bug in this repo, not in the caller's request, so it says so plainly.
+    return err(`${tool} '${operation}' declares batch resource ${spec.resource}, which has no body builder.`);
+  }
+
+  const account = params.email as string | undefined;
+  if (!account) return err(`mode:'batch' needs \`email\` — the account to act as.`);
+
+  // Batch reaches Google without passing through generateHandler, so it gets no policy
+  // check for free — the same way manage_scratchpad did not (#171). Doing many writes at
+  // once is the last place to skip this: a read-only account would otherwise be refused
+  // one contact deletion and permitted two hundred.
+  const decision = await evaluatePolicies([], { operation: spec.operation, params, account }, spec.googleService, {
+    service: spec.service,
+    googleService: spec.googleService,
+    resource: spec.resource,
+    type: spec.type,
+  });
+  if (decision.action === 'block') {
+    return {
+      text: `**Blocked by safety policy:** ${decision.reason}`,
+      refs: { blocked: true, error: true, policy: decision.reason },
+    };
+  }
+
+  // Shared arguments are everything the caller passed that is not batch plumbing.
+  const { mode: _m, tool: _t, operation: _o, items: _i, email: _e, detail: _d, ...shared } = params;
+  const body = { ...spec.defaults, ...build({ ...spec.defaults, ...shared }, items) };
+
+  const data = await call(
+    spec.googleService as GoogleService,
+    spec.resource as ServiceMethods[GoogleService],
+    body,
+    { account },
+  );
+
+  return {
+    text:
+      `## Batch: ${tool} ${operation}\n\n` +
+      `${items.length} item${items.length === 1 ? '' : 's'} in one request ` +
+      `(\`${spec.resource}\`).\n\n${summarize(data)}`,
+    refs: { batch: true, tool, operation, resource: spec.resource, count: items.length, data },
+  };
+}
+
+/**
+ * Say what Google said, without inventing per-item detail it did not send.
+ *
+ * The methods differ here and the difference is not ours to paper over: batchModify and
+ * batchDelete answer 204 with no body, so a partial failure is not distinguishable per
+ * item; batchCreateContacts answers with a result per contact. Presenting one uniform
+ * shape would mean fabricating the missing half.
+ */
+function summarize(data: unknown): string {
+  if (data === undefined || data === null || (typeof data === 'object' && Object.keys(data).length === 0)) {
+    return 'Google accepted the request and returned no body, which is how it reports success for this method. It does not report per-item status.';
+  }
+  const rec = data as Record<string, unknown>;
+  for (const key of ['createContacts', 'updateResult', 'responses']) {
+    const arr = rec[key];
+    if (Array.isArray(arr)) return `${arr.length} result${arr.length === 1 ? '' : 's'} returned.`;
+  }
+  if (rec.responses || rec.createContacts || rec.updateResult) return 'Completed.';
+  return 'Completed.';
+}
+
+function err(text: string): HandlerResponse {
+  return { text, refs: { error: true } };
+}

--- a/src/server/batch.ts
+++ b/src/server/batch.ts
@@ -243,8 +243,12 @@ export async function handleBatch(params: Record<string, unknown>): Promise<Hand
   const batchable = batchableOperations();
   const spec = batchable.get(`${tool}.${operation}`);
   if (!spec) {
+    // Deliberately does not claim "Google publishes no batch method". For docs and
+    // sheets that is false — they publish `batchUpdate`, which batches many edits to ONE
+    // document rather than one edit across many. Saying otherwise would teach the caller
+    // something untrue about Google's API.
     return err(
-      `${tool} '${operation}' cannot be batched — Google publishes no batch method for it. ` +
+      `${tool} '${operation}' cannot be batched. ` +
       `Operations that can: ${batchableList()}. ` +
       `Use mode:'queue' instead, which works for every operation.`,
     );

--- a/src/server/batch.ts
+++ b/src/server/batch.ts
@@ -14,6 +14,7 @@
 import { loadManifest } from '../factory/generator.js';
 import { evaluatePolicies } from '../factory/safety.js';
 import { call } from '../google/client.js';
+import { buildPerson } from '../services/contacts/patch.js';
 import type { GoogleService, ServiceMethods } from '../google/methods.js';
 import type { HandlerResponse } from './formatting/markdown.js';
 
@@ -66,6 +67,40 @@ function batchableList(): string {
  */
 type BodyBuilder = (shared: Record<string, unknown>, items: Record<string, unknown>[]) => Record<string, unknown>;
 
+/**
+ * The one field an item is mostly likely to be, per method — so a caller with a list of
+ * ids can pass a list of ids.
+ *
+ * `items: ['people/c1', 'people/c2']` says everything `items: [{contactId:'people/c1'},
+ * {contactId:'people/c2'}]` says, with less to get wrong. The object form still works for
+ * the operations that carry more than an id.
+ */
+const ITEM_ID_FIELD: Record<string, string> = {
+  'users.messages.batchModify': 'messageId',
+  'people.batchDeleteContacts': 'contactId',
+  'people.getBatchGet': 'contactId',
+  'people.batchUpdateContacts': 'contactId',
+};
+
+/**
+ * Accept a bare id where an object is expected, and a bare contact id where Google wants
+ * the `people/` prefix — the same courtesy the single-contact operations extend.
+ */
+function normalizeItems(items: unknown[], resource: string): Record<string, unknown>[] {
+  const field = ITEM_ID_FIELD[resource];
+  return items.map((item) => {
+    const obj = (typeof item === 'string' && field)
+      ? { [field]: item }
+      : (item as Record<string, unknown>);
+
+    const id = obj?.contactId ?? obj?.resourceName;
+    if (typeof id === 'string' && id && !id.startsWith('people/')) {
+      return { ...obj, contactId: `people/${id}` };
+    }
+    return obj;
+  });
+}
+
 const BODY_BUILDERS: Record<string, BodyBuilder> = {
   // ids + the label changes, which are shared by definition: one call sets one label set.
   'users.messages.batchModify': (shared, items) => ({
@@ -74,9 +109,12 @@ const BODY_BUILDERS: Record<string, BodyBuilder> = {
     ...(shared.removeLabelIds ? { removeLabelIds: list(shared.removeLabelIds) } : {}),
   }),
 
-  // Each contact is different, so the whole payload comes from items.
+  // Each contact is different, so the whole payload comes from items. `buildPerson` is
+  // the same converter single `create` uses, so a batch item takes the same flat fields —
+  // name, contactEmail, phone. Passing them raw is a 400 from Google, measured; the raw
+  // People shape is still accepted via `person` for anything the flat fields cannot say.
   'people.batchCreateContacts': (shared, items) => ({
-    contacts: items.map((i) => ({ contactPerson: i.person ?? i })),
+    contacts: items.map((i) => ({ contactPerson: i.person ?? buildPerson(i).person })),
     readMask: shared.readMask ?? 'names,emailAddresses,phoneNumbers,organizations,metadata',
   }),
 
@@ -84,14 +122,26 @@ const BODY_BUILDERS: Record<string, BodyBuilder> = {
     resourceNames: items.map((i) => str(i.contactId ?? i.resourceName)),
   }),
 
-  // A map keyed by resource name rather than an array — Google's shape, not ours.
-  'people.batchUpdateContacts': (shared, items) => ({
-    contacts: Object.fromEntries(
-      items.map((i) => [str(i.contactId ?? i.resourceName), i.person ?? i]),
-    ),
-    updateMask: shared.updateMask,
-    readMask: shared.readMask ?? 'names,emailAddresses,phoneNumbers,organizations,metadata',
-  }),
+  // A map keyed by resource name rather than an array — Google's shape, not ours. Each
+  // person must carry its current etag, which `prepare` below fetches; without it Google
+  // answers FAILED_PRECONDITION (measured).
+  'people.batchUpdateContacts': (shared, items) => {
+    const touched = new Set<string>();
+    const contacts: Record<string, unknown> = {};
+    for (const i of items) {
+      const built = i.person ? { person: i.person as Record<string, unknown>, touched: new Set<string>() } : buildPerson(i);
+      for (const f of built.touched) touched.add(f);
+      contacts[str(i.contactId ?? i.resourceName)] = { ...built.person, etag: i.etag };
+    }
+    return {
+      contacts,
+      // Derived from the fields the caller actually supplied, exactly as single `update`
+      // does. A fixed mask would name fields nobody touched, and naming a field with no
+      // value in the body CLEARS it.
+      updateMask: shared.updateMask ?? [...touched].join(','),
+      readMask: shared.readMask ?? 'names,emailAddresses,phoneNumbers,organizations,metadata',
+    };
+  },
 
   // A GET: resourceNames is a repeated QUERY parameter, not a body.
   'people.getBatchGet': (shared, items) => ({
@@ -111,6 +161,68 @@ function list(v: unknown): string[] {
 }
 
 /**
+ * Work some methods need before the batch call itself.
+ *
+ * `batchUpdateContacts` requires each person's current etag — Google answers
+ * FAILED_PRECONDITION without one (measured). Fetching them is one `getBatchGet`, so a
+ * batch update costs two calls for N contacts rather than the 2N a queue would.
+ */
+const PREPARE: Record<string, (items: Record<string, unknown>[], account: string) => Promise<Record<string, unknown>[]>> = {
+  'people.batchUpdateContacts': async (items, account) => {
+    const names = items.map((i) => str(i.contactId ?? i.resourceName));
+    const got = await call('people', 'people.getBatchGet', {
+      resourceNames: names,
+      personFields: 'names,emailAddresses,phoneNumbers,organizations,biographies,metadata',
+    }, { account }) as Record<string, unknown>;
+
+    const etags = new Map<string, unknown>();
+    for (const r of (got.responses as Record<string, unknown>[] | undefined) ?? []) {
+      const person = r.person as Record<string, unknown> | undefined;
+      if (person?.resourceName) etags.set(str(person.resourceName), person.etag);
+    }
+
+    return items.map((i) => {
+      const name = str(i.contactId ?? i.resourceName);
+      const etag = etags.get(name);
+      if (etag === undefined) throw new Error(`No contact found for ${name} — cannot update what does not exist.`);
+      return { ...i, contactId: name, etag };
+    });
+  },
+};
+
+/** A person as one line, matching how the single-contact operations print. */
+function personLine(person: Record<string, unknown>): string {
+  const names = (person.names as Record<string, unknown>[] | undefined) ?? [];
+  const display = names[0]?.displayName ?? [names[0]?.givenName, names[0]?.familyName].filter(Boolean).join(' ');
+  const emails = (person.emailAddresses as Record<string, unknown>[] | undefined) ?? [];
+  const parts = [str(person.resourceName), str(display || '(no name)')];
+  if (emails[0]?.value) parts.push(str(emails[0].value));
+  return parts.join(' | ');
+}
+
+/**
+ * Render what came back, so a batch READ is worth making.
+ *
+ * `refs` never reaches the model — the server returns `result.text` only — so anything
+ * the agent must act on has to be in the text. Live, `get` answered "2 results returned"
+ * and threw the two people away.
+ */
+function renderPeople(data: Record<string, unknown>): string | null {
+  const rows: string[] = [];
+  for (const r of (data.responses as Record<string, unknown>[] | undefined) ?? []) {
+    if (r.person) rows.push(personLine(r.person as Record<string, unknown>));
+  }
+  for (const r of (data.createdPeople as Record<string, unknown>[] | undefined) ?? []) {
+    if (r.person) rows.push(personLine(r.person as Record<string, unknown>));
+  }
+  const updated = data.updateResult as Record<string, Record<string, unknown>> | undefined;
+  for (const r of Object.values(updated ?? {})) {
+    if (r.person) rows.push(personLine(r.person as Record<string, unknown>));
+  }
+  return rows.length ? rows.join('\n') : null;
+}
+
+/**
  * Run one batch call.
  *
  * Refusing is as important as running: an operation with no `batch:` block cannot be
@@ -119,12 +231,12 @@ function list(v: unknown): string[] {
 export async function handleBatch(params: Record<string, unknown>): Promise<HandlerResponse> {
   const tool = params.tool as string | undefined;
   const operation = params.operation as string | undefined;
-  const items = params.items as Record<string, unknown>[] | undefined;
+  const rawItems = params.items as unknown[] | undefined;
 
   if (!tool || !operation) {
     return err(`mode:'batch' needs \`tool\` and \`operation\`. Operations that batch: ${batchableList()}.`);
   }
-  if (!Array.isArray(items) || items.length === 0) {
+  if (!Array.isArray(rawItems) || rawItems.length === 0) {
     return err(`mode:'batch' needs a non-empty \`items\` array — one entry per resource to act on.`);
   }
 
@@ -137,6 +249,8 @@ export async function handleBatch(params: Record<string, unknown>): Promise<Hand
       `Use mode:'queue' instead, which works for every operation.`,
     );
   }
+
+  const items = normalizeItems(rawItems, spec.resource);
 
   const build = BODY_BUILDERS[spec.resource];
   if (!build) {
@@ -167,7 +281,18 @@ export async function handleBatch(params: Record<string, unknown>): Promise<Hand
 
   // Shared arguments are everything the caller passed that is not batch plumbing.
   const { mode: _m, tool: _t, operation: _o, items: _i, email: _e, detail: _d, ...shared } = params;
-  const body = { ...spec.defaults, ...build({ ...spec.defaults, ...shared }, items) };
+
+  let prepared = items;
+  const prepare = PREPARE[spec.resource];
+  if (prepare) {
+    try {
+      prepared = await prepare(items, account);
+    } catch (e) {
+      return err(e instanceof Error ? e.message : String(e));
+    }
+  }
+
+  const body = { ...spec.defaults, ...build({ ...spec.defaults, ...shared }, prepared) };
 
   const data = await call(
     spec.googleService as GoogleService,
@@ -176,11 +301,12 @@ export async function handleBatch(params: Record<string, unknown>): Promise<Hand
     { account },
   );
 
+  const rendered = renderPeople((data ?? {}) as Record<string, unknown>);
   return {
     text:
       `## Batch: ${tool} ${operation}\n\n` +
       `${items.length} item${items.length === 1 ? '' : 's'} in one request ` +
-      `(\`${spec.resource}\`).\n\n${summarize(data)}`,
+      `(\`${spec.resource}\`).\n\n${rendered ?? summarize(data)}`,
     refs: { batch: true, tool, operation, resource: spec.resource, count: items.length, data },
   };
 }

--- a/src/server/handler.ts
+++ b/src/server/handler.ts
@@ -2,6 +2,7 @@ import { handleAccounts } from './handlers/accounts.js';
 import { handleWorkspace } from './handlers/workspace.js';
 import { handleScratchpad } from './scratchpad/handler.js';
 import { handleQueue } from './queue.js';
+import { handleBatch } from './batch.js';
 import { generatedTools } from '../factory/registry.js';
 import { getSessionTracker, sessionContext } from './session/index.js';
 
@@ -74,6 +75,7 @@ export async function handleToolCall(
 
   // Bulk wraps the domain handlers (each queued op also advances the epoch)
   if (BULK_TOOL_NAMES.includes(toolName)) {
+    if (params.mode === 'batch') return await handleBatch(params);
     const result = await handleQueue(params, queueableHandlers(1), 1);
     const queueEmail = extractEmailFromQueue(params);
     if (queueEmail) {

--- a/src/server/tools.ts
+++ b/src/server/tools.ts
@@ -137,8 +137,8 @@ const handCodedSchemas: ToolSchema[] = [
         },
         items: {
           type: 'array',
-          items: { type: 'object' },
-          description: "batch only — one entry per resource, carrying just what DIFFERS between them (e.g. {contactId}). Anything shared by the whole batch goes at the top level of this call, not in here.",
+          items: { type: ['string', 'object'] },
+          description: "batch only — one entry per resource. A bare id string is enough when that is all that differs, e.g. ['people/c1', 'people/c2']; use objects when items carry more, e.g. [{name: 'Ada Lovelace', contactEmail: 'ada@example.com'}]. Anything shared by the WHOLE batch — labels to add, a field mask — goes at the top level of this call, not in here.",
         },
         operations: {
           type: 'array',

--- a/src/server/tools.ts
+++ b/src/server/tools.ts
@@ -114,10 +114,32 @@ const handCodedSchemas: ToolSchema[] = [
   },
   {
     name: 'bulk_operations',
-    description: 'Execute multiple operations in sequence. Operations run in order with result references ($0.field) to chain outputs. Use for multi-step workflows.',
+    description: "Do many things in one call, two ways. mode:'queue' (default) runs different operations in sequence, chaining results with $N.field — works for every tool. mode:'batch' does ONE operation across many resources in a single Google request — far fewer round trips, but only where Google publishes a batch method.",
     inputSchema: {
       type: 'object',
       properties: {
+        mode: {
+          type: 'string',
+          enum: ['queue', 'batch'],
+          description: "queue (default): N operations, N API calls, in order, with $N.field references between them. batch: ONE operation across many resources in a single API call — no $N references, because there is no 'between'.",
+        },
+        tool: {
+          type: 'string',
+          description: "batch only — the tool to call, e.g. 'manage_contacts'.",
+        },
+        operation: {
+          type: 'string',
+          description: "batch only — the operation to apply to every item, e.g. 'delete'. Ask for one that cannot batch and the error names the ones that can.",
+        },
+        email: {
+          type: 'string',
+          description: 'batch only — the account to act as.',
+        },
+        items: {
+          type: 'array',
+          items: { type: 'object' },
+          description: "batch only — one entry per resource, carrying just what DIFFERS between them (e.g. {contactId}). Anything shared by the whole batch goes at the top level of this call, not in here.",
+        },
         operations: {
           type: 'array',
           items: {
@@ -153,7 +175,8 @@ const handCodedSchemas: ToolSchema[] = [
           description: 'summary: one-line status per operation (default) | full: include complete output from each operation',
         },
       },
-      required: ['operations'],
+      // `operations` is required for queue and absent for batch, so neither can be
+      // required here. The handler validates per mode and names what is missing.
       additionalProperties: false,
     },
   },

--- a/src/services/contacts/patch.ts
+++ b/src/services/contacts/patch.ts
@@ -328,7 +328,13 @@ function withoutMetadata(entry: Rec): Rec {
  * the employer — a data loss with no error, inside a single field, from a parameter that
  * never mentioned the employer.
  */
-function buildPerson(
+/**
+ * Exported for batch mode (ADR-308): a batch item carries the same flat fields as a
+ * single create or update, and gets converted the same way. Without this, batch would
+ * demand the raw People API shape — parallel arrays of objects — which is precisely what
+ * manage_contacts exists to hide, and Google rejects the flat form with a 400.
+ */
+export function buildPerson(
   params: Record<string, unknown>,
   existingOrgs: Rec[] = [],
 ): { person: Record<string, unknown>; touched: Set<string> } {


### PR DESCRIPTION
Second increment of #10, on top of #174. **ADR-308** carries the design.

## Description

`bulk_operations {mode:'batch', tool, operation, items}` performs one operation across many resources in a single request. 200 contact deletions become one call.

**The rule that makes one shape serve five Google methods:** top-level arguments are shared across the batch, `items` carry what differs. A batch is one call with one set of parameters, so a parameter that varies per item isn't a batch — it's a queue.

```
bulk_operations { mode:'batch', tool:'manage_email', operation:'trash',
                  items:['m1','m2','m3'] }
```

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## What live Google said about shapes I had only written down

The first commit had **15 green tests and was broken in four of its six operations.** Every one of these was invisible to mocked tests:

| # | Defect | What Google returned |
|---|---|---|
| 1 | Flat fields rejected | `400: Unknown name "name" at 'contacts[0].contact_person'` |
| 2 | `update` failed entirely | `FAILED_PRECONDITION: must set person.etag` |
| 3 | `trash` didn't work at all | `missing required path param 'userId'` |
| 4 | Batch reads returned nothing usable | "2 results returned", people discarded into `refs` |
| 5 | `items` demanded objects | — (friction, not an error) |

**1.** `items:[{name:'Ada Lovelace'}]` — the same fields single `create` takes — was rejected. Batch demanded the raw People shape, parallel arrays of objects, which `manage_contacts` exists to hide. Now runs items through the same `buildPerson` the single operations use.

**2.** `batchUpdateContacts` needs each person's current etag, so update is a read-modify-write: one `getBatchGet`, one `batchUpdateContacts`. Two calls for N contacts against the 2N a queue would make. `updateMask` is derived from the fields actually supplied — a fixed mask names fields nobody touched, and naming a field with no value **clears** it.

**3.** The single gmail operations each carry `userId: me` in their own defaults; batch reads only the batch block. A new test derives every batch method's **required path params from the descriptor** and asserts a default exists.

**4.** `refs` never reaches the model — an invariant written down in this repo that I tripped over anyway. `get`, `create` and `update` now print resourceName, name and email per person. Envelopes measured directly rather than guessed: `createdPeople`, `responses`, `updateResult`.

**5.** Per the standing rule that a tool call should be cheap to write: `items` now takes `['people/c1','people/c2']` and adds the `people/` prefix when left off, as the single-contact operations do.

## Verified live on aaronsb@gmail.com — all six operations

| Operation | Result |
|---|---|
| `create` (flat fields) | Two contacts, names and emails intact, ids printed |
| `get` | Both rendered from one `getBatchGet` |
| `update` | `jobTitle` applied; **email and phone survived** — the field-precision property the derived mask exists for |
| `delete` | 93 contacts → 91 |
| `trash` (bulk) | Two real messages trashed in one request, then restored |
| refusal | `manage_calendar delete` refused, naming the six that batch |

Queue mode re-verified under the new tool name in the same session.

## Deliberately absent: `users.messages.batchDelete`

Gmail's delete is immediate and permanent, and the scopes say so:

```
users.messages.trash        ["https://mail.google.com/", ".../gmail.modify"]
users.messages.batchDelete  ["https://mail.google.com/"]
```

`trash` accepts `gmail.modify`. Permanent delete accepts **only** the broadest scope Gmail publishes. This server requests `gmail.modify` and nothing wider, so batching it would mean widening every account to full mailbox authority and re-consenting all of them — to gain an operation whose only advantage over `trash` is irreversibility. Bulk trash covers the real need.

## Batch goes through the safety layer

Batch reaches Google without passing through `generateHandler`, so it gets no policy check for free — the same defect as #171, in code written the same day. Doing many writes at once is the last place to skip it: a read-only account would otherwise be refused one contact deletion and permitted two hundred. Tested, and proven by disabling the block.

## Testing Performed

- [x] `make check` green — **969 tests**, up from 943.
- [x] 23 batch tests, including read-only refusal, the etag read-modify-write, and the exact wire bodies.
- [x] Every batch resource asserted to resolve in `descriptor.json`; every required **path param** asserted to have a default — proven by removing `userId` and watching it fail.
- [x] All six operations verified against live Google, with cleanup.

## Additional Notes

**ADR-308 carried a false claim and it was load-bearing.** It said docs and sheets "already work this way", which made a whole axis look solved. They don't: both call `batchUpdate` but send `requests: [ …one request… ]`, so five edits to one document cost five calls. Corrected in the ADR, and the refusal message no longer claims "Google publishes no batch method" — false for docs and sheets. Filed as #175.