### PR TITLE
feat(gmail): list and delete drafts via manage_email

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ flowchart LR
 
 | Tool | What It Does |
 |------|--------------|
-| `manage_email` | Gmail — search, read (plain or sanitized HTML), send, reply / reply-all, forward, triage, trash, labels, threads, attachments |
+| `manage_email` | Gmail — search, read (plain or sanitized HTML), send, reply / reply-all, forward, triage, trash, drafts (list / delete), labels, threads, attachments |
 | `manage_calendar` | Calendar — list, agenda, get, create, quickAdd (natural language), update, delete, calendars, freebusy |
 | `manage_drive` | Drive — search, get, upload, download, copy, rename / move, delete, export, permissions, comments, view images |
 | `manage_sheets` | Sheets — read / write ranges (row-numbered output), append, clear, manage tabs, copy / duplicate / rename |

--- a/coverage-baseline.json
+++ b/coverage-baseline.json
@@ -557,10 +557,14 @@
           "status": "gap"
         },
         "users.drafts.delete": {
-          "status": "gap"
+          "status": "covered"
         },
         "users.drafts.list": {
-          "status": "gap"
+          "status": "covered",
+          "params": {
+            "pageToken": "gap",
+            "includeSpamTrash": "gap"
+          }
         },
         "users.drafts.send": {
           "status": "gap"

--- a/src/__tests__/server/tools.test.ts
+++ b/src/__tests__/server/tools.test.ts
@@ -74,6 +74,14 @@ describe('manage_email schema', () => {
     expect(props.operation.enum).toContain('send');
     expect(props.operation.enum).toContain('reply');
     expect(props.operation.enum).toContain('triage');
+    expect(props.operation.enum).toContain('listDrafts');
+    expect(props.operation.enum).toContain('deleteDraft');
+  });
+
+  it('exposes draftId (the id deleteDraft needs) and nothing named after a message id', () => {
+    expect(props.draftId).toMatchObject({ type: 'string' });
+    expect(props.draftId.description).toContain('Draft id');
+    expect(props.draftId.description).toContain('listDrafts');
   });
 
   it('requires email', () => {

--- a/src/__tests__/services/gmail/drafts.test.ts
+++ b/src/__tests__/services/gmail/drafts.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Drafts: listDrafts hydration + deleteDraft.
+ *
+ * Drafts are their own Gmail resource. users.drafts.list returns one bare
+ * {id: draftId, message: {id, threadId}} per draft, and users.drafts.delete takes
+ * the DRAFT id — not the message id a `search in:drafts` returns. The bugs this
+ * suite guards against are the shape ones: a draft list that shows draft ids but
+ * no recipient/subject (indistinguishable drafts), and a deleteDraft that is
+ * handed a message id and does nothing while claiming success.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../google/client.js');
+import { mockCall } from '../../server/handlers/__mocks__/client.js';
+
+import { gmailPatch } from '../../../services/gmail/patch.js';
+import type { PatchContext } from '../../../factory/types.js';
+
+const ctx = { operation: 'listDrafts', params: {}, account: 'me@test.com' };
+
+/** A draft's message, as users.messages.get (metadata format) returns it. */
+function draftMessage(id: string, to = 'bob@test.com', subject = 'Hello'): Record<string, unknown> {
+  return {
+    id,
+    threadId: 't-1',
+    snippet: 'draft snippet',
+    payload: { headers: [
+      { name: 'From', value: 'me@test.com' },
+      { name: 'To', value: to },
+      { name: 'Subject', value: subject },
+      { name: 'Date', value: 'Sun, 12 Jul 2026 10:00:00 -0500' },
+    ] },
+  };
+}
+
+beforeEach(() => mockCall.mockReset());
+
+describe('listDrafts afterExecute', () => {
+  it('hydrates each draft with recipient/subject/date, keeping the DRAFT id on the row', async () => {
+    mockCall
+      .mockResolvedValueOnce(draftMessage('m-1', 'bob@test.com', 'Invoice'))
+      .mockResolvedValueOnce(draftMessage('m-2', 'carol@test.com', 'Draft reply'));
+
+    const raw = {
+      resultSizeEstimate: 2,
+      drafts: [
+        { id: 'r-111', message: { id: 'm-1', threadId: 't-1' } },
+        { id: 'r-222', message: { id: 'm-2', threadId: 't-2' } },
+      ],
+    };
+    const hydrated = await gmailPatch.afterExecute!.listDrafts(raw, ctx) as { drafts: Record<string, unknown>[] };
+
+    // Hydration fetches by MESSAGE id, but the row is keyed by DRAFT id.
+    expect(mockCall).toHaveBeenNthCalledWith(1, 'gmail', 'users.messages.get',
+      expect.objectContaining({ userId: 'me', id: 'm-1', format: 'metadata' }),
+      expect.objectContaining({ account: 'me@test.com' }));
+
+    expect(hydrated.drafts).toEqual([
+      expect.objectContaining({ draftId: 'r-111', messageId: 'm-1', to: 'bob@test.com', subject: 'Invoice' }),
+      expect.objectContaining({ draftId: 'r-222', messageId: 'm-2', to: 'carol@test.com', subject: 'Draft reply' }),
+    ]);
+  });
+
+  it('marks a draft it could not fetch, instead of rendering a blank row', async () => {
+    mockCall.mockRejectedValueOnce(new Error('boom'));
+
+    const raw = { drafts: [{ id: 'r-1', message: { id: 'm-1', threadId: 't-1' } }] };
+    const hydrated = await gmailPatch.afterExecute!.listDrafts(raw, ctx) as { drafts: Record<string, unknown>[] };
+
+    const row = hydrated.drafts[0];
+    expect(row.draftId).toBe('r-1');
+    expect(row.error).toBeTruthy();
+
+    // And the reader SEES it in the list, not a draft with no recipient.
+    const rendered = gmailPatch.formatList!({ drafts: hydrated.drafts }, ctx).text;
+    expect(rendered).toContain('⚠');
+    expect(rendered).toContain('r-1 |');
+  });
+
+  it('returns an empty list when there are no drafts', async () => {
+    const hydrated = await gmailPatch.afterExecute!.listDrafts(
+      { drafts: [], resultSizeEstimate: 0 }, ctx) as { drafts: unknown[] };
+    expect(hydrated.drafts).toEqual([]);
+    expect(mockCall).not.toHaveBeenCalled();
+  });
+});
+
+describe('formatDraftList', () => {
+  it('renders the DRAFT id first, so deleteDraft can be driven from the row', () => {
+    const data = { drafts: [
+      { draftId: 'r-111', messageId: 'm-1', to: 'bob@test.com', subject: 'Invoice', date: 'Sun, 12 Jul 2026 10:00:00 -0500' },
+      { draftId: 'r-222', messageId: 'm-2', to: 'carol@test.com', subject: 'Draft reply', date: 'Mon, 13 Jul 2026 09:00:00 -0500' },
+    ] };
+    const result = gmailPatch.formatList!(data, ctx);
+
+    expect(result.text).toContain('## Drafts (2)');
+    expect(result.text).toContain('r-111 | bob@test.com | Invoice');
+    expect(result.text).toContain('r-222 | carol@test.com | Draft reply');
+    expect(result.refs).toMatchObject({
+      count: 2,
+      draftId: 'r-111',
+      draftIds: ['r-111', 'r-222'],
+      messageIds: ['m-1', 'm-2'],
+    });
+  });
+
+  it('renders an empty state, not an error, when the list is empty', () => {
+    const ctxEmpty: PatchContext = { ...ctx, params: {} };
+    const result = gmailPatch.formatList!({ drafts: [], resultSizeEstimate: 0 }, ctxEmpty);
+    expect(result.text).toBe('No drafts found.');
+    expect(result.refs).toEqual({ count: 0 });
+  });
+});
+
+describe('deleteDraft custom handler', () => {
+  it('deletes by DRAFT id and confirms with that id', async () => {
+    // Google answers a successful drafts.delete with an empty 204 body.
+    mockCall.mockResolvedValueOnce({});
+
+    const handler = gmailPatch.customHandlers!.deleteDraft!;
+    const result = await handler({ draftId: 'r-111' }, 'me@test.com');
+
+    expect(mockCall).toHaveBeenCalledWith(
+      'gmail',
+      'users.drafts.delete',
+      { userId: 'me', id: 'r-111' },
+      expect.objectContaining({ account: 'me@test.com' }),
+    );
+    expect(result.text).toContain('r-111');
+    expect(result.refs).toEqual({ draftId: 'r-111', deleted: true });
+  });
+
+  it('refuses to delete without a draft id', async () => {
+    const handler = gmailPatch.customHandlers!.deleteDraft!;
+    await expect(handler({}, 'me@test.com')).rejects.toThrow(/draftId/);
+    expect(mockCall).not.toHaveBeenCalled();
+  });
+});

--- a/src/factory/manifest/gmail.yaml
+++ b/src/factory/manifest/gmail.yaml
@@ -211,6 +211,44 @@ operations:
     defaults:
       userId: me
 
+  # --- Drafts ---
+
+  # Drafts are their own Gmail resource: users.drafts.list returns DRAFT ids
+  # (they start with "r", e.g. r24657...), and deleteDraft addresses the draft, not
+  # the message. A message id from `search in:drafts` cannot be handed to
+  # drafts.delete, which is why listDrafts exists — it pairs each draft id with
+  # its recipient/subject/date.
+
+  listDrafts:
+    type: list
+    description: "list saved drafts (unsent messages) with each draft's DRAFT id (the r… id), recipient, subject and date. Use that draft id with deleteDraft — a message id from search in:drafts will not work for deletion."
+    resource: users.drafts.list
+    params:
+      query:
+        type: string
+        description: 'Gmail search query (e.g. "from:alice subject:meeting has:attachment")'
+        maps_to: q
+      maxResults:
+        type: number
+        description: "Max results (default: 10, max: 50)"
+        default: 10
+        max: 50
+    defaults:
+      userId: me
+
+  deleteDraft:
+    type: action
+    description: "permanently delete a draft (unsent message) by its draft id (the r… id returned by listDrafts). Irreversible — the draft is discarded, not moved to trash."
+    resource: users.drafts.delete
+    params:
+      draftId:
+        type: string
+        description: "Draft id as returned by listDrafts (an r… id, not the message id)"
+        required: true
+        maps_to: id
+    defaults:
+      userId: me
+
   getAttachment:
     type: detail
     description: "download an email attachment to workspace directory (use read first to see attachment list)"

--- a/src/server/formatting/markdown.ts
+++ b/src/server/formatting/markdown.ts
@@ -466,11 +466,11 @@ export function formatFileDetail(data: unknown): HandlerResponse {
 
 // --- Helpers ---
 
-function truncate(s: string, max: number): string {
+export function truncate(s: string, max: number): string {
   return s.length > max ? s.slice(0, max - 1) + '…' : s;
 }
 
-function formatShortDate(value: unknown): string {
+export function formatShortDate(value: unknown): string {
   if (!value) return '';
   const s = String(value);
   try {

--- a/src/server/formatting/next-steps.ts
+++ b/src/server/formatting/next-steps.ts
@@ -62,6 +62,14 @@ const suggestions: Record<string, Record<string, NextStep[]>> = {
       { description: 'Read a specific email', tool: 'manage_email', example: { operation: 'read', email: '<email>', messageId: '<id from results>' } },
       { description: 'Search for specific emails', tool: 'manage_email', example: { operation: 'search', email: '<email>', query: '<query>' } },
     ],
+    listDrafts: [
+      { description: 'Delete a draft', tool: 'manage_email', example: { operation: 'deleteDraft', email: '<email>', draftId: '<draftId from results>' } },
+      { description: 'Compose a new email', tool: 'manage_email', example: { operation: 'send', email: '<email>', to: '<recipient>', subject: '<subject>', body: '<body>' } },
+    ],
+    deleteDraft: [
+      { description: 'List remaining drafts', tool: 'manage_email', example: { operation: 'listDrafts', email: '<email>' } },
+      { description: 'Compose a new email', tool: 'manage_email', example: { operation: 'send', email: '<email>', to: '<recipient>', subject: '<subject>', body: '<body>' } },
+    ],
   },
   calendar: {
     list: [

--- a/src/services/gmail/patch.ts
+++ b/src/services/gmail/patch.ts
@@ -12,7 +12,7 @@ import { dirname } from 'node:path';
 
 import { call } from '../../google/client.js';
 import { GoogleApiError } from '../../google/errors.js';
-import { formatEmailList, formatEmailDetail, extractBodyFromPayload, extractAttachments, decodeSnippet, type EmailBodyFormat } from '../../server/formatting/markdown.js';
+import { formatEmailList, formatEmailDetail, extractBodyFromPayload, extractAttachments, decodeSnippet, truncate, formatShortDate, type EmailBodyFormat } from '../../server/formatting/markdown.js';
 import { requireString } from '../../server/handlers/validate.js';
 import { ensureWorkspaceDir, resolveWorkspacePath, verifyPathSafety } from '../../executor/workspace.js';
 import { handleGetAttachment, handleViewAttachment } from './attachments.js';
@@ -72,6 +72,55 @@ async function hydrateMessages(
 
 /** Concurrent, but bounded. */
 const HYDRATE_CONCURRENCY = 8;
+
+/**
+ * Hydrate draft resources with message metadata (From, To, Subject, Date, snippet).
+ *
+ * users.drafts.list returns one bare {id: draftId, message: {id, threadId}} per draft —
+ * enough to identify a draft, nothing to tell drafts apart. Each draft's message is
+ * fetched (metadata format, exactly like the search/triage hydration) and the DRAFT id
+ * stays on the row, because it — not the message id — is what deleteDraft addresses.
+ */
+async function hydrateDrafts(
+  drafts: Array<{ id: string; message?: { id?: string; threadId?: string } }>,
+  account: string,
+): Promise<Record<string, unknown>[]> {
+  return mapLimited(drafts, HYDRATE_CONCURRENCY, async (draft) => {
+    const draftId = draft.id;
+    const messageId = draft.message?.id;
+    if (!messageId) {
+      return { draftId, error: 'draft carries no message id' };
+    }
+    try {
+      const data = await call('gmail', 'users.messages.get', {
+        userId: 'me',
+        id: messageId,
+        format: 'metadata',
+        metadataHeaders: ['From', 'To', 'Subject', 'Date'],
+      }, { account }) as Record<string, unknown>;
+      const headers = ((data.payload as Record<string, unknown>)?.headers ?? []) as Array<{ name: string; value: string }>;
+      const getHeader = (name: string) => headers.find(h => h.name.toLowerCase() === name.toLowerCase())?.value;
+      return {
+        draftId,
+        messageId: data.id,
+        threadId: data.threadId,
+        to: getHeader('to'),
+        from: getHeader('from'),
+        subject: getHeader('subject'),
+        date: getHeader('date'),
+        snippet: data.snippet,
+      };
+    } catch (err) {
+      return {
+        draftId,
+        messageId,
+        error: err instanceof GoogleApiError
+          ? `could not load (${err.status}${err.reason ? ' ' + err.reason : ''})`
+          : `could not load (${err instanceof Error ? err.message : String(err)})`,
+      };
+    }
+  });
+}
 
 async function mapLimited<T, R>(
   items: T[],
@@ -186,6 +235,48 @@ function formatThreadList(data: unknown): HandlerResponse {
   };
 }
 
+/**
+ * Format draft list — DRAFT id (the id deleteDraft needs), recipient, subject, date.
+ *
+ * Drafts are their own Gmail resource, so the row's first column is the DRAFT id
+ * (the "r…" id), NOT the message id: handing the message id to deleteDraft is how a draft
+ * "deletes" without deleting. The refs carry both, keyed so `deleteDraft` can be
+ * chained straight off a row (`$0.draftId`).
+ */
+function formatDraftList(data: unknown): HandlerResponse {
+  const raw = data as Record<string, unknown>;
+  const drafts = (raw?.drafts ?? []) as Array<Record<string, unknown>>;
+
+  if (drafts.length === 0) {
+    const hasEstimate = 'resultSizeEstimate' in (raw ?? {});
+    const text = hasEstimate
+      ? 'No drafts found.'
+      : 'No drafts returned. The API response was missing expected fields — this may indicate an authentication or scope issue rather than an empty result.';
+    return { text, refs: { count: 0 } };
+  }
+
+  const lines = drafts.map(d => {
+    const draftId = String(d.draftId ?? '');
+    // A draft we FAILED TO FETCH is not a draft with no recipient and no subject.
+    // Same rule as the messages list: say what actually happened, in the row.
+    if (d.error) return `${draftId} | ⚠ ${String(d.error)}`;
+    const to = truncate(String(d.to ?? '(no recipient)'), 40);
+    const subject = truncate(String(d.subject ?? '(no subject)'), 50);
+    const date = formatShortDate(d.date);
+    return `${draftId} | ${to} | ${subject} | ${date}`;
+  });
+
+  return {
+    text: `## Drafts (${drafts.length})\n\n${lines.join('\n')}`,
+    refs: {
+      count: drafts.length,
+      draftId: String(drafts[0]?.draftId ?? ''),
+      draftIds: drafts.map(d => String(d.draftId ?? '')).filter(Boolean),
+      messageIds: drafts.map(d => String(d.messageId ?? '')).filter(Boolean),
+    },
+  };
+}
+
 /** Format thread detail — all messages in the thread. */
 function formatThreadDetail(data: unknown): HandlerResponse {
   const raw = data as Record<string, unknown>;
@@ -251,6 +342,18 @@ export const gmailPatch: ServicePatch = {
       const messages = await hydrateMessages(ids, ctx.account);
       return { messages, resultSizeEstimate: raw?.resultSizeEstimate };
     },
+
+    // users.drafts.list returns bare draft resources ({id, message:{id}}) — hydrate
+    // each with metadata so listDrafts shows recipient/subject/date, not just ids.
+    listDrafts: async (result, ctx) => {
+      const raw = result as Record<string, unknown>;
+      const drafts = (raw?.drafts ?? []) as Array<{ id: string; message?: { id?: string; threadId?: string } }>;
+      if (drafts.length === 0) {
+        return { drafts: [], resultSizeEstimate: raw?.resultSizeEstimate ?? 0 };
+      }
+      const hydrated = await hydrateDrafts(drafts, ctx.account);
+      return { drafts: hydrated, resultSizeEstimate: raw?.resultSizeEstimate };
+    },
   },
 
   formatList: (data: unknown, ctx: PatchContext) => {
@@ -259,6 +362,8 @@ export const gmailPatch: ServicePatch = {
         return formatLabelList(data);
       case 'threads':
         return formatThreadList(data);
+      case 'listDrafts':
+        return formatDraftList(data);
       default:
         return formatEmailList(data);
     }
@@ -448,6 +553,28 @@ export const gmailPatch: ServicePatch = {
 
     getAttachment: handleGetAttachment,
     viewAttachment: handleViewAttachment,
+
+    /**
+     * Delete a draft — permanently discard an unsent message.
+     *
+     * The id is the DRAFT resource id (the "r…" id listDrafts returns). This addresses the draft
+     * RESOURCE: a message id from `search in:drafts` cannot be handed to
+     * users.drafts.delete, so it is rejected here rather than silently doing
+     * nothing at Google. Unlike trash there is no undo — Gmail discards drafts,
+     * it does not recycle them through the trash, so the confirmation says
+     * "deleted" and there is deliberately no untrash step offered after it.
+     */
+    deleteDraft: async (params, account): Promise<HandlerResponse> => {
+      const draftId = requireString(params, 'draftId');
+      await call('gmail', 'users.drafts.delete', {
+        userId: 'me',
+        id: draftId,
+      }, { account });
+      return {
+        text: `Deleted draft **${draftId}**.`,
+        refs: { draftId, deleted: true },
+      };
+    },
 
     reply: async (params, account): Promise<HandlerResponse> => {
       const messageId = requireString(params, 'messageId');


### PR DESCRIPTION
## Description

Adds `listDrafts` and `deleteDraft` to `manage_email` so drafts can be discarded through the tool instead of hand-rolling the Gmail API.

Drafts are their own Gmail resource: `users.drafts.delete` takes the **DRAFT id** (which `users.drafts.list` returns), not the message id a `search in:drafts` returns. The existing `trash` operation addresses messages, so there was previously no way to delete a draft at all.

- **`listDrafts`** — `users.drafts.list`, hydrated per draft (recipient/subject/date) exactly like the `search`/`triage` hydration, keeping the draft id on each row.
- **`deleteDraft`** — `users.drafts.delete` by draft id, as a custom handler: Google answers a successful delete with an empty 204 body, so a plain resource op would have rendered the generic "Operation completed." with no identifier. The handler returns a confirmation naming the deleted draft id.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Testing Performed

1. Unit Tests:
   - [x] Added `src/__tests__/services/gmail/drafts.test.ts` (7 tests): listDrafts hydration (row keeps the draft id, order, failure rows render ⚠ rather than a blank draft), the empty-list path, `formatDraftList` output, and `deleteDraft` (calls `users.drafts.delete` with the draft id, requires `draftId`).
   - [x] All existing tests pass — full `make check` (typecheck, lint, gates, 1034 tests, build, smoke, smoke-orphan) is green.
   - [x] Test coverage maintained: `coverage-baseline.json` marks `users.drafts.list` / `users.drafts.delete` covered.

2. Integration Testing:
   - [x] Live-verified against a real Google account (2026-09-03): created a draft via `users.drafts.create`, listed it (`users.drafts.list`), read its message metadata (`users.messages.get`, `format: metadata`), deleted it (`users.drafts.delete` → empty 204), confirmed it was gone.
   - [x] Error handling: a draft that fails hydration renders an explicit ⚠ row (same rule as the messages list); `deleteDraft` without `draftId` throws rather than silently doing nothing.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README tool table; operation descriptions in the manifest)
- [x] My changes generate no new warnings
- [ ] I have updated the CHANGELOG.md file (repo has no CHANGELOG.md — release notes are per-version RELEASE-NOTES files)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Security Considerations

- [x] I have followed security best practices
- [x] No sensitive information is exposed
- [x] API keys and tokens are properly handled (no changes to auth; the existing `gmail.modify` scope already covers `drafts.delete`)
- [x] Input validation is implemented where necessary (`draftId` required via the same `requireString` used elsewhere)

## Additional Notes

Deleting a draft is permanent — it is discarded, not moved to trash (Gmail has no draft trash path). The operation description and the `listDrafts` output make that explicit. Draft ids look like `r2465784785066018840` and are distinct from message ids; `listDrafts` exists precisely so the right id is available to feed `deleteDraft`.
