### PR TITLE
fix(gmail): refuse to report a send Gmail never confirmed

### DIFF
--- a/src/__tests__/services/gmail/mail.test.ts
+++ b/src/__tests__/services/gmail/mail.test.ts
@@ -192,3 +192,48 @@ describe('replyMail', () => {
     expect(headerLine(msg, 'Cc')).not.toContain('alice@test.com');
   });
 });
+
+describe('an unconfirmed send is not reported as a send', () => {
+  // Sending is the one operation here that cannot be undone or checked
+  // afterwards. A response with no id leaves nothing to look the message up by,
+  // so "sent" would be a claim rather than a fact.
+  it('throws when Gmail returns no message id', async () => {
+    mockCall.mockResolvedValue(originalMessage());
+    mockUpload.mockResolvedValue({});
+
+    await expect(replyMail(ACCOUNT, { messageId: 'msg-1', body: 'ok' }))
+      .rejects.toThrow(/no message id/);
+  });
+
+  it('throws when the id is present but empty', async () => {
+    mockCall.mockResolvedValue(originalMessage());
+    mockUpload.mockResolvedValue({ id: '' });
+
+    await expect(replyMail(ACCOUNT, { messageId: 'msg-1', body: 'ok' }))
+      .rejects.toThrow(/no message id/);
+  });
+
+  it('warns about double delivery, since the request may well have landed', async () => {
+    mockCall.mockResolvedValue(originalMessage());
+    mockUpload.mockResolvedValue({});
+
+    await expect(replyMail(ACCOUNT, { messageId: 'msg-1', body: 'ok' }))
+      .rejects.toThrow(/twice/);
+  });
+
+  it('says "draft" rather than "sent" when a draft could not be confirmed', async () => {
+    mockCall.mockResolvedValue(originalMessage());
+    mockUpload.mockResolvedValue({});
+
+    await expect(replyMail(ACCOUNT, { messageId: 'msg-1', body: 'ok', draft: true }))
+      .rejects.toThrow(/draft/);
+  });
+
+  it('returns the response untouched when an id is present', async () => {
+    mockCall.mockResolvedValue(originalMessage());
+    mockUpload.mockResolvedValue({ id: 'sent-1', threadId: ORIGINAL_THREAD });
+
+    const data = await replyMail(ACCOUNT, { messageId: 'msg-1', body: 'ok' });
+    expect(data.id).toBe('sent-1');
+  });
+});

--- a/src/services/gmail/mail.ts
+++ b/src/services/gmail/mail.ts
@@ -77,12 +77,27 @@ async function deliver(
     ? (draft ? { message: { threadId } } : { threadId })
     : {};
 
-  return await upload('gmail', resource, { userId: 'me' }, {
+  const data = await upload('gmail', resource, { userId: 'me' }, {
     account,
     media: message,
     contentType: 'message/rfc822',
     metadata,
   }) as Record<string, unknown>;
+
+  // Gmail returns the created resource, and its id is the only evidence the
+  // send happened. Without one there is nothing to look the message up by, so
+  // "sent" would be a claim rather than a fact — and sending is the one thing
+  // here that cannot be checked afterwards or undone. Refuse to report success
+  // we cannot stand behind.
+  if (typeof data?.id !== 'string' || data.id === '') {
+    throw new Error(
+      `Gmail accepted the ${draft ? 'draft' : 'send'} request but returned no message id, ` +
+      `so whether it ${draft ? 'was saved' : 'was sent'} cannot be confirmed. ` +
+      'Check the mailbox before retrying — retrying may deliver it twice.',
+    );
+  }
+
+  return data;
 }
 
 export async function sendMail(account: string, opts: SendOptions): Promise<Record<string, unknown>> {

--- a/src/services/gmail/patch.ts
+++ b/src/services/gmail/patch.ts
@@ -372,7 +372,7 @@ export const gmailPatch: ServicePatch = {
       });
 
       return {
-        text: `Message forwarded to ${to}.\n\n**Message ID:** ${data.id ?? 'unknown'}`,
+        text: `Message forwarded to ${to}.\n\n**Message ID:** ${data.id}`,
         refs: { id: data.id, threadId: data.threadId, messageId, to },
       };
     },
@@ -406,13 +406,13 @@ export const gmailPatch: ServicePatch = {
 
       if (draft || attachmentNames.length > 0) {
         return {
-          text: `Draft created for ${to}.\n\n**Subject:** ${subject}${attachNote}\n**Draft ID:** ${data.id ?? 'unknown'}`,
+          text: `Draft created for ${to}.\n\n**Subject:** ${subject}${attachNote}\n**Draft ID:** ${data.id}`,
           refs: { id: data.id, draftId: data.id, to, subject, attachments: attachmentNames, isDraft: true },
         };
       }
 
       return {
-        text: `Email sent to ${to}.\n\n**Subject:** ${subject}\n**Message ID:** ${data.id ?? 'unknown'}`,
+        text: `Email sent to ${to}.\n\n**Subject:** ${subject}\n**Message ID:** ${data.id}`,
         refs: { id: data.id, threadId: data.threadId, to, subject },
       };
     },
@@ -469,13 +469,13 @@ export const gmailPatch: ServicePatch = {
 
       if (draft || attachmentNames.length > 0) {
         return {
-          text: `Draft reply created.\n\n**Draft ID:** ${data.id ?? 'unknown'}${attachNote}`,
+          text: `Draft reply created.\n\n**Draft ID:** ${data.id}${attachNote}`,
           refs: { id: data.id, draftId: data.id, messageId, attachments: attachmentNames, isDraft: true },
         };
       }
 
       return {
-        text: `Reply sent.\n\n**Message ID:** ${data.id ?? 'unknown'}`,
+        text: `Reply sent.\n\n**Message ID:** ${data.id}`,
         refs: { id: data.id, threadId: data.threadId, messageId },
       };
     },
@@ -502,13 +502,13 @@ export const gmailPatch: ServicePatch = {
 
       if (draft || attachmentNames.length > 0) {
         return {
-          text: `Draft reply-all created.\n\n**Draft ID:** ${data.id ?? 'unknown'}${attachNote}`,
+          text: `Draft reply-all created.\n\n**Draft ID:** ${data.id}${attachNote}`,
           refs: { id: data.id, draftId: data.id, messageId, attachments: attachmentNames, isDraft: true },
         };
       }
 
       return {
-        text: `Reply-all sent.\n\n**Message ID:** ${data.id ?? 'unknown'}`,
+        text: `Reply-all sent.\n\n**Message ID:** ${data.id}`,
         refs: { id: data.id, threadId: data.threadId, messageId },
       };
     },

--- a/src/services/tasks/patch.ts
+++ b/src/services/tasks/patch.ts
@@ -22,8 +22,12 @@ import type { ServicePatch } from '../../factory/types.js';
  *
  * These are named as GOOGLE names them, not as the manifest does. beforeExecute runs
  * AFTER buildResourceParams has applied `maps_to`, so by this point `taskListId` is
- * already `tasklist` and `taskId` is `task`. The ids need no checking here anyway —
- * the manifest marks them required, so the tool schema rejects a call without them.
+ * already `tasklist` and `taskId` is `task`.
+ *
+ * This used to claim the ids need no checking because the manifest marks them
+ * required and the schema rejects a call without them. It does not — generateSchema
+ * builds `required` from `requires_email` alone and never reads a param's own
+ * `required` flag, so a missing id reaches Google as a malformed request. See #165.
  */
 const MUTABLE = ['title', 'notes', 'due', 'status'] as const;
 


### PR DESCRIPTION
Closes #182.

`data.id ?? 'unknown'` rendered an unconfirmed send as **"Email sent to alice@example.com"** with an id of `unknown`. Nothing distinguished that from a real send.

As the issue argues, this matters more than it looks because **sending is the one operation here that cannot be undone or verified after the fact**. A created contact can be fetched, a file can be listed — a message the agent believes it sent has no follow-up that separates "sent, id missing from the response" from "never sent". And `unknown` is a plausible-looking value, which is the worst kind.

## The fix

Guarded in `deliver()` rather than at the report sites. Every send, draft, reply, reply-all and forward funnels through it — including the scratchpad adapter — so one check covers all of them, and the fallbacks become unreachable and are removed.

```ts
if (typeof data?.id !== 'string' || data.id === '') {
  throw new Error(
    `Gmail accepted the ${draft ? 'draft' : 'send'} request but returned no message id, ` +
    `so whether it ${draft ? 'was saved' : 'was sent'} cannot be confirmed. ` +
    'Check the mailbox before retrying — retrying may deliver it twice.',
  );
}
```

The error says what is unknown and warns about double delivery, because the request may well have landed — a bare failure would invite exactly the retry that sends twice.

**Note:** the issue counted four report sites. There are seven — `:375` forward, `:409` draft, `:415` send, `:472` draft reply, `:478` reply, `:505` draft reply-all, `:511` reply-all. Guarding the funnel rather than the sites is what makes that count stop mattering.

## Also here

Corrects a comment in `src/services/tasks/patch.ts` claiming the tool schema rejects calls missing a required id. It does not — `generateSchema` builds `required` from `requires_email` alone and never reads a param's own `required` flag (#165). The comment described a guarantee that was never there, which is worse than no comment.

## Not here

**#165 itself.** It looks like a small fix and is not. The schema is one tool with an `operation` enum and every param flattened across operations, so `required` is tool-level — marking `fileId` required would break every operation that does not take one. Expressing "required *when* `operation=trash`" needs per-operation `if`/`then` conditionals or a different schema shape. That is a design decision, not a patch, and it should not be started in the hour before a release.

## Verification

- `make check` green — typecheck, lint, gates, build, smoke, smoke-orphan
- **1026 tests / 50 files**, 5 new: missing id, empty id, the double-delivery warning, draft wording, and the success path returning untouched