### PR TITLE
ci: harden the publish pipeline — shared gates, idempotent fallback

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -41,23 +41,14 @@ jobs:
 
       # Node 24 ships an npm 11.x that is usually new enough, and Node 22 shipped npm 10.x
       # which is not. Neither is a promise: the bundled npm moves with the Node patch the
-      # runner happens to have. An npm below the floor does not report a missing feature —
-      # it looks for a token, finds none, and fails with a 401 that says nothing about OIDC.
-      # So upgrade, then assert, rather than trusting what the image came with.
+      # runner happens to have. An npm below the 11.5.1 floor does not report a missing
+      # feature — it looks for a token, finds none, and fails with a 401 that says nothing
+      # about OIDC. Carrying the floor in the install spec makes an unsatisfiable floor
+      # fail loudly right here.
       - name: Upgrade npm past the trusted-publishing floor
         run: |
-          npm install -g npm@latest
-          V=$(npm --version)
-          echo "npm $V"
-          node -e '
-            const v = process.argv[1];
-            const [maj, min, pat] = v.split(".").map(Number);
-            const ok = maj > 11 || (maj === 11 && (min > 5 || (min === 5 && pat >= 1)));
-            if (!ok) {
-              console.error(`npm ${v} is below the 11.5.1 trusted-publishing floor — publish would fall back to token auth and 401.`);
-              process.exit(1);
-            }
-          ' "$V"
+          npm install -g 'npm@>=11.5.1'
+          npm --version
 
       - name: Install dependencies
         run: npm ci
@@ -76,42 +67,78 @@ jobs:
       # A PRE-RELEASE must not become `latest`. `npm publish` with no --tag publishes as
       # `latest`, which every `npm install` and every `^x.y.z` range picks up — so an alpha
       # published bare is not "available to those who want it", it is shipped to everyone.
-      # This mirrors the same derivation in `make publish-all`; both read the marker out of
-      # the version string.
+      # Semver defines a pre-release as anything after `-`, so match on that rather than an
+      # allowlist of names — an allowlist publishes the spellings it forgot (`-pre`,
+      # `-next`, `-canary`) as `latest`. This mirrors the same derivation in
+      # `make publish-all`.
       - name: Determine npm dist-tag
         id: npm-tag
         run: |
           VERSION=$(node -p "require('./package.json').version")
-          if echo "$VERSION" | grep -qE '(alpha|beta|rc)'; then
-            echo "tag=$(echo "$VERSION" | grep -oE '(alpha|beta|rc)')" >> "$GITHUB_OUTPUT"
-          else
-            echo "tag=latest" >> "$GITHUB_OUTPUT"
-          fi
+          case "$VERSION" in
+            *-*)
+              PRE="${VERSION#*-}"
+              PRE="${PRE%%.*}"
+              # npm rejects a dist-tag that parses as a semver range, which a
+              # bare numeric identifier (v1.0.0-1) would.
+              case "$PRE" in
+                [0-9]*) PRE=prerelease ;;
+              esac
+              echo "tag=$PRE" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "tag=latest" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      # The tag names one version; package.json names another. Publishing on a mismatch
-      # ships whatever package.json says under a tag that claims something else.
-      - name: Check the tag matches package.json
-        run: |
-          TAG_VERSION="${GITHUB_REF_NAME#v}"
-          PKG_VERSION="${{ steps.npm-tag.outputs.version }}"
-          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
-            echo "tag $GITHUB_REF_NAME says $TAG_VERSION, package.json says $PKG_VERSION."
-            exit 1
-          fi
-          echo "tag $GITHUB_REF_NAME matches package.json $PKG_VERSION"
+      # The tag, package.json, server.json, the manifest, and src/version.ts must agree on
+      # one version, and server.json must point at the npm package this repo publishes.
+      # One script owns that invariant; every publish path calls it.
+      - name: Check the release identity
+        run: node scripts/check-publish-identity.cjs "$GITHUB_REF_NAME"
 
       # An npm version is permanent, so a re-run of this job on an already-published
       # version must be a no-op rather than a red X on a release that actually succeeded.
+      # The pre-check compares the served version rather than trusting `npm view`'s exit
+      # code, and a failed publish re-checks the registry before turning red — otherwise a
+      # transient registry error during the pre-check turns a no-op re-run into a publish
+      # conflict.
       - name: Publish to npm
         run: |
           PKG=$(node -p "require('./package.json').name")
           VERSION="${{ steps.npm-tag.outputs.version }}"
-          if npm view "$PKG@$VERSION" version >/dev/null 2>&1; then
+          if [ "$(npm view "$PKG@$VERSION" version 2>/dev/null)" = "$VERSION" ]; then
             echo "$PKG@$VERSION is already on the registry — nothing to publish."
             exit 0
           fi
-          npm publish --provenance --access public --tag "${{ steps.npm-tag.outputs.tag }}"
+          if ! npm publish --provenance --access public --tag "${{ steps.npm-tag.outputs.tag }}"; then
+            if [ "$(npm view "$PKG@$VERSION" version 2>/dev/null)" = "$VERSION" ]; then
+              echo "$PKG@$VERSION is already on the registry — the publish conflict is a no-op."
+              exit 0
+            fi
+            exit 1
+          fi
+
+      # A failed publish is easy to miss: it lives in a different workflow from the tag
+      # push, and the .mcpb release succeeds beside it, so the release looks done. Assert
+      # the registry actually serves the tagged version rather than trusting the step
+      # above not to quietly no-op.
+      - name: Verify the registry serves this version
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG=$(node -p 'require("./package.json").name')
+          for i in 1 2 3 4 5; do
+            PUBLISHED=$(npm view "$PKG@$TAG" version 2>/dev/null || true)
+            if [ "$PUBLISHED" = "$TAG" ]; then
+              echo "npm serves $PKG@$TAG"
+              exit 0
+            fi
+            echo "registry has not caught up (attempt $i/5), waiting..."
+            sleep 10
+          done
+          echo "FATAL: npm does not serve $PKG@$TAG after a reported-successful publish"
+          exit 1
 
   mcp-registry:
     name: Publish to the MCP Registry
@@ -138,20 +165,13 @@ jobs:
           tar -xzf mcp-publisher.tar.gz mcp-publisher
           ./mcp-publisher --version
 
-      # server.json carries the version TWICE — once for the server entry and once for the
-      # npm package it points at — and `make version-sync` writes only what it knows about.
-      # A mismatch here publishes a registry entry naming the wrong tarball, which no
-      # amount of npm-side checking would catch.
-      - name: Check server.json agrees with the tag
-        run: |
-          TAG_VERSION="${GITHUB_REF_NAME#v}"
-          SERVER_VERSION=$(node -p "require('./server.json').version")
-          PKG_VERSION=$(node -p "require('./server.json').packages[0].version")
-          fail=0
-          [ "$SERVER_VERSION" = "$TAG_VERSION" ] || { echo "server.json version is $SERVER_VERSION, tag says $TAG_VERSION"; fail=1; }
-          [ "$PKG_VERSION" = "$TAG_VERSION" ] || { echo "server.json packages[0].version is $PKG_VERSION, tag says $TAG_VERSION"; fail=1; }
-          [ "$fail" = 0 ] || { echo "Run 'make version-sync' and commit the result."; exit 1; }
-          echo "server.json and its npm package both say $TAG_VERSION"
+      # Same script as the npm job — server.json carries the version TWICE (the server
+      # entry and the npm package it points at) and names the tarball this entry points
+      # at, and `make version-sync` writes only what it knows about. A mismatch here
+      # publishes a registry entry naming the wrong tarball, which no amount of npm-side
+      # checking would catch.
+      - name: Check the release identity
+        run: node scripts/check-publish-identity.cjs "$GITHUB_REF_NAME"
 
       - name: Authenticate by GitHub OIDC
         # No secret. The registry validates the token's issuer and audience, then grants
@@ -159,22 +179,8 @@ jobs:
         run: ./mcp-publisher login github-oidc
 
       # Same reasoning as the npm step: a re-run on an already-published version must be a
-      # no-op rather than a red X on a release that already succeeded.
+      # no-op rather than a red X on a release that already succeeded. The script filters
+      # the registry search by exact server name — the search is a substring match — and
+      # treats a failed probe as "unknown, publish anyway".
       - name: Publish to the MCP Registry
-        run: |
-          NAME=$(node -p "require('./server.json').name")
-          VERSION="${GITHUB_REF_NAME#v}"
-          published=$(curl -fsSL "https://registry.modelcontextprotocol.io/v0/servers?search=${NAME}&limit=100" \
-            | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{
-                const j=JSON.parse(s);
-                const vs=(j.servers||[]).map(x=>x.version||(x.server&&x.server.version)).filter(Boolean);
-                console.log(vs.join(" "));
-              })')
-          echo "already on the registry: ${published:-<none>}"
-          for v in $published; do
-            if [ "$v" = "$VERSION" ]; then
-              echo "$NAME $VERSION is already published — nothing to do."
-              exit 0
-            fi
-          done
-          ./mcp-publisher publish server.json
+        run: MCP_PUBLISHER=./mcp-publisher bash scripts/mcp-registry-publish.sh

--- a/.github/workflows/release-mcpb.yml
+++ b/.github/workflows/release-mcpb.yml
@@ -26,6 +26,13 @@ jobs:
           node-version: '24'
           cache: 'npm'
 
+      # npm-publish.yml enforces the same invariant, but each workflow triggers
+      # independently off the tag push — without this gate, a tag on a commit with stale
+      # manifests ships a public GitHub Release carrying a mismatched bundle while the
+      # npm job fails beside it.
+      - name: Check the release identity
+        run: node scripts/check-publish-identity.cjs "$GITHUB_REF_NAME"
+
       - name: Install dependencies
         run: npm ci
 

--- a/Makefile
+++ b/Makefile
@@ -247,6 +247,9 @@ publish-all: check-release-tag mcpb ## Publish by hand when CI cannot (normal pa
 	@echo ""
 	@if [ -n "$(YES)" ]; then echo "YES=1 — confirmed on the command line, not prompting."; \
 	else read -p "Continue? [y/N] " confirm && [ "$$confirm" = "y" ] || { echo "Aborted."; exit 1; }; fi
+	@# Same identity gate CI runs: a fallback runs precisely when something already
+	@# went wrong, so it needs the guard more than CI does.
+	node scripts/check-publish-identity.cjs "v$(VERSION)"
 	@echo ""
 	@echo "── npm ──"
 	@# .github/workflows/npm-publish.yml publishes on tag push via OIDC (ADR-105), so by
@@ -261,8 +264,12 @@ publish-all: check-release-tag mcpb ## Publish by hand when CI cannot (normal pa
 	  who=$$(npm whoami 2>/dev/null) && echo "npm: logged in as $$who" || { \
 	    echo "npm: not logged in — starting 'npm login' (browser + security key)"; npm login; }; \
 	  : "A PRE-RELEASE must not become 'latest' — bare `npm publish` ships an alpha to"; \
-	  : "everyone on ^x.y.z. Same derivation as npm-publish.yml, which explains it in full."; \
-	  tag=$$(echo "$(VERSION)" | grep -oE 'alpha|beta|rc' || echo latest); \
+	  : "everyone on ^x.y.z. Same derivation as npm-publish.yml, which explains it in full:"; \
+	  : "anything after '-' is a pre-release, not just the spellings we remembered."; \
+	  case "$(VERSION)" in \
+	    *-*) v="$(VERSION)"; p="$${v#*-}"; p="$${p%%.*}"; case "$$p" in [0-9]*) p=prerelease;; esac; tag="$$p";; \
+	    *) tag=latest;; \
+	  esac; \
 	  echo "npm: publishing $(VERSION) under dist-tag '$$tag'"; \
 	  npm publish --access public --tag "$$tag"; \
 	fi
@@ -272,13 +279,18 @@ publish-all: check-release-tag mcpb ## Publish by hand when CI cannot (normal pa
 	@# there — same reasoning as the npm step above. `mcp-publisher login github` is a
 	@# device flow needing a tty, so the skip also keeps this target runnable without one
 	@# when the registry is already current.
+	@# The probe filters by EXACT server name — ?search= is a substring match, so
+	@# without the filter any similarly named server carrying this version number
+	@# would skip the real publish. Same filter as scripts/mcp-registry-publish.sh,
+	@# which CI uses; this inline copy exists only to put the device-flow login
+	@# between the probe and the publish.
 	@name=$$(node -p "require('./server.json').name"); \
 	published=$$(curl -fsSL "https://registry.modelcontextprotocol.io/v0/servers?search=$$name&limit=100" 2>/dev/null \
-	  | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{const j=JSON.parse(s);console.log((j.servers||[]).map(x=>x.version||(x.server&&x.server.version)).filter(Boolean).join(" "))}catch(e){console.log("")}})'); \
+	  | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{const j=JSON.parse(s);console.log((j.servers||[]).filter(x=>(x.name||(x.server&&x.server.name))===process.argv[1]).map(x=>x.version||(x.server&&x.server.version)).filter(Boolean).join(" "))}catch(e){console.log("")}})' "$$name"); \
 	if echo " $$published " | grep -q " $(VERSION) "; then \
 	  echo "mcp: $$name $(VERSION) is already on the registry — skipping"; \
 	else \
-	  mcp-publisher login github && mcp-publisher publish server.json; \
+	  mcp-publisher login github && bash scripts/mcp-registry-publish.sh; \
 	fi
 	@echo ""
 	@echo "── GitHub Release ──"

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -16,9 +16,10 @@ OIDC (ADR-105) — no `NPM_TOKEN`, no secret to rotate. The registry job `needs`
 job, because `server.json` advertises the npm package at that version and publishing the
 registry entry first would point people at a tarball that does not exist yet.
 
-The workflow picks the npm dist-tag itself: a pre-release publishes under `alpha`/`beta`/
-`rc`, never `latest`, or every `npm install` and every `^x.y.z` range picks it up. It
-reads the marker out of the version string, the same derivation `make publish-all` uses.
+The workflow picks the npm dist-tag itself: any pre-release (anything after `-` in the
+version, per semver) publishes under its identifier — `alpha`, `beta`, `rc`, `pre`,
+`next` — never `latest`, or every `npm install` and every `^x.y.z` range picks it up.
+`make publish-all` uses the same derivation.
 
 `make publish-all` still exists for publishing by hand if CI is unavailable. It is no
 longer the normal path — running it after a tag would republish what CI already shipped.
@@ -114,10 +115,10 @@ make version-sync
 # commit, tag, push as above
 ```
 
-CI reads the pre-release marker out of the version string and publishes with `--tag alpha`
-(or `beta`/`rc`) rather than `--tag latest`, so a pre-release is available to people who
-ask for it and invisible to everyone else. `make publish-all` derives the same tag the
-same way, for the hand-publish path.
+CI derives the dist-tag from the semver pre-release identifier (anything after `-`) and
+publishes with `--tag alpha` (or `beta`, `rc`, `pre`, ...) rather than `--tag latest`, so
+a pre-release is available to people who ask for it and invisible to everyone else.
+`make publish-all` derives the same tag the same way, for the hand-publish path.
 
 ## Retagging
 

--- a/scripts/check-publish-identity.cjs
+++ b/scripts/check-publish-identity.cjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+// Asserts the release identity is coherent before anything publishes: the tag,
+// package.json, server.json, mcpb/manifest.json, and src/version.ts must name
+// ONE version, and server.json must point at the npm package this repo
+// actually publishes.
+//
+// version-sync.cjs writes only version fields, so a renamed npm package with a
+// stale server.json identifier passes every version check and publishes a
+// registry entry naming the wrong tarball (see ADR-105 for why the registry
+// entry and the tarball must be treated as one release). This script is the
+// one place the whole invariant lives; both release workflows and the Makefile
+// fallback call it, so a future change to the tag scheme has one file to edit.
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const root = path.join(__dirname, '..');
+
+const tag = process.argv[2];
+if (!tag || !/^v\d/.test(tag)) {
+  console.error(`usage: check-publish-identity.cjs vX.Y.Z (got ${tag || 'nothing'})`);
+  process.exit(1);
+}
+const version = tag.slice(1);
+
+const pkg = require(path.join(root, 'package.json'));
+const server = require(path.join(root, 'server.json'));
+const mcpbManifest = require(path.join(root, 'mcpb', 'manifest.json'));
+const versionTs = fs.readFileSync(path.join(root, 'src', 'version.ts'), 'utf-8');
+const versionTsMatch = versionTs.match(/VERSION = '([^']+)'/);
+
+const failures = [];
+const expect = (what, actual) => {
+  if (actual !== version) failures.push(`${what} is ${actual}, tag says ${version}`);
+};
+expect('package.json version', pkg.version);
+expect('server.json version', server.version);
+expect('server.json packages[0].version', server.packages[0].version);
+expect('mcpb/manifest.json version', mcpbManifest.version);
+expect('src/version.ts VERSION', versionTsMatch && versionTsMatch[1]);
+if (server.packages[0].identifier !== pkg.name) {
+  failures.push(
+    `server.json packages[0].identifier is ${server.packages[0].identifier}, package.json name is ${pkg.name}`
+  );
+}
+
+if (failures.length > 0) {
+  for (const f of failures) console.error(`FATAL: ${f}`);
+  console.error("Run 'make version-sync' and commit the result.");
+  process.exit(1);
+}
+console.log(`${pkg.name}@${version}: tag, package.json, server.json, manifest, and src/version.ts agree`);

--- a/scripts/mcp-registry-publish.sh
+++ b/scripts/mcp-registry-publish.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Idempotent MCP Registry publish, shared by CI (npm-publish.yml) and the
+# Makefile fallback (publish-all). Set MCP_PUBLISHER to the publisher binary
+# (default: mcp-publisher on PATH).
+#
+# The already-published pre-check filters by EXACT server name:
+# /v0/servers?search= is a substring match, so without the filter any
+# similarly named server carrying the same version number would make this
+# skip the real publish while staying green.
+#
+# The pre-check is a read-only convenience, so a failure of the search
+# endpoint must not block a release — on any probe failure this falls
+# through and lets `mcp-publisher publish` be the authority. An attempt to
+# republish an existing version fails there, loudly, which is the correct
+# residual behavior for the rare probe-missed case.
+set -uo pipefail
+
+MCP_PUBLISHER="${MCP_PUBLISHER:-mcp-publisher}"
+NAME=$(node -p "require('./server.json').name")
+VERSION=$(node -p "require('./server.json').version")
+
+published=$(curl -fsSL "https://registry.modelcontextprotocol.io/v0/servers?search=${NAME}&limit=100" 2>/dev/null \
+  | node -e '
+      let s = "";
+      process.stdin.on("data", d => s += d).on("end", () => {
+        let j;
+        try { j = JSON.parse(s); } catch { process.exit(0); }
+        const name = process.argv[1];
+        const versions = (j.servers || [])
+          .filter(x => (x.name || (x.server && x.server.name)) === name)
+          .map(x => x.version || (x.server && x.server.version))
+          .filter(Boolean);
+        console.log(versions.join(" "));
+      });
+    ' "$NAME" 2>/dev/null) || published=""
+
+echo "already on the registry for ${NAME}: ${published:-<none, or the probe failed>}"
+for v in $published; do
+  if [ "$v" = "$VERSION" ]; then
+    echo "$NAME $VERSION is already published — nothing to do."
+    exit 0
+  fi
+done
+
+exec "$MCP_PUBLISHER" publish server.json


### PR DESCRIPTION
Backports the fixes from [salesforce-cloud PR #96](https://github.com/aaronsb/salesforce-cloud/pull/96)'s review. The findings apply verbatim here — this repo is where the pattern originated (ADR-105) — so the same hardening lands for consistency across the four MCP servers.

## Changes

- **`scripts/check-publish-identity.cjs`** — one script owns the release-identity invariant: tag == `package.json` == `server.json` (both version fields) == `mcpb/manifest.json` == `src/version.ts`, and `server.json`'s `packages[0].identifier` == `package.json`'s `name`. Called by both workflows and `make publish-all`. `release-mcpb.yml` previously had no gate: a tag on a commit with stale manifests shipped a public GitHub Release with a mismatched bundle while the npm job failed beside it.
- **`scripts/mcp-registry-publish.sh`** — idempotent registry publish: the already-published probe filters by **exact server name** (`?search=` is a substring match, so a similarly named server carrying the same version number could silently skip the real publish), and a failed probe falls through to publish instead of aborting the release. The Makefile keeps an inline probe only to put the device-flow login between probe and publish — now with the same exact-name filter.
- **Prerelease dist-tags** derive from the semver prerelease identifier (anything after `-`) instead of the `alpha|beta|rc` allowlist, which published the spellings it forgot (`-pre`, `-next`, `-canary`) as `latest`. Numeric identifiers fall back to `prerelease` (npm rejects a dist-tag that parses as a range). Workflow, Makefile, and runbook prose all updated.
- **npm already-published guard** compares the served version instead of trusting `npm view`'s exit code, and re-checks the registry after a failed publish — a transient registry error on a re-run no longer turns into a duplicate-publish red X.
- **New post-publish verify step** asserts npm actually serves the tagged version before the job goes green (ported from salesforce-cloud, which had it first).
- **npm 11.5.1 floor** moves into the install spec (`npm install -g 'npm@>=11.5.1'`), replacing the ten-line inline semver parser.

## Verification

- `node scripts/check-publish-identity.cjs v4.5.0` passes; `v9.9.9` fails on all five files.
- `MCP_PUBLISHER=echo bash scripts/mcp-registry-publish.sh` — exact-name probe returned this server's ten published versions and correctly no-opped on 4.5.0.
- Both workflow files parse as YAML; `make -n publish-all` parses.
- `check-test-gates`, `check-node-floor`, and the full suite pass (1026 tests, 50 files).