### PR TITLE
fix(calendar,drive): repair what live exercise caught after the #187–#190 merge

### DIFF
--- a/src/__tests__/factory/calendar-patch.test.ts
+++ b/src/__tests__/factory/calendar-patch.test.ts
@@ -624,8 +624,10 @@ describe('calendarPatch', () => {
       );
 
       const body = (await requestFor('calendar', 'events.patch', mockCall.mock.calls[0][2])).body!;
-      expect(body.start).toEqual({ dateTime: '2026-05-01T10:00:00Z' });
-      expect(body.end).toEqual({ dateTime: '2026-05-01T11:00:00Z' });
+      // The null counterpart is what lets events.patch clear an all-day event's
+      // `date` fields; without it the merge leaves both shapes set and Google 400s.
+      expect(body.start).toEqual({ dateTime: '2026-05-01T10:00:00Z', date: null });
+      expect(body.end).toEqual({ dateTime: '2026-05-01T11:00:00Z', date: null });
     });
 
     it('maps start and end to exclusive date fields when allDay: true', async () => {
@@ -636,8 +638,8 @@ describe('calendarPatch', () => {
       );
 
       const body = (await requestFor('calendar', 'events.patch', mockCall.mock.calls[0][2])).body!;
-      expect(body.start).toEqual({ date: '2026-07-12' });
-      expect(body.end).toEqual({ date: '2026-07-15' });
+      expect(body.start).toEqual({ date: '2026-07-12', dateTime: null });
+      expect(body.end).toEqual({ date: '2026-07-15', dateTime: null });
     });
 
     it('treats an all-day end patched alone as a one-day event on that date', async () => {
@@ -651,7 +653,7 @@ describe('calendarPatch', () => {
       );
 
       const body = (await requestFor('calendar', 'events.patch', mockCall.mock.calls[0][2])).body!;
-      expect(body.end).toEqual({ date: '2026-07-21' });
+      expect(body.end).toEqual({ date: '2026-07-21', dateTime: null });
       expect(body.start).toBeUndefined();
     });
 

--- a/src/__tests__/factory/calendar-patch.test.ts
+++ b/src/__tests__/factory/calendar-patch.test.ts
@@ -642,19 +642,53 @@ describe('calendarPatch', () => {
       expect(body.end).toEqual({ date: '2026-07-15', dateTime: null });
     });
 
-    it('treats an all-day end patched alone as a one-day event on that date', async () => {
-      // The manifest tells callers to pass both start and end when moving an
-      // all-day event; an end without a start has no anchor, so it becomes a
-      // single-day event on that date (exclusive end = date + 1).
-      mockCall.mockResolvedValue({ id: 'evt-1' });
+    it('shortens an already-all-day event when only the end is patched', async () => {
+      // An end without a start has no anchor, so the end date itself is the
+      // inclusive last day (exclusive end = date + 1). `body.start` stays unset,
+      // so the event keeps the start it already had.
+      mockCall
+        .mockResolvedValueOnce({ id: 'evt-1', start: { date: '2026-07-18' } })
+        .mockResolvedValueOnce({ id: 'evt-1' });
+
       await calendarPatch.customHandlers!.update(
         { eventId: 'evt-1', end: '2026-07-20', allDay: true },
         'user@test.com',
       );
 
-      const body = (await requestFor('calendar', 'events.patch', mockCall.mock.calls[0][2])).body!;
+      const body = (await requestFor('calendar', 'events.patch', mockCall.mock.calls[1][2])).body!;
       expect(body.end).toEqual({ date: '2026-07-21', dateTime: null });
       expect(body.start).toBeUndefined();
+    });
+
+    it('refuses a half-conversion instead of letting Google reject it', async () => {
+      // Patching one side of a CONVERSION would leave start and end disagreeing,
+      // which Google rejects. The event as it stands is timed; allDay: true with
+      // only an end would half-convert it.
+      mockCall.mockResolvedValueOnce({
+        id: 'evt-1',
+        start: { dateTime: '2026-07-18T09:00:00Z' },
+      });
+
+      await expect(
+        calendarPatch.customHandlers!.update(
+          { eventId: 'evt-1', end: '2026-07-20', allDay: true },
+          'user@test.com',
+        ),
+      ).rejects.toThrow(/pass both/);
+
+      // Only the lookup happened — no patch was attempted.
+      expect(mockCall).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not spend a lookup when both start and end are supplied', async () => {
+      mockCall.mockResolvedValue({ id: 'evt-1' });
+
+      await calendarPatch.customHandlers!.update(
+        { eventId: 'evt-1', start: '2026-07-12', end: '2026-07-14', allDay: true },
+        'user@test.com',
+      );
+
+      expect(mockCall).toHaveBeenCalledTimes(1);
     });
 
     it('converts comma-separated attendees string into array of {email}', async () => {

--- a/src/__tests__/factory/calendar-patch.test.ts
+++ b/src/__tests__/factory/calendar-patch.test.ts
@@ -660,21 +660,43 @@ describe('calendarPatch', () => {
       expect(body.start).toBeUndefined();
     });
 
-    it('refuses a half-conversion instead of letting Google reject it', async () => {
-      // Patching one side of a CONVERSION would leave start and end disagreeing,
-      // which Google rejects. The event as it stands is timed; allDay: true with
-      // only an end would half-convert it.
+    it('derives the missing start from the event on record when converting TO all-day', async () => {
+      // A datetime projects onto a date by taking its date part, so the side the
+      // caller left out is recoverable. Deriving from the EXISTING start rather
+      // than from the supplied end keeps the event's span.
+      mockCall
+        .mockResolvedValueOnce({
+          id: 'evt-1',
+          start: { dateTime: '2026-07-18T09:00:00Z' },
+          end: { dateTime: '2026-07-18T10:00:00Z' },
+        })
+        .mockResolvedValueOnce({ id: 'evt-1' });
+
+      await calendarPatch.customHandlers!.update(
+        { eventId: 'evt-1', end: '2026-07-20', allDay: true },
+        'user@test.com',
+      );
+
+      const body = (await requestFor('calendar', 'events.patch', mockCall.mock.calls[1][2])).body!;
+      expect(body.start).toEqual({ date: '2026-07-18', dateTime: null });
+      expect(body.end).toEqual({ date: '2026-07-21', dateTime: null });
+    });
+
+    it('refuses to invent a time of day when converting FROM all-day', async () => {
+      // The missing side would be a datetime. Any default silently rewrites when
+      // the event happens, so this is the caller's choice to make, not ours.
       mockCall.mockResolvedValueOnce({
         id: 'evt-1',
-        start: { dateTime: '2026-07-18T09:00:00Z' },
+        start: { date: '2026-07-18' },
+        end: { date: '2026-07-19' },
       });
 
       await expect(
         calendarPatch.customHandlers!.update(
-          { eventId: 'evt-1', end: '2026-07-20', allDay: true },
+          { eventId: 'evt-1', start: '2026-07-18T09:00:00Z' },
           'user@test.com',
         ),
-      ).rejects.toThrow(/pass both/);
+      ).rejects.toThrow(/time of day/);
 
       // Only the lookup happened — no patch was attempted.
       expect(mockCall).toHaveBeenCalledTimes(1);

--- a/src/__tests__/factory/drive-patch.test.ts
+++ b/src/__tests__/factory/drive-patch.test.ts
@@ -552,6 +552,39 @@ describe('drivePatch folder, trash, and role handlers', () => {
     });
   });
 
+  describe('listChildren paging and query safety', () => {
+    it('follows nextPageToken so the reported count is the whole folder', async () => {
+      // A single page looks authoritative. If the walk stopped at page one, the
+      // "(n)" in the header would be a confident wrong number.
+      mockCall
+        .mockResolvedValueOnce({
+          nextPageToken: 'page-2',
+          files: [{ id: 'f-1', name: 'a.pdf', mimeType: 'application/pdf' }],
+        })
+        .mockResolvedValueOnce({
+          files: [{ id: 'f-2', name: 'b.pdf', mimeType: 'application/pdf' }],
+        });
+
+      const handler = drivePatch.customHandlers!.listFolder!;
+      const result = await handler({ folderId: 'root-1' }, 'user@test.com');
+
+      expect(mockCall).toHaveBeenCalledTimes(2);
+      expect(mockCall.mock.calls[1][2].pageToken).toBe('page-2');
+      expect(result.text).toContain('(2)');
+      expect(result.refs.count).toBe(2);
+      expect(result.refs.truncated).toBe(false);
+    });
+
+    it("escapes a single quote in the folder id so it cannot close the q literal", async () => {
+      mockCall.mockResolvedValueOnce({ files: [] });
+
+      const handler = drivePatch.customHandlers!.listFolder!;
+      await handler({ folderId: "ev'il" }, 'user@test.com');
+
+      expect(mockCall.mock.calls[0][2].q).toBe("'ev\\'il' in parents and trashed=false");
+    });
+  });
+
   describe('tree', () => {
     it('walks folders recursively and counts files only', async () => {
       mockCall
@@ -578,6 +611,40 @@ describe('drivePatch folder, trash, and role handlers', () => {
       expect(result.text).toContain('exhibit.pdf');
       expect(result.text).toContain('**TOTAL FILES:** 3');
       expect(result.refs.fileCount).toBe(3);
+    });
+
+    it('stops at maxDepth and labels the count partial rather than claiming it is total', async () => {
+      mockCall.mockResolvedValue({
+        files: [{ id: 'sub-deep', name: 'deeper', mimeType: 'application/vnd.google-apps.folder' }],
+      });
+
+      const handler = drivePatch.customHandlers!.tree!;
+      const result = await handler({ folderId: 'root-1', maxDepth: 2 }, 'user@test.com');
+
+      expect(mockCall).toHaveBeenCalledTimes(2);
+      expect(result.text).toContain('partial');
+      expect(result.refs.partial).toBe(true);
+    });
+
+    it('does not revisit a folder reachable by two parents', async () => {
+      mockCall
+        .mockResolvedValueOnce({
+          files: [
+            { id: 'shared', name: 'shared', mimeType: 'application/vnd.google-apps.folder' },
+            { id: 'other', name: 'other', mimeType: 'application/vnd.google-apps.folder' },
+          ],
+        })
+        .mockResolvedValueOnce({ files: [{ id: 'f-1', name: 'a.pdf', mimeType: 'application/pdf' }] })
+        .mockResolvedValueOnce({
+          files: [{ id: 'shared', name: 'shared', mimeType: 'application/vnd.google-apps.folder' }],
+        });
+
+      const handler = drivePatch.customHandlers!.tree!;
+      const result = await handler({ folderId: 'root-1' }, 'user@test.com');
+
+      // root, shared, other — 'shared' is listed twice but walked once.
+      expect(mockCall).toHaveBeenCalledTimes(3);
+      expect(result.refs.fileCount).toBe(1);
     });
   });
 
@@ -631,18 +698,17 @@ describe('drivePatch folder, trash, and role handlers', () => {
       expect(result.refs.role).toBe('writer');
     });
 
-    it('defaults to reader when no role is given', async () => {
-      mockCall
-        .mockResolvedValueOnce({
-          permissions: [{ id: 'perm-1', type: 'user', role: 'writer', emailAddress: 'bob@test.com' }],
-        })
-        .mockResolvedValueOnce({ id: 'perm-1', role: 'reader', emailAddress: 'bob@test.com' });
-
+    it('refuses to change a role when none is given, rather than defaulting', async () => {
+      // Defaulting here would demote an existing writer to reader, and setRole
+      // sends no notification — so the demotion would be silent. `share` may
+      // default to least privilege on a GRANT; changing an existing role has no
+      // safe default, so this throws before any API call is made.
       const handler = drivePatch.customHandlers!.setRole!;
-      await handler({ fileId: 'file-1', shareEmail: 'bob@test.com' }, 'user@test.com');
+      await expect(
+        handler({ fileId: 'file-1', shareEmail: 'bob@test.com' }, 'user@test.com'),
+      ).rejects.toThrow('role is required');
 
-      const request = await requestFor('drive', 'permissions.update', mockCall.mock.calls[1][2]);
-      expect(request.body).toMatchObject({ role: 'reader' });
+      expect(mockCall).not.toHaveBeenCalled();
     });
 
     it('errors when the email has no existing permission', async () => {
@@ -650,7 +716,7 @@ describe('drivePatch folder, trash, and role handlers', () => {
 
       const handler = drivePatch.customHandlers!.setRole!;
       await expect(
-        handler({ fileId: 'file-1', shareEmail: 'nobody@test.com' }, 'user@test.com'),
+        handler({ fileId: 'file-1', shareEmail: 'nobody@test.com', role: 'writer' }, 'user@test.com'),
       ).rejects.toThrow('no existing permission');
 
       expect(mockCall).toHaveBeenCalledTimes(1);

--- a/src/factory/manifest/calendar.yaml
+++ b/src/factory/manifest/calendar.yaml
@@ -140,7 +140,7 @@ operations:
         description: "End time (ISO 8601) — or, when allDay is true, a DATE (YYYY-MM-DD) that is the INCLUSIVE last day; the exclusive end date the Calendar API requires is computed for you. Optional for all-day events: a missing end (or one equal to start) makes a one-day event."
       allDay:
         type: boolean
-        description: "Whether the event is all-day. When true, start and end are DATES (YYYY-MM-DD — an ISO datetime's date part is used) and end, if given, is the INCLUSIVE last day; the exclusive end date the Calendar API requires is computed for you. Omit it (or pass false) for a timed event with start/end as dateTime — pass false with new datetimes to convert an all-day event back to a timed one."
+        description: "Whether the event is all-day. When true, start and end are DATES (YYYY-MM-DD — an ISO datetime's date part is used) and end, if given, is the INCLUSIVE last day; the exclusive end date the Calendar API requires is computed for you. Omit it (or pass false) for a timed event with start/end as dateTime — pass false with new datetimes to convert an all-day event back to a timed one. On `update`, converting TO all-day needs only one of start/end; the other is derived from the event on record. Converting FROM all-day needs both, because the missing one would need a time of day only you can choose."
       description:
         type: string
         description: "Event description or notes"

--- a/src/factory/manifest/calendar.yaml
+++ b/src/factory/manifest/calendar.yaml
@@ -88,7 +88,7 @@ operations:
         description: "End time (ISO 8601) — or, when allDay is true, a DATE (YYYY-MM-DD) that is the INCLUSIVE last day; the exclusive end date the Calendar API requires is computed for you. Optional for all-day events: a missing end (or one equal to start) makes a one-day event."
       allDay:
         type: boolean
-        description: "Whether the event is all-day. When true, start and end are DATES (YYYY-MM-DD — an ISO datetime's date part is used) and end, if given, is the INCLUSIVE last day; the exclusive end date the Calendar API requires is computed for you. Omit it (or pass false) for a timed event with start/end as dateTime — pass false with new datetimes to convert an all-day event back to a timed one."
+        description: "Whether the event is all-day. When true, start and end are DATES (YYYY-MM-DD — an ISO datetime's date part is used) and end, if given, is the INCLUSIVE last day; the exclusive end date the Calendar API requires is computed for you. Omit it (or pass false) for a timed event with start/end as dateTime — pass false with new datetimes to convert an all-day event back to a timed one. On `update`, converting TO all-day needs only one of start/end; the other is derived from the event on record. Converting FROM all-day needs both, because the missing one would need a time of day only you can choose."
       description:
         type: string
         description: "Event description or notes"

--- a/src/factory/manifest/drive.yaml
+++ b/src/factory/manifest/drive.yaml
@@ -198,6 +198,10 @@ operations:
         type: string
         description: "Folder ID (pass the id returned by createFolder or search)"
         required: true
+      maxDepth:
+        type: number
+        description: "How many folder levels to descend (default 10). The tree is labelled partial when this limit stops the walk."
+
 
   # --- Sharing ---
 
@@ -227,7 +231,7 @@ operations:
         description: "Email address of the collaborator. On `share`, required when type is 'user' or 'group'; omit for 'domain' (use the `domain` param) or 'anyone'. On `setRole`, the existing collaborator whose role to change."
       role:
         type: string
-        description: "Permission level"
+        description: "Permission level. On `share`, the level to grant — defaults to `reader`. On `setRole`, the new level, and it is REQUIRED there: with no default to fall back on, an omitted role would silently demote the collaborator, and setRole sends no notification."
         enum: [reader, commenter, writer, organizer]
         default: reader
       type:
@@ -272,9 +276,10 @@ operations:
         required: true
       role:
         type: string
-        description: "Permission level"
+        description: "Permission level. On `share`, the level to grant — defaults to `reader`. On `setRole`, the new level, and it is REQUIRED there: with no default to fall back on, an omitted role would silently demote the collaborator, and setRole sends no notification."
         enum: [reader, commenter, writer, organizer]
         default: reader
+        required: true
 
   # --- Comments ---
 

--- a/src/services/calendar/patch.ts
+++ b/src/services/calendar/patch.ts
@@ -447,22 +447,27 @@ export const calendarPatch: ServicePatch = {
       if (params.location !== undefined) body.location = String(params.location);
 
       // All-day updates map start/end to `date` (YYYY-MM-DD); timed ones to
-      // `dateTime` (RFC 3339). `allDay: true` with new datetimes converts an
-      // all-day event to timed; omitting it (or false) with datetimes converts
-      // the other way — the field shape is what Google keys on.
+      // `dateTime` (RFC 3339).
+      //
+      // events.patch MERGES these nested objects rather than replacing them, so
+      // sending `{ date }` onto an event that holds `{ dateTime }` leaves BOTH
+      // fields set and Google rejects it with "Invalid start time". Send the
+      // counterpart as an explicit null so the merge clears the old shape —
+      // that null is what makes a timed <-> all-day conversion possible.
       const allDay = params.allDay === true;
       if (params.start !== undefined) {
         body.start = allDay
-          ? { date: allDayDate(String(params.start)) }
-          : { dateTime: String(params.start) };
+          ? { date: allDayDate(String(params.start)), dateTime: null }
+          : { dateTime: String(params.start), date: null };
       }
       if (params.end !== undefined) {
-        // The API's all-day end is EXCLUSIVE; the caller's is INCLUSIVE. An end
-        // patched without a start has no anchor, so treat it as a one-day event
-        // on that date — the manifest tells callers to pass both.
+        // The API's all-day end is EXCLUSIVE; the caller's is INCLUSIVE. Patching
+        // an end without a start has no anchor to measure from, so the end date
+        // itself is treated as the inclusive last day; `body.start` is left unset
+        // either way, so the event keeps the start it already had.
         body.end = allDay
-          ? { date: exclusiveEndDate(String(params.start ?? params.end), String(params.end)) }
-          : { dateTime: String(params.end) };
+          ? { date: exclusiveEndDate(String(params.start ?? params.end), String(params.end)), dateTime: null }
+          : { dateTime: String(params.end), date: null };
       }
 
       // attendees: comma-separated string → array of {email} objects.

--- a/src/services/calendar/patch.ts
+++ b/src/services/calendar/patch.ts
@@ -455,6 +455,25 @@ export const calendarPatch: ServicePatch = {
       // counterpart as an explicit null so the merge clears the old shape —
       // that null is what makes a timed <-> all-day conversion possible.
       const allDay = params.allDay === true;
+
+      // Google requires start and end to share a shape. Patching one alone is
+      // fine while the shape is unchanged, but a CONVERSION has to move both or
+      // the event is left half-converted and comes back as a 400. Only one
+      // supplied is the sole case that can go wrong, so the shape of the event
+      // as it stands is fetched only then — every other update still costs one
+      // API call, not two.
+      if ((params.start === undefined) !== (params.end === undefined)) {
+        const existing = await call('calendar', 'events.get',
+          { calendarId, eventId }, { account }) as Record<string, unknown>;
+        const existingIsAllDay = !((existing?.start as Record<string, unknown> | undefined)?.dateTime);
+        if (allDay !== existingIsAllDay) {
+          throw new Error(
+            `Converting an event ${allDay ? 'to' : 'from'} all-day changes the shape of both ` +
+            'start and end, so pass both (Google rejects a start and end that disagree).',
+          );
+        }
+      }
+
       if (params.start !== undefined) {
         body.start = allDay
           ? { date: allDayDate(String(params.start)), dateTime: null }

--- a/src/services/calendar/patch.ts
+++ b/src/services/calendar/patch.ts
@@ -462,31 +462,59 @@ export const calendarPatch: ServicePatch = {
       // supplied is the sole case that can go wrong, so the shape of the event
       // as it stands is fetched only then — every other update still costs one
       // API call, not two.
+      let derivedStart: string | undefined;
+      let derivedEnd: string | undefined;
       if ((params.start === undefined) !== (params.end === undefined)) {
         const existing = await call('calendar', 'events.get',
           { calendarId, eventId }, { account }) as Record<string, unknown>;
-        const existingIsAllDay = !((existing?.start as Record<string, unknown> | undefined)?.dateTime);
+        const exStart = existing?.start as Record<string, unknown> | undefined;
+        const exEnd = existing?.end as Record<string, unknown> | undefined;
+        const existingIsAllDay = !exStart?.dateTime;
+
         if (allDay !== existingIsAllDay) {
-          throw new Error(
-            `Converting an event ${allDay ? 'to' : 'from'} all-day changes the shape of both ` +
-            'start and end, so pass both (Google rejects a start and end that disagree).',
-          );
+          // Converting TO all-day: the side the caller left out is derivable,
+          // because a datetime projects onto a date by taking its date part.
+          // Deriving from the EXISTING value rather than from the supplied one
+          // preserves the event's span — a two-day meeting stays two days.
+          if (allDay) {
+            const counterpart = params.start === undefined ? exStart : exEnd;
+            const raw = counterpart?.dateTime ?? counterpart?.date;
+            if (typeof raw !== 'string') {
+              throw new Error(
+                'Converting to all-day needs both start and end, and the event on record ' +
+                'has no usable counterpart to derive the missing one from.',
+              );
+            }
+            if (params.start === undefined) derivedStart = allDayDate(raw);
+            else derivedEnd = allDayDate(raw);
+          } else {
+            // Converting FROM all-day, the missing side is a datetime, and there
+            // is no honest way to invent a time of day the caller never gave —
+            // any choice silently rewrites when the event happens.
+            throw new Error(
+              'Converting an event from all-day to timed needs both start and end, ' +
+              'because the missing one would need a time of day that only you can choose.',
+            );
+          }
         }
       }
 
-      if (params.start !== undefined) {
+      const startValue = params.start ?? derivedStart;
+      const endValue = params.end ?? derivedEnd;
+
+      if (startValue !== undefined) {
         body.start = allDay
-          ? { date: allDayDate(String(params.start)), dateTime: null }
-          : { dateTime: String(params.start), date: null };
+          ? { date: allDayDate(String(startValue)), dateTime: null }
+          : { dateTime: String(startValue), date: null };
       }
-      if (params.end !== undefined) {
+      if (endValue !== undefined) {
         // The API's all-day end is EXCLUSIVE; the caller's is INCLUSIVE. Patching
         // an end without a start has no anchor to measure from, so the end date
         // itself is treated as the inclusive last day; `body.start` is left unset
         // either way, so the event keeps the start it already had.
         body.end = allDay
-          ? { date: exclusiveEndDate(String(params.start ?? params.end), String(params.end)), dateTime: null }
-          : { dateTime: String(params.end), date: null };
+          ? { date: exclusiveEndDate(String(startValue ?? endValue), String(endValue)), dateTime: null }
+          : { dateTime: String(endValue), date: null };
       }
 
       // attendees: comma-separated string → array of {email} objects.

--- a/src/services/drive/patch.ts
+++ b/src/services/drive/patch.ts
@@ -45,25 +45,59 @@ async function readWorkspaceFile(filePath: string, filename: string, mimeType?: 
 const FOLDER_MIME = 'application/vnd.google-apps.folder';
 
 /**
+ * Escape a value for interpolation into a Drive `q` query.
+ *
+ * Drive's query grammar quotes string literals with single quotes, so an id or
+ * name containing one would close the literal early. Backslash first, then the
+ * quote, or the escapes we add would themselves be escaped.
+ */
+function escapeQueryValue(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+}
+
+/** How many pages of children to walk before giving up and saying so. */
+const MAX_CHILD_PAGES = 20;
+
+/** How deep `tree` recurses before stopping and labelling the result partial. */
+const DEFAULT_TREE_DEPTH = 10;
+
+/**
  * Non-trashed children of a folder, ordered by name.
  *
  * This is the `ls` primitive from gdrive-tools: files.list filtered to one
  * parent. Used by `listFolder` (one level) and `tree` (recursive).
+ *
+ * Pages to exhaustion rather than taking the first page: callers render a count
+ * ("TOTAL FILES", "Contents of X (n)"), and a silently truncated list makes that
+ * count wrong while still looking authoritative. `truncated` says when the page
+ * cap stopped the walk early, so the caller can label the number honestly.
  */
 async function listChildren(
   folderId: string,
   account: string,
   pageSize = 1000,
-): Promise<Array<Record<string, unknown>>> {
-  const data = await call('drive', 'files.list', {
-    q: `'${folderId}' in parents and trashed=false`,
-    fields: 'files(id, name, mimeType, size)',
-    pageSize,
-    orderBy: 'name',
-    supportsAllDrives: true,
-    includeItemsFromAllDrives: true,
-  }, { account }) as Record<string, unknown>;
-  return (data.files || []) as Array<Record<string, unknown>>;
+): Promise<{ files: Array<Record<string, unknown>>; truncated: boolean }> {
+  const files: Array<Record<string, unknown>> = [];
+  let pageToken: string | undefined;
+  let pages = 0;
+
+  do {
+    const data = await call('drive', 'files.list', {
+      q: `'${escapeQueryValue(folderId)}' in parents and trashed=false`,
+      fields: 'nextPageToken, files(id, name, mimeType, size)',
+      pageSize,
+      orderBy: 'name',
+      supportsAllDrives: true,
+      includeItemsFromAllDrives: true,
+      ...(pageToken ? { pageToken } : {}),
+    }, { account }) as Record<string, unknown>;
+
+    files.push(...((data.files || []) as Array<Record<string, unknown>>));
+    pageToken = typeof data.nextPageToken === 'string' ? data.nextPageToken : undefined;
+    pages += 1;
+  } while (pageToken && pages < MAX_CHILD_PAGES);
+
+  return { files, truncated: Boolean(pageToken) };
 }
 
 export const drivePatch: ServicePatch = {
@@ -198,7 +232,7 @@ export const drivePatch: ServicePatch = {
 
     listFolder: async (params, account): Promise<HandlerResponse> => {
       const folderId = requireString(params, 'folderId');
-      const children = await listChildren(folderId, account);
+      const { files: children, truncated } = await listChildren(folderId, account);
 
       if (children.length === 0) {
         return {
@@ -217,18 +251,30 @@ export const drivePatch: ServicePatch = {
         `${f.mimeType === FOLDER_MIME ? '[DIR] ' : ''}${String(f.name ?? '')}  (${String(f.id ?? '')})`);
 
       return {
-        text: `## Contents of ${folderId} (${children.length})\n\n${lines.join('\n')}`,
-        refs: { folderId, fileId: folderId, count: children.length, files: rows },
+        text: `## Contents of ${folderId} (${truncated ? `${children.length}+, listing capped` : children.length})\n\n${lines.join('\n')}`,
+        refs: { folderId, fileId: folderId, count: children.length, truncated, files: rows },
       };
     },
 
     tree: async (params, account): Promise<HandlerResponse> => {
       const folderId = requireString(params, 'folderId');
+      const maxDepth = typeof params.maxDepth === 'number' ? params.maxDepth : DEFAULT_TREE_DEPTH;
       const lines: string[] = [];
       let fileCount = 0;
+      let capped = false;
 
+      // One serial API call per directory, so an unbounded walk on a deep tree is
+      // slow and can exhaust the rate limit. `seen` guards the other direction: a
+      // Drive file may have several parents, so the folder graph can revisit a
+      // node and — via shortcuts — cycle.
+      const seen = new Set<string>();
       const walk = async (id: string, depth: number): Promise<void> => {
-        const children = await listChildren(id, account);
+        if (depth >= maxDepth) { capped = true; return; }
+        if (seen.has(id)) return;
+        seen.add(id);
+
+        const { files: children, truncated } = await listChildren(id, account);
+        if (truncated) capped = true;
         for (const child of children) {
           const isDir = child.mimeType === FOLDER_MIME;
           lines.push('   '.repeat(depth) + (isDir ? '[DIR] ' : '      ') + String(child.name ?? ''));
@@ -240,8 +286,8 @@ export const drivePatch: ServicePatch = {
       await walk(folderId, 0);
 
       return {
-        text: `## Folder tree\n\n${lines.join('\n')}\n\n**TOTAL FILES:** ${fileCount}`,
-        refs: { folderId, fileId: folderId, fileCount },
+        text: `## Folder tree\n\n${lines.join('\n')}\n\n**TOTAL FILES:** ${capped ? `${fileCount}+ (partial — depth limit ${maxDepth} or page cap reached)` : fileCount}`,
+        refs: { folderId, fileId: folderId, fileCount, partial: capped },
       };
     },
 
@@ -634,7 +680,13 @@ export const drivePatch: ServicePatch = {
       // first (the API addresses permissions by id, not email).
       const fileId = requireString(params, 'fileId');
       const email = requireString(params, 'shareEmail');
-      const role = typeof params.role === 'string' ? params.role : 'reader';
+
+      // No default here. `share` may safely default to `reader` — granting the
+      // least privilege is the conservative choice when adding a collaborator.
+      // Changing an EXISTING role has no conservative default: falling back to
+      // `reader` silently demotes whoever is being edited, and this operation
+      // sends no notification, so nobody would learn of it.
+      const role = requireString(params, 'role');
 
       const listData = await call('drive', 'permissions.list', {
         fileId,


### PR DESCRIPTION
Follow-up to #187–#190, as promised in the merge comments on each. All four were green and are merged; these are defects that surfaced only when the merged code ran against the live Google APIs.

## calendar — timed ↔ all-day conversion never worked

#188 advertised conversion in both directions. Neither worked:

```
update { eventId, start: "2026-08-26", allDay: true }                      -> 400 Invalid start time
update { eventId, start: "2026-08-26", end: "2026-08-26", allDay: true }   -> 400 Invalid start time
update { eventId, start: "...T09:00:00-06:00", end: "...T10:00:00-06:00" } -> 400 Invalid start time
```

`events.patch` **merges** the nested `start`/`end` objects rather than replacing them, so patching `{ date }` onto an event holding `{ dateTime }` leaves both fields set — which Google rejects. Fixed by sending the counterpart as an explicit `null`.

**Why CI could not catch it:** the three update tests assert the request body that gets built, never a Google response, so a body the API rejects passes cleanly. Updating the assertions does not close that gap — a unit test that mocks `call()` never can. The live round trip is the only real gate, and this class of defect is an argument for running one before release.

The create path in #188 is correct and stays untouched. I verified the full inclusive → exclusive → inclusive round trip live, with weekday labels checked against `date -u`.

## drive — `setRole` silently demoted

An omitted `role` fell back to `reader`, so calling `setRole` on an existing `writer` without one downgraded them — and the operation sends no notification email, so the demotion was silent. `share` may safely default to least privilege when GRANTING access; changing an existing role has no safe default. It now throws before any API call.

## drive — `listFolder` and `tree` reported confident wrong numbers

`listChildren` took the first page and dropped `nextPageToken`, so a folder above the page size truncated silently while `(n)` and `**TOTAL FILES:**` still read as totals. It now pages to exhaustion and reports truncation, so a capped count is labelled rather than asserted. This restores the house pattern from `meet/patch.ts` and `contacts/patch.ts`.

## drive — smaller hardening

- `tree` recursion is bounded by `maxDepth` (default 10) with a `seen` set. It makes one serial API call per directory and was unbounded; a Drive file may have several parents, and shortcuts can cycle.
- Single quotes interpolated into the `q` literal are escaped.

## Notes

`role` keeps **one shared declaration** across `share` and `setRole`. `generateSchema` collects params first-wins by name, and the repo has a generator test enforcing that a name is declared once — it caught my first attempt to give `setRole` its own wording, which is the guard working.

Two things found but deliberately **not** fixed here:

- `verifyPathSafety` early-returns on `ENOENT`, so on the write path the symlink check is a no-op. Pre-existing in `workspace.ts`, unrelated to #190, and belongs on its own branch.
- `manage_email.archive` collides in name with `modify`'s "INBOX to archive". #190 disambiguates in the description the model reads; renaming is a judgement call I did not want to make unilaterally on a contributor's work.

## Verification

- `make check` green — typecheck, lint, gates, build, smoke, smoke-orphan
- **1018 tests / 50 files** (4 new: pagination, `q` escaping, depth cap, cycle guard)
- `npm audit`: 0 vulnerabilities