### PR TITLE
feat(calendar): support all-day events on create and update

### DIFF
--- a/src/__tests__/factory/calendar-patch.test.ts
+++ b/src/__tests__/factory/calendar-patch.test.ts
@@ -464,6 +464,121 @@ describe('calendarPatch', () => {
         { email: 'c@d.com' },
       ]);
     });
+
+    describe('all-day events (allDay: true)', () => {
+      it('sends date fields, with an EXCLUSIVE end computed from the inclusive last day', async () => {
+        // The Calendar API's all-day end date is one day AFTER the last day of
+        // the event. The caller thinks in inclusive days, so '2026-07-12' as the
+        // last day must become end.date '2026-07-13'.
+        mockCall.mockResolvedValue(calendarInsertResponse);
+        await calendarPatch.customHandlers!.create(
+          { summary: 'Vacation', start: '2026-07-12', end: '2026-07-12', allDay: true },
+          'user@test.com',
+        );
+
+        const request = await requestFor('calendar', 'events.insert', mockCall.mock.calls[0][2]);
+        expect(request.body!.start).toEqual({ date: '2026-07-12' });
+        expect(request.body!.end).toEqual({ date: '2026-07-13' });
+        expect(request.body!.dateTime).toBeUndefined();
+      });
+
+      it('extends a multi-day inclusive range by one day for the API', async () => {
+        mockCall.mockResolvedValue(calendarInsertResponse);
+        await calendarPatch.customHandlers!.create(
+          { summary: 'Conference', start: '2026-07-12', end: '2026-07-14', allDay: true },
+          'user@test.com',
+        );
+
+        const request = await requestFor('calendar', 'events.insert', mockCall.mock.calls[0][2]);
+        expect(request.body!.start).toEqual({ date: '2026-07-12' });
+        expect(request.body!.end).toEqual({ date: '2026-07-15' });
+      });
+
+      it('defaults a missing end to the start date (a one-day event)', async () => {
+        mockCall.mockResolvedValue(calendarInsertResponse);
+        await calendarPatch.customHandlers!.create(
+          { summary: 'Birthday', start: '2026-07-12', allDay: true },
+          'user@test.com',
+        );
+
+        const request = await requestFor('calendar', 'events.insert', mockCall.mock.calls[0][2]);
+        expect(request.body!.start).toEqual({ date: '2026-07-12' });
+        expect(request.body!.end).toEqual({ date: '2026-07-13' });
+      });
+
+      it('uses the date part when an ISO datetime is passed', async () => {
+        mockCall.mockResolvedValue(calendarInsertResponse);
+        await calendarPatch.customHandlers!.create(
+          { summary: 'Holiday', start: '2026-07-12T00:00:00Z', end: '2026-07-14T23:59:59Z', allDay: true },
+          'user@test.com',
+        );
+
+        const request = await requestFor('calendar', 'events.insert', mockCall.mock.calls[0][2]);
+        expect(request.body!.start).toEqual({ date: '2026-07-12' });
+        expect(request.body!.end).toEqual({ date: '2026-07-15' });
+      });
+
+      it('rejects values that are not dates', async () => {
+        await expect(
+          calendarPatch.customHandlers!.create(
+            { summary: 'X', start: 'noon-ish', allDay: true },
+            'user@test.com',
+          ),
+        ).rejects.toThrow(/YYYY-MM-DD/);
+        expect(mockCall).not.toHaveBeenCalled();
+      });
+
+      it('still requires an end for TIMED events (the all-day-only relaxation)', async () => {
+        await expect(
+          calendarPatch.customHandlers!.create(
+            { summary: 'Meeting', start: '2026-07-12T09:00:00Z' },
+            'user@test.com',
+          ),
+        ).rejects.toThrow(/end is required for timed events/);
+        expect(mockCall).not.toHaveBeenCalled();
+      });
+
+      it('renders the inclusive range and marks the event all-day', async () => {
+        mockCall.mockResolvedValue(calendarInsertResponse);
+        const result = await calendarPatch.customHandlers!.create(
+          { summary: 'Trip', start: '2026-07-12', end: '2026-07-14', allDay: true },
+          'user@test.com',
+        );
+
+        expect(result.text).toContain('(all day)');
+        expect(result.text).toContain('**When:** 2026-07-12 – 2026-07-14');
+        expect(result.refs.allDay).toBe(true);
+        expect(result.refs.start).toBe('2026-07-12');
+        expect(result.refs.end).toBe('2026-07-14');
+      });
+
+      it('renders a single-day event as just its date', async () => {
+        mockCall.mockResolvedValue(calendarInsertResponse);
+        const result = await calendarPatch.customHandlers!.create(
+          { summary: 'Trip', start: '2026-07-12', allDay: true },
+          'user@test.com',
+        );
+
+        expect(result.text).toContain('**When:** 2026-07-12');
+        expect(result.text).not.toContain(' – ');
+      });
+
+      it('scopes the Meet idempotency key to allDay so timed/all-day twins differ', async () => {
+        mockCall.mockResolvedValue(calendarInsertResponse);
+        await calendarPatch.customHandlers!.create(
+          { summary: 'X', start: '2026-07-12', end: '2026-07-12', allDay: true, meet: true },
+          'user@test.com',
+        );
+        await calendarPatch.customHandlers!.create(
+          { summary: 'X', start: '2026-07-12T00:00:00Z', end: '2026-07-12T01:00:00Z', meet: true },
+          'user@test.com',
+        );
+
+        const requestIdOf = (i: number) =>
+          ((mockCall.mock.calls[i][2].conferenceData as any).createRequest.requestId as string);
+        expect(requestIdOf(0)).not.toBe(requestIdOf(1));
+      });
+    });
   });
 
   describe('update custom handler', () => {
@@ -511,6 +626,33 @@ describe('calendarPatch', () => {
       const body = (await requestFor('calendar', 'events.patch', mockCall.mock.calls[0][2])).body!;
       expect(body.start).toEqual({ dateTime: '2026-05-01T10:00:00Z' });
       expect(body.end).toEqual({ dateTime: '2026-05-01T11:00:00Z' });
+    });
+
+    it('maps start and end to exclusive date fields when allDay: true', async () => {
+      mockCall.mockResolvedValue({ id: 'evt-1' });
+      await calendarPatch.customHandlers!.update(
+        { eventId: 'evt-1', start: '2026-07-12', end: '2026-07-14', allDay: true },
+        'user@test.com',
+      );
+
+      const body = (await requestFor('calendar', 'events.patch', mockCall.mock.calls[0][2])).body!;
+      expect(body.start).toEqual({ date: '2026-07-12' });
+      expect(body.end).toEqual({ date: '2026-07-15' });
+    });
+
+    it('treats an all-day end patched alone as a one-day event on that date', async () => {
+      // The manifest tells callers to pass both start and end when moving an
+      // all-day event; an end without a start has no anchor, so it becomes a
+      // single-day event on that date (exclusive end = date + 1).
+      mockCall.mockResolvedValue({ id: 'evt-1' });
+      await calendarPatch.customHandlers!.update(
+        { eventId: 'evt-1', end: '2026-07-20', allDay: true },
+        'user@test.com',
+      );
+
+      const body = (await requestFor('calendar', 'events.patch', mockCall.mock.calls[0][2])).body!;
+      expect(body.end).toEqual({ date: '2026-07-21' });
+      expect(body.start).toBeUndefined();
     });
 
     it('converts comma-separated attendees string into array of {email}', async () => {

--- a/src/__tests__/server/formatting/markdown.test.ts
+++ b/src/__tests__/server/formatting/markdown.test.ts
@@ -208,6 +208,24 @@ describe('formatEventList', () => {
     expect(result.text).toContain('(no title)');
   });
 
+  it('renders an all-day event as its date, not a shifted local time', () => {
+    // A bare `date` parsed as UTC midnight would render as the previous evening
+    // in most timezones ("Aug 19 20:00" etc.) — all-day must show the date.
+    const result = formatEventList({
+      items: [{ id: 'evt-1', summary: 'Lunch', start: { date: '2026-08-20' }, end: { date: '2026-08-21' } }],
+    });
+    expect(result.text).toContain('Thu, Aug 20 (all day)');
+    expect(result.text).not.toContain('20:00');
+  });
+
+  it('renders a multi-day all-day range with the exclusive end minus one day', () => {
+    const result = formatEventList({
+      items: [{ id: 'evt-1', summary: 'Trip', start: { date: '2026-08-20' }, end: { date: '2026-08-23' } }],
+    });
+    // API end is exclusive: 2026-08-23 means the last day is the 22nd.
+    expect(result.text).toContain('Thu, Aug 20 – Sat, Aug 22 (all day)');
+  });
+
   it('handles empty items', () => {
     expect(formatEventList({}).text).toBe('No events found.');
     expect(formatEventList({}).refs.count).toBe(0);
@@ -235,6 +253,15 @@ describe('formatEventDetail', () => {
   it('handles missing conference data', () => {
     const result = formatEventDetail({ id: 'x', start: {}, end: {} });
     expect(result.refs.meetLink).toBeUndefined();
+  });
+
+  it('renders an all-day event detail as its date', () => {
+    const result = formatEventDetail({
+      id: 'evt-1', summary: 'Holiday',
+      start: { date: '2026-08-20' }, end: { date: '2026-08-21' },
+    });
+    expect(result.text).toContain('**When:** Thu, Aug 20 (all day)');
+    expect(result.refs.start).toBe('2026-08-20');
   });
 
   it('shows declined attendees with [-] marker', () => {

--- a/src/__tests__/services/calendar/dates.test.ts
+++ b/src/__tests__/services/calendar/dates.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import { allDayDate, exclusiveEndDate, allDayRange } from '../../../services/calendar/dates.js';
+
+describe('calendar all-day date helpers', () => {
+  describe('allDayDate', () => {
+    it('passes a bare YYYY-MM-DD through', () => {
+      expect(allDayDate('2026-07-12')).toBe('2026-07-12');
+    });
+
+    it('takes the date part of an ISO datetime', () => {
+      expect(allDayDate('2026-07-12T09:30:00Z')).toBe('2026-07-12');
+      expect(allDayDate('2026-07-12T23:59:59-05:00')).toBe('2026-07-12');
+    });
+
+    it('rejects non-dates', () => {
+      expect(() => allDayDate('noon')).toThrow(/YYYY-MM-DD/);
+      expect(() => allDayDate('2026-7-2')).toThrow(/YYYY-MM-DD/);
+    });
+  });
+
+  describe('exclusiveEndDate', () => {
+    // The Calendar API's all-day end is one day AFTER the last day of the event.
+    it('makes a same-day range a one-day event', () => {
+      expect(exclusiveEndDate('2026-07-12', '2026-07-12')).toBe('2026-07-13');
+    });
+
+    it('treats end as the INCLUSIVE last day and adds one', () => {
+      expect(exclusiveEndDate('2026-07-12', '2026-07-14')).toBe('2026-07-15');
+    });
+
+    it('collapses an end before the start to a one-day event', () => {
+      expect(exclusiveEndDate('2026-07-14', '2026-07-12')).toBe('2026-07-15');
+    });
+
+    it('is DST-proof (UTC arithmetic)', () => {
+      // Around a DST boundary in most zones; UTC has no DST so this is stable.
+      expect(exclusiveEndDate('2026-03-07', '2026-03-08')).toBe('2026-03-09');
+    });
+
+    it('rejects an invalid calendar date (e.g. Feb 30)', () => {
+      expect(() => exclusiveEndDate('2026-02-30', '2026-03-01')).toThrow(/YYYY-MM-DD/);
+      expect(() => exclusiveEndDate('2026-07-12', '2026-13-01')).toThrow(/YYYY-MM-DD/);
+    });
+  });
+
+  describe('allDayRange', () => {
+    it('renders a single-day event as just the date', () => {
+      expect(allDayRange('2026-07-12')).toBe('2026-07-12');
+      expect(allDayRange('2026-07-12', '2026-07-12')).toBe('2026-07-12');
+    });
+
+    it('renders a multi-day range inclusively', () => {
+      expect(allDayRange('2026-07-12', '2026-07-14')).toBe('2026-07-12 – 2026-07-14');
+    });
+  });
+});

--- a/src/factory/manifest/calendar.yaml
+++ b/src/factory/manifest/calendar.yaml
@@ -81,12 +81,14 @@ operations:
         required: true
       start:
         type: string
-        description: "Start time (ISO 8601)"
+        description: "Start time (ISO 8601) — or a DATE (YYYY-MM-DD) when allDay is true"
         required: true
       end:
         type: string
-        description: "End time (ISO 8601)"
-        required: true
+        description: "End time (ISO 8601) — or, when allDay is true, a DATE (YYYY-MM-DD) that is the INCLUSIVE last day; the exclusive end date the Calendar API requires is computed for you. Optional for all-day events: a missing end (or one equal to start) makes a one-day event."
+      allDay:
+        type: boolean
+        description: "Whether the event is all-day. When true, start and end are DATES (YYYY-MM-DD — an ISO datetime's date part is used) and end, if given, is the INCLUSIVE last day; the exclusive end date the Calendar API requires is computed for you. Omit it (or pass false) for a timed event with start/end as dateTime — pass false with new datetimes to convert an all-day event back to a timed one."
       description:
         type: string
         description: "Event description or notes"
@@ -132,10 +134,13 @@ operations:
         description: "Event title"
       start:
         type: string
-        description: "Start time (ISO 8601)"
+        description: "Start time (ISO 8601) — or a DATE (YYYY-MM-DD) when allDay is true"
       end:
         type: string
-        description: "End time (ISO 8601)"
+        description: "End time (ISO 8601) — or, when allDay is true, a DATE (YYYY-MM-DD) that is the INCLUSIVE last day; the exclusive end date the Calendar API requires is computed for you. Optional for all-day events: a missing end (or one equal to start) makes a one-day event."
+      allDay:
+        type: boolean
+        description: "Whether the event is all-day. When true, start and end are DATES (YYYY-MM-DD — an ISO datetime's date part is used) and end, if given, is the INCLUSIVE last day; the exclusive end date the Calendar API requires is computed for you. Omit it (or pass false) for a timed event with start/end as dateTime — pass false with new datetimes to convert an all-day event back to a timed one."
       description:
         type: string
         description: "Event description or notes"

--- a/src/server/formatting/markdown.ts
+++ b/src/server/formatting/markdown.ts
@@ -326,7 +326,9 @@ export function formatEventList(data: unknown): HandlerResponse {
     const summary = String(event.summary ?? '(no title)');
     const start = formatEventTime(event.start);
     const end = formatEventTime(event.end);
-    const timeRange = formatTimeRange(start, end);
+    const timeRange = isAllDay(event.start)
+      ? formatAllDayRange(start, end)
+      : formatTimeRange(start, end);
     const location = event.location ? ` | ${event.location}` : '';
     const attendeeCount = Array.isArray(event.attendees) ? event.attendees.length : 0;
     const attendees = attendeeCount > 0 ? ` | ${attendeeCount} attendee${attendeeCount > 1 ? 's' : ''}` : '';
@@ -365,7 +367,7 @@ export function formatEventDetail(data: unknown): HandlerResponse {
   const parts: string[] = [
     `## ${summary}`,
     '',
-    `**When:** ${formatTimeRange(start, end)}`,
+    `**When:** ${isAllDay(event.start) ? formatAllDayRange(start, end) : formatTimeRange(start, end)}`,
   ];
 
   if (location) parts.push(`**Where:** ${location}`);
@@ -484,6 +486,45 @@ function formatEventTime(time: unknown): string {
   if (!time) return '';
   const t = time as Record<string, string>;
   return t.dateTime ?? t.date ?? '';
+}
+
+/** True when the event's start is a bare date — an all-day event, not a timed one. */
+function isAllDay(time: unknown): boolean {
+  const t = time as Record<string, unknown> | undefined;
+  return Boolean(t && typeof t.date === 'string' && !t.dateTime);
+}
+
+const MONTH_SHORT = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+const WEEKDAY_SHORT = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+/**
+ * "Sat, Aug 20" from a YYYY-MM-DD, built from UTC components. Parsing the bare
+ * date with `new Date()` yields UTC midnight, which then shifts a day in most
+ * timezones — the all-day display must not depend on the viewer's offset.
+ */
+function formatDateLabel(ymd: string): string {
+  const [y, m, d] = ymd.split('-').map(Number);
+  if (!y || !m || !d) return ymd;
+  const dow = new Date(Date.UTC(y, m - 1, d)).getUTCDay();
+  return `${WEEKDAY_SHORT[dow]}, ${MONTH_SHORT[m - 1]} ${d}`;
+}
+
+/**
+ * All-day range for display. The Calendar API's end date is EXCLUSIVE (one day
+ * after the last day of the event), so the last day shown is `end - 1`; a
+ * single-day event renders as just its date.
+ */
+function formatAllDayRange(startDate: string, endDate?: string): string {
+  let lastDay = startDate;
+  if (endDate && endDate > startDate) {
+    const last = new Date(`${endDate}T00:00:00Z`);
+    last.setUTCDate(last.getUTCDate() - 1);
+    lastDay = last.toISOString().slice(0, 10);
+  }
+  const range = lastDay === startDate
+    ? formatDateLabel(startDate)
+    : `${formatDateLabel(startDate)} – ${formatDateLabel(lastDay)}`;
+  return `${range} (all day)`;
 }
 
 function formatTimeRange(start: string, end: string): string {

--- a/src/server/scratchpad/adapters/send-calendar.ts
+++ b/src/server/scratchpad/adapters/send-calendar.ts
@@ -6,12 +6,14 @@ import { call } from '../../../google/client.js';
 import type { HandlerResponse } from '../../handler.js';
 import type { ScratchpadManager } from '../manager.js';
 import { nextSteps } from '../../formatting/next-steps.js';
+import { allDayDate, exclusiveEndDate, allDayRange } from '../../../services/calendar/dates.js';
 
 interface CalendarEventParams {
   email: string;
   summary: string;
   start: string;
-  end: string;
+  end?: string;
+  allDay?: boolean;
   location?: string;
   attendees?: string;
 }
@@ -26,24 +28,33 @@ export async function sendCalendarEvent(
     return { text: `Scratchpad ${scratchpadId} not found.`, refs: { error: true } };
   }
 
-  const { email, summary, start, end, location, attendees } = targetParams;
-  if (!email || !summary || !start || !end) {
+  const { email, summary, start, end, location, attendees, allDay = false } = targetParams;
+  if (!email || !summary || !start || (!allDay && !end)) {
     return {
-      text: `Send failed: email, summary, start, and end are required for calendar_event.\nScratchpad ${scratchpadId} is still active.`,
+      text: `Send failed: email, summary, and start are required for calendar_event` +
+        (allDay ? '.' : ', and end is required for timed events (or pass allDay: true).') +
+        `\nScratchpad ${scratchpadId} is still active.`,
       refs: { error: true, scratchpadId },
     };
   }
 
   // `calendarId` is the one PATH param the descriptor declares; everything else
   // here is the Event resource and lands in the body. Same shape as
-  // services/calendar/patch.ts `create`.
+  // services/calendar/patch.ts `create` — all-day events use `date`
+  // (YYYY-MM-DD, exclusive API end computed from the caller's inclusive end),
+  // timed ones use `dateTime`.
   const body: Record<string, unknown> = {
     calendarId: 'primary',
     summary,
-    start: { dateTime: start },
-    end: { dateTime: end },
     description: content,
   };
+  if (allDay) {
+    body.start = { date: allDayDate(start) };
+    body.end = { date: exclusiveEndDate(start, end ?? start) };
+  } else {
+    body.start = { dateTime: start };
+    body.end = { dateTime: end };
+  }
   if (location) body.location = location;
   if (attendees) {
     body.attendees = attendees
@@ -54,14 +65,15 @@ export async function sendCalendarEvent(
   try {
     const data = await call('calendar', 'events.insert', body, { account: email }) as Record<string, unknown>;
 
+    const when = allDay ? allDayRange(start, end) : `${start} – ${end}`;
     return {
-      text: `Event created: **${summary}**\n\n` +
-        `**When:** ${start} – ${end}\n` +
+      text: `Event created: **${summary}**${allDay ? ' (all day)' : ''}\n\n` +
+        `**When:** ${when}\n` +
         (location ? `**Where:** ${location}\n` : '') +
         `**Description:** scratchpad content (${content.split('\n').length} lines)\n` +
         `**Event ID:** ${data.id ?? 'unknown'}` +
         nextSteps('calendar', 'create', { email }),
-      refs: { scratchpadId, eventId: data.id, summary, start, end },
+      refs: { scratchpadId, eventId: data.id, summary, start, end, allDay },
     };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/src/services/calendar/dates.ts
+++ b/src/services/calendar/dates.ts
@@ -1,0 +1,82 @@
+/**
+ * All-day event date handling for the calendar service.
+ *
+ * Google's Calendar API stores an all-day event's start/end as bare `date`
+ * fields (YYYY-MM-DD), and the END DATE IS EXCLUSIVE — one day after the last
+ * day of the event. A one-day event on 2026-07-12 therefore needs
+ * `end: { date: '2026-07-13' }` (this is the classic all-day API gotcha).
+ *
+ * Callers of this MCP think in inclusive days ("from the 12th to the 14th"),
+ * so these helpers accept an INCLUSIVE end and compute the exclusive one the
+ * API requires. An end equal to (or before) the start means a single-day
+ * event, so `exclusiveEndDate('2026-07-12', '2026-07-12')` is `2026-07-13`.
+ */
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Strict YYYY-MM-DD validation.
+ *
+ * Date.parse is too lenient here: V8 rolls an out-of-range day over
+ * ('2026-02-30' silently becomes March 2). Parse the components and check they
+ * round-trip through UTC, so a date that never existed is rejected.
+ */
+function isValidDate(date: string): boolean {
+  const [y, m, d] = date.split('-').map(Number);
+  if (!Number.isInteger(y) || !Number.isInteger(m) || !Number.isInteger(d)) return false;
+  const roundTrip = new Date(Date.UTC(y, m - 1, d));
+  return roundTrip.getUTCFullYear() === y &&
+    roundTrip.getUTCMonth() === m - 1 &&
+    roundTrip.getUTCDate() === d;
+}
+
+/**
+ * Normalize an all-day start/end value to a YYYY-MM-DD date.
+ *
+ * Accepts a bare date ('2026-07-12') or an ISO datetime ('2026-07-12T09:00:00Z')
+ * and uses the date part — all-day events have no time of day.
+ */
+export function allDayDate(value: string): string {
+  const date = value.trim().slice(0, 10);
+  if (!DATE_RE.test(date) || !isValidDate(date)) {
+    throw new Error(`All-day events need dates in YYYY-MM-DD format (got "${value}")`);
+  }
+  return date;
+}
+
+/**
+ * The EXCLUSIVE end date the Calendar API requires, from an INCLUSIVE last day.
+ *
+ * `end` is the last day the event covers. The API wants the day AFTER it, so a
+ * multi-day event '2026-07-12 – 2026-07-14' becomes end.date '2026-07-15'. An
+ * end that is equal to (or before) the start collapses to a single-day event
+ * (start + 1 day) — the natural way to say "all day on July 12".
+ */
+export function exclusiveEndDate(start: string, end: string): string {
+  const startDate = allDayDate(start);
+  const endDate = allDayDate(end);
+
+  // Parse against UTC midnight so the +1 day arithmetic is DST-proof.
+  const startMs = Date.parse(`${startDate}T00:00:00Z`);
+  const endMs = Date.parse(`${endDate}T00:00:00Z`);
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs)) {
+    throw new Error(`Invalid all-day date range: "${start}" – "${end}"`);
+  }
+
+  const lastDayMs = Math.max(startMs, endMs);
+  return new Date(lastDayMs + DAY_MS).toISOString().slice(0, 10);
+}
+
+/**
+ * The inclusive range for DISPLAY, from the caller's raw values.
+ *
+ * A single-day event (end equal to or before start, or no end) renders as just
+ * the date; a multi-day one renders as `start – end`.
+ */
+export function allDayRange(start: string, end?: string): string {
+  const startDate = allDayDate(start);
+  if (end === undefined) return startDate;
+  const endDate = allDayDate(end);
+  return endDate > startDate ? `${startDate} – ${endDate}` : startDate;
+}

--- a/src/services/calendar/patch.ts
+++ b/src/services/calendar/patch.ts
@@ -13,7 +13,8 @@ import { createHash } from 'node:crypto';
 
 import { call } from '../../google/client.js';
 import { formatEventList, formatEventDetail } from '../../server/formatting/markdown.js';
-import { requireString } from '../../server/handlers/validate.js';
+import { requireString, optionalString } from '../../server/handlers/validate.js';
+import { allDayDate, exclusiveEndDate, allDayRange } from './dates.js';
 import type { ServicePatch, PatchContext } from '../../factory/types.js';
 import type { HandlerResponse } from '../../server/formatting/markdown.js';
 
@@ -361,16 +362,28 @@ export const calendarPatch: ServicePatch = {
     create: async (params, account): Promise<HandlerResponse> => {
       const summary = requireString(params, 'summary');
       const start = requireString(params, 'start');
-      const end = requireString(params, 'end');
+      const allDay = params.allDay === true;
+      // `end` is optional ONLY for all-day events (defaults to the start date).
+      // A timed event without an end has no duration — reject it explicitly.
+      const end = optionalString(params, 'end');
+      if (!allDay && end === undefined) {
+        throw new Error('end is required for timed events (or pass allDay: true for a date-only event)');
+      }
       const calendarId = (params.calendarId as string) || 'primary';
 
       // Attendees are an ARRAY OF OBJECTS in the event body, not a repeated scalar.
-      const body: Record<string, unknown> = {
-        calendarId,
-        summary,
-        start: { dateTime: start },
-        end: { dateTime: end },
-      };
+      // All-day events use `date` (YYYY-MM-DD); timed ones use `dateTime` (RFC 3339).
+      const body: Record<string, unknown> = { calendarId, summary };
+      if (allDay) {
+        body.start = { date: allDayDate(start) };
+        // The Calendar API's all-day end date is EXCLUSIVE — one day after the
+        // last day. `end` here is the caller's INCLUSIVE last day, and defaults
+        // to the start date (a one-day event).
+        body.end = { date: exclusiveEndDate(start, end ?? start) };
+      } else {
+        body.start = { dateTime: start };
+        body.end = { dateTime: end };
+      }
       if (params.description) body.description = String(params.description);
       if (params.location) body.location = String(params.location);
       if (params.attendees) {
@@ -385,7 +398,7 @@ export const calendarPatch: ServicePatch = {
         // Derive it deterministically from the event fields so a retried create
         // cannot double-book.
         const fingerprint = createHash('sha256')
-          .update(JSON.stringify({ calendarId, summary, start, end, location: params.location ?? '' }))
+          .update(JSON.stringify({ calendarId, summary, start, end, allDay, location: params.location ?? '' }))
           .digest('hex').slice(0, 32);
         body.conferenceData = {
           createRequest: {
@@ -398,13 +411,15 @@ export const calendarPatch: ServicePatch = {
 
       const data = await call('calendar', 'events.insert', body, { account }) as Record<string, unknown>;
       const meetLink = params.meet ? ' (with Google Meet)' : '';
+      const allDayMarker = allDay ? ' (all day)' : '';
+      const when = allDay ? allDayRange(start, end) : `${start} – ${end}`;
       return {
-        text: `Event created: **${summary}**${meetLink}\n\n` +
-          `**When:** ${start} – ${end}\n` +
+        text: `Event created: **${summary}**${meetLink}${allDayMarker}\n\n` +
+          `**When:** ${when}\n` +
           (params.location ? `**Where:** ${params.location}\n` : '') +
           `**Calendar:** ${calendarId}\n` +
           `**Event ID:** ${data.id ?? 'unknown'}`,
-        refs: { id: data.id, eventId: data.id, calendarId, summary, start, end },
+        refs: { id: data.id, eventId: data.id, calendarId, summary, start, end, allDay },
       };
     },
 
@@ -430,8 +445,25 @@ export const calendarPatch: ServicePatch = {
       if (params.summary !== undefined) body.summary = String(params.summary);
       if (params.description !== undefined) body.description = String(params.description);
       if (params.location !== undefined) body.location = String(params.location);
-      if (params.start !== undefined) body.start = { dateTime: String(params.start) };
-      if (params.end !== undefined) body.end = { dateTime: String(params.end) };
+
+      // All-day updates map start/end to `date` (YYYY-MM-DD); timed ones to
+      // `dateTime` (RFC 3339). `allDay: true` with new datetimes converts an
+      // all-day event to timed; omitting it (or false) with datetimes converts
+      // the other way — the field shape is what Google keys on.
+      const allDay = params.allDay === true;
+      if (params.start !== undefined) {
+        body.start = allDay
+          ? { date: allDayDate(String(params.start)) }
+          : { dateTime: String(params.start) };
+      }
+      if (params.end !== undefined) {
+        // The API's all-day end is EXCLUSIVE; the caller's is INCLUSIVE. An end
+        // patched without a start has no anchor, so treat it as a one-day event
+        // on that date — the manifest tells callers to pass both.
+        body.end = allDay
+          ? { date: exclusiveEndDate(String(params.start ?? params.end), String(params.end)) }
+          : { dateTime: String(params.end) };
+      }
 
       // attendees: comma-separated string → array of {email} objects.
       // Google events.patch replaces the attendees array wholesale (no diff semantics),


### PR DESCRIPTION
## Summary

`manage_calendar create`/`update` always sent `start`/`end` as `dateTime`, which made it impossible to create all-day events. This PR adds an `allDay: true` flag that sends Calendar API `date` fields instead, plus an all-day-aware display fix for `list`/`get`.

## Behavior

- **`allDay: true` on create/update** — `start`/`end` become dates (`YYYY-MM-DD`; an ISO datetime's date part is accepted). The Calendar API's all-day `end.date` is **exclusive** (one day after the last day), which is a classic gotcha, so the MCP treats the caller's `end` as the **inclusive last day** and computes the exclusive date: `end == start` (or a missing `end`) means a one-day event; `start=2026-08-20, end=2026-08-22` becomes `end.date=2026-08-23`.
- **`end` optional for all-day on create** — a date-only request like `{summary, start: '2026-08-20', allDay: true}` works; timed events still require `end` (validated in the handler).
- **Timed ↔ all-day conversion on update** — the field shape (`date` vs `dateTime`) is what Google keys on, so `allDay: true` with new dates converts an event to all-day, and omitting it (or `false`) with datetimes converts back.
- **Display** — `list`/`get` previously rendered an all-day event's bare `date` as a timezone-shifted local time ("Aug 19 20:00"). They now render `Thu, Aug 20 – Sat, Aug 22 (all day)` (inclusive range, `end - 1` from the API's exclusive date, timezone-proof).
- **Scratchpad** — the `calendar_event` send adapter honors the same `allDay` flag.

## Notes

- The Meet-link idempotency key now includes `allDay` so a timed and all-day event with otherwise-identical fields don't collide.
- Date validation is strict (a real calendar check, not `Date.parse`, which rolls `2026-02-30` over to March 2).

## Testing

- `make check` passes (typecheck, lint, gates, 1005 unit tests including new ones for date conversion, validation, and rendering, build, smoke).
- Verified live against the Calendar API: created and read back a multi-day all-day event (`start.date`/`end.date` fields confirmed; rendered as `Thu, Aug 20 – Sat, Aug 22 (all day)`), then deleted it.
