### PR TITLE
fix(registry): say where the source is, and what this thing is called

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,8 +1,15 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.aaronsb/google-workspace",
+  "title": "Google Workspace",
   "description": "Give AI agents access to Gmail, Calendar, Drive, and more — multi-account, manifest-driven",
   "version": "4.4.0",
+  "websiteUrl": "https://github.com/aaronsb/google-workspace-mcp#readme",
+  "repository": {
+    "url": "https://github.com/aaronsb/google-workspace-mcp",
+    "source": "github",
+    "id": "922830617"
+  },
   "packages": [
     {
       "registryType": "npm",

--- a/src/__tests__/server-json.test.ts
+++ b/src/__tests__/server-json.test.ts
@@ -1,0 +1,74 @@
+/**
+ * server.json is what the MCP Registry publishes, and it is only ever exercised at
+ * release time — by a CI job, on a tag, after npm has already published. A field missing
+ * or a version out of step fails there, which is the worst moment to find out.
+ *
+ * Everything here is offline and compares the file to what the repo already knows.
+ * Deliberately not schema-validated with ajv: ajv is present only transitively via the
+ * MCP SDK, so a dependency bump could remove the validator and silently take the check
+ * with it.
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const server = JSON.parse(
+  readFileSync(new URL('../../server.json', import.meta.url), 'utf-8'),
+) as {
+  name: string;
+  title?: string;
+  description: string;
+  version: string;
+  websiteUrl?: string;
+  repository?: { url?: string; source?: string; id?: string };
+  packages: { registryType: string; identifier: string; version: string; transport: { type: string } }[];
+};
+
+const pkg = JSON.parse(
+  readFileSync(new URL('../../package.json', import.meta.url), 'utf-8'),
+) as { name: string; version: string };
+
+describe('server.json', () => {
+  it('carries the version package.json does, in both places it appears', () => {
+    // `make version-sync` writes all three. It has been wrong before: the file records the
+    // version twice — once for the server entry, once for the npm package it points at —
+    // and a mismatch publishes a registry entry naming a tarball that does not exist.
+    expect(server.version).toBe(pkg.version);
+    for (const p of server.packages) expect(p.version).toBe(pkg.version);
+  });
+
+  it('points at the npm package this repo actually publishes', () => {
+    const npm = server.packages.find((p) => p.registryType === 'npm');
+    expect(npm?.identifier).toBe(pkg.name);
+    expect(npm?.transport.type).toBe('stdio');
+  });
+
+  it('tells people where the source is', () => {
+    // Without this the registry lists a server with no way to inspect what it runs. The
+    // schema calls that out: repository metadata is what lets users and security
+    // reviewers read the code before installing it.
+    expect(server.repository?.url).toBe('https://github.com/aaronsb/google-workspace-mcp');
+    expect(server.repository?.source).toBe('github');
+  });
+
+  it('carries the forge id, not just the path', () => {
+    // GitHub's own numeric id. It survives a rename, and it CHANGES if a repository is
+    // deleted and recreated — which is how a registry detects someone recreating an
+    // abandoned repo at the same path to inherit its reputation.
+    expect(server.repository?.id).toMatch(/^\d+$/);
+  });
+
+  it('has a website and a human-readable title', () => {
+    expect(server.websiteUrl).toMatch(/^https:\/\//);
+    // A title is a NAME, not the description over again — some registry entries paste a
+    // truncated description here and it reads as one in the listing.
+    expect(server.title).toBeTruthy();
+    expect(server.title!.length).toBeLessThan(40);
+    expect(server.title).not.toBe(server.description);
+  });
+
+  it('names itself under the namespace the OIDC publish can claim', () => {
+    // The registry grants io.github.<repository_owner>/* from the OIDC token's owner
+    // claim (ADR-105). A name outside that namespace cannot be published by CI at all.
+    expect(server.name).toMatch(/^io\.github\.aaronsb\//);
+  });
+});


### PR DESCRIPTION
## Description

The MCP Registry listing had **no link to the repository**. Someone deciding whether to run this had nothing to inspect — and the schema names exactly that as the field's purpose: repository metadata is what lets users and security reviewers read the code before installing it.

| Field | Value |
|---|---|
| `repository.url` | `https://github.com/aaronsb/google-workspace-mcp` |
| `repository.source` | `github` |
| `repository.id` | `922830617` |
| `websiteUrl` | the README |
| `title` | `Google Workspace` |

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Notes on two of the fields

**`repository.id`** is GitHub's numeric identifier rather than the path. It survives a rename, and it **changes if a repository is deleted and recreated** — which is how a registry detects someone recreating an abandoned repo at the same path to inherit its reputation. Taken from `gh api repos/aaronsb/google-workspace-mcp --jq .id`, as the schema instructs.

**`title` is a name, not the description again.** Some registry entries paste a truncated description into it, and it reads as one in the listing.

There is **no author field** in the schema — ownership comes from the namespace and the repository, both of which are now stated.

## Testing Performed

- [x] Validated against the published registry schema with ajv: valid.
- [x] `make check` green — **975 tests**, up from 969.
- [x] Six new offline assertions in `src/__tests__/server-json.test.ts`.

`server.json` is otherwise only exercised **at release time** — by a CI job, on a tag, after npm has already published. A missing field or a stale version fails there, which is the worst moment to find out. The test compares the file against what the repo already knows: `package.json`'s name and version, the namespace the OIDC publish can actually claim, and that the version appears correctly in **both** places the file records it.

Deliberately **not** ajv-validated in the test despite ajv being importable: it's present only transitively via the MCP SDK, so a dependency bump could remove the validator and silently take the check with it.

## Additional Notes

Spotted alongside this: other registry entries advertise an **`mcpb` package** pointing at their GitHub release asset, letting Claude Desktop users install straight from the registry. We build and attach `google-workspace-mcp.mcpb` to every release but only advertise the npm package. That needs `fileSha256`, which is required for mcpb packages and can't be committed ahead of time — our bundle hashes differently on every build — so it needs the two release workflows to coordinate. Filed separately.